### PR TITLE
Test for running hotplug and module parallely

### DIFF
--- a/em_stress/em_stress.py
+++ b/em_stress/em_stress.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import re
+from avocado import Test
+from avocado import main
+
+
+class em_stress(Test):
+    def setUp(self):
+        architecture = os.uname()[4]
+        if "ppc" not in architecture:
+            self.skip('supported only on Power platform')
+        file = os.uname()[2]
+        filename = "/lib/modules/%s/build/.config" % file
+        for line in open(filename, 'r'):
+            if re.search('CONFIG_POWERNV_CPUFREQ', line):
+                line1 = line.split('=')[1]
+                if str(line1).strip() == 'm':
+                    self.log.info("Dynamically loadable")
+                else:
+                    self.skip('Module not loadable,Skipping this test')
+
+    def test(self):
+        error_count = 0
+        cpu_hotplug = os.path.join(self.datadir, 'cpu_hotplug.py')
+        load = os.path.join(self.datadir, 'load.py')
+        list1 = [cpu_hotplug, load]
+        processes = {}
+        try:
+            for cmd in list1:
+                cmd1 = "python %s" % cmd
+                p = subprocess.Popen(cmd1, shell=True)
+                processes[cmd] = p
+            for key, value in processes.items():
+                P, rc = value.communicate()[0], value.returncode
+                if rc != 0:
+                    error_count += 1
+                    self.log.info("The test %s failed with return code %d" % (key, rc))
+        except Exception as e:
+            self.error("Unexpected error :" + e.message)
+
+        if error_count != 0:
+            self.fail('The test failed with errors')
+
+if __name__ == "__main__":
+    main()

--- a/em_stress/em_stress.py.data/cpu_hotplug.py
+++ b/em_stress/em_stress.py.data/cpu_hotplug.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import os
+import subprocess
+
+
+class cpu_hotplug():
+    count = 0
+
+    def func_hot(self):
+        cmd = "ls -1 /sys/devices/system/cpu/ | grep ^cpu[0-9][0-9]* |wc -l"
+        cpu_list = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        (list, err) = cpu_list.communicate()
+        for count in range(0, 100):
+            for cpus in range(1, (int(list))):
+                cpu = "cpu%s" % (cpus)
+                cmd = 'echo 0 > /sys/devices/system/cpu/%s/online' % cpu
+                status = os.system(cmd)
+                if status != 0:
+                    print "Error offline cpu %s" % (cpus)
+                else:
+                    print "offline'd CPU %s" % (cpus)
+                cmd1 = 'echo 1 > /sys/devices/system/cpu/%s/online' % cpu
+                status1 = os.system(cmd1)
+                if status1 != 0:
+                    print "Error online cpu %s" % (cpus)
+                else:
+                    print "Online'd CPU %s" % (cpus)
+
+hotplug = cpu_hotplug()
+hotplug.func_hot()

--- a/em_stress/em_stress.py.data/load.py
+++ b/em_stress/em_stress.py.data/load.py
@@ -1,0 +1,41 @@
+#!/bin/python
+from random import randint
+from time import sleep
+import subprocess
+
+
+def check_loaded():
+    processA = subprocess.Popen("lsmod", stdout=subprocess.PIPE)
+    processB = subprocess.Popen(["grep", "powernv_cpufreq"], stdin=processA.stdout, stdout=subprocess.PIPE)
+    mod = processB.communicate()[0]
+    if mod:
+        return True
+    else:
+        return False
+
+
+class load():
+    mod_name = "powernv_cpufreq"
+    count = 0
+    version = 1
+
+    def load_func(self):
+        for count in range(0, 100):
+            if not check_loaded():
+                print "Module not loaded,Loading the module..."
+                try:
+                    subprocess.check_call("modprobe" + ' ' + 'powernv_cpufreq', shell=True)
+                    sleep(randint(5, 15))
+                except subprocess.CalledProcessError as e:
+                    print "Could not load module "
+            else:
+                print "Module already Loaded,Removing the module"
+                try:
+                    subprocess.check_call("rmmod" + ' ' + 'powernv_cpufreq', shell=True)
+                    sleep(randint(5, 15))
+                except subprocess.CalledProcessError as e:
+                    print "could not unload the module"
+
+
+A = load()
+A.load_func()


### PR DESCRIPTION
This test case will stress kernel by loading/unloading the modules and hotplug/unplugging the CPUs parallely and check the kernel robustness.

1)load.py - The test runs loading/unloading modules for certain duration

2)cpu_hotplug.py - The test hotplug/unplugs CPUs for certian duration.

3)em_stress.py - Both scripts runs in parallel to check robustness