### PR TITLE
Fixed nvme write command in nvmetest

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -102,7 +102,7 @@ class NVMeTest(Test):
         """
         Write to the namespace on the device.
         """
-        cmd = 'nvme write %s -z %d -t' % (self.id_ns, self.format_size)
+        cmd = 'echo 1|nvme write %s -z %d -t' % (self.id_ns, self.format_size)
         if process.system(cmd, timeout=300, ignore_status=True, shell=True):
             self.fail("Write failed")
 


### PR DESCRIPTION
nvme write command expects an input from stdin or a file.
Without that input, write waits forever expecting an input.
Fixed that in nvmetest.py

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>