### PR TITLE
Adding MOFED Install test

### DIFF
--- a/io/net/infiniband/mofed_install_test.py
+++ b/io/net/infiniband/mofed_install_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM
+# Author: Narasimhan V <sim@linux.vnet.ibm.com>
+
+"""
+Mellanox OpenFabrics Enterprise Distribution (MOFED) System Update Package,
+provides necessary softwares to operates across all Mellanox network adapter
+solutions supporting 10, 20, 40 and 56 Gb/s InfiniBand (IB); 10, 40 and 56 Gb/s
+Ethernet; and 2.5 or 5.0 GT/s PCI Express 2.0 and 8 GT/s PCI Express 3.0
+uplinks to servers.
+"""
+
+import os
+from avocado import Test
+from avocado import main
+from avocado.utils import process
+
+
+class MOFEDInstallTest(Test):
+
+    """
+    This test verifies the installation of MOFED iso with different
+    combinations of input parameters, as specified in multiplexer file.
+
+    """
+
+    def setUp(self):
+        """
+        Mount MOFED iso.
+        """
+        self.iso_location = self.params.get('iso_location', default='')
+        if self.iso_location is '':
+            self.skip("No ISO location given")
+        self.option = self.params.get('option', default='')
+        self.tarball = self.fetch_asset(self.iso_location)
+        cmd = "mount -o loop %s %s" % (self.tarball, self.srcdir)
+        process.run(cmd, shell=True)
+        self.pwd = os.getcwd()
+        os.chdir(self.srcdir)
+
+    def install(self):
+        """
+        Installs MOFED with given options.
+        """
+        cmd = './mlnxofedinstall %s --force' % self.option
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Install Failed with %s" % self.option)
+
+    def uninstall(self):
+        """
+        Uninstalls MOFED, if installed fine.
+        """
+        cmd = "etc/init.d/openibd restart"
+        if not process.system(cmd, ignore_status=True, shell=True):
+            return
+        cmd = "ibstat"
+        if not process.system(cmd, ignore_status=True, shell=True):
+            return
+        cmd = './uninstall.sh --force'
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Uninstall Failed")
+
+    def test(self):
+        """
+        Tests install and uninstall of MOFED.
+        """
+        self.install()
+        self.uninstall()
+
+    def tearDown(self):
+        """
+        Clean up
+        """
+        os.chdir(self.pwd)
+        cmd = "umount %s" % self.srcdir
+        process.run(cmd, shell=True)
+        cmd = "rm -rf %s" % self.tarball
+        process.run(cmd, shell=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/io/net/infiniband/mofed_install_test.py.data/README.txt
+++ b/io/net/infiniband/mofed_install_test.py.data/README.txt
@@ -1,0 +1,15 @@
+Mellanox OpenFabrics Enterprise Distribution (MOFED) System Update Package,
+provides necessary softwares to operates across all Mellanox network adapter
+solutions supporting 10, 20, 40 and 56 Gb/s InfiniBand (IB); 10, 40 and 56 Gb/s
+Ethernet; and 2.5 or 5.0 GT/s PCI Express 2.0 and 8 GT/s PCI Express 3.0
+uplinks to servers.
+
+This test verifies the installation of MOFED iso with different
+combinations of input parameters, as specified in multiplexer file.
+
+This test needs to be run as root.
+
+Inputs Needed (in multiplexer file):
+------------------------------------
+iso_location -  HTTP location of MOFED ISO
+option -        installation parameters

--- a/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
+++ b/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
@@ -1,0 +1,48 @@
+ISO_Location:
+    location:
+        iso_location: http://ausgsa.ibm.com/gsa/ausgsa/home/c/l/clsoto/public/MOFED_3.4/MLNX_OFED_LINUX-3.4-0.1.0.0-rhel7.3-ppc64le.iso
+Options: !mux
+    all:
+        option: --all --post-start-delay 15 --pre-install-opensm "echo pre" --post-install-mstflint "echo post"
+    32-bit:
+        option: --with-32bit
+    without_32-bit:
+        option: --without-32bit  --with-fabric-collector -vv --vma-eth
+    skip-distro-check:
+        option: --skip-distro-check -q
+    skip-kmp-verify:
+        option: --skip-kmp-verify --disable-affinity
+    force-fw-update:
+        option: --vma --force-fw-update --tmpdir /tmp 
+    disable-kmp_skip-distro-check:
+        option: --disable-kmp --skip-distro-check -vvv --disable-affinity --add-kernel-support --skip-repo
+    dpdk:
+        option: --dpdk
+    hpc:
+        option: --hpc
+    basic:
+        option: --basic
+    msm:
+        option: --msm
+    p:
+        option: -p
+    kernel:
+        option: -s /lib/modules/`uname -r`/build -k `uname -r`  --umad-dev-na  --enable-affinity
+    umad-dev-rw:
+        option: --umad-dev-rw
+    distro:
+        option: -U --distro rhel7.3 --with-vma
+    fw-update-only:
+        option: --fw-update-only
+    check-deps-only:
+        option: --check-deps-only
+    guest:
+        option: --guest
+    hypervisor:
+        option: --hypervisor
+    kernel-only_without-fw-update:
+        option: --kernel-only   --without-fw-update  -v  --enable-mlnx_tune
+    ofed-conf:
+        option: -c docs/conf/ofed-basic.conf -n docs/conf/ofed_net.conf-example
+    add-kernel-support:
+        option: --add-kernel-support --skip-repo --force --kmp


### PR DESCRIPTION
This test verifies the installation of MOFED iso with different
combinations of input parameters.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>