### PR TITLE
Adding test for Module unload/load operation

### DIFF
--- a/io/driver/module_unload_load.sh
+++ b/io/driver/module_unload_load.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2016 IBM
+# Author: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>
+
+CONFIG_FILE="$AVOCADO_TEST_DATADIR"/config
+BUILT_IN_DRIVERS=`cat /lib/modules/$(uname -r)/modules.builtin |grep drivers|awk -F"/" '{print $NF}'|sed 's/\.ko//g'`
+DRIVERS=`lspci -k | grep -iw "Kernel driver in use" | cut -d ':' -f2 | sort | uniq`
+ERR=""
+PASS=""
+ITERATIONS=100
+
+
+module_load() {
+    echo "Reloading driver $1"
+    modprobe $1
+    if [[  $? != 0  ]]; then
+        echo "Failed to load driver module $1"
+        ERR="$ERR,load-$1"
+        break;
+    fi
+    echo
+}
+
+
+module_unload() {
+    for i in $( cat $CONFIG_FILE | grep "$1=" | awk -F'=' '{print $2}' ); do
+        module_unload $i
+        if [[  $? != 0  ]]; then
+            return
+        fi
+    done
+    echo "Unloaded driver $1"
+    rmmod $1
+    if [[  $? != 0  ]]; then
+        echo "Failed to unload driver module $i"
+        ERR="$ERR,unload-$1"
+        break;
+    fi
+}
+
+
+for driver in $DRIVERS; do
+    echo "Starting driver module load/unload test for $driver"
+    echo
+    for j in $(seq 1 $ITERATIONS); do
+        echo $BUILT_IN_DRIVERS | grep $driver > /dev/null
+        if [[ $? == "0" ]]; then
+            echo $driver" is builtin and it cannot be unloaded"
+            break ;
+        fi
+        module_unload $driver
+        # Sleep for 5s to allow the module unload to complete
+        sleep 5
+        module_load $driver
+        # Sleep for 5s to allow the module load to complete
+        sleep 5
+    done
+    if [[  $j -eq $ITERATIONS  ]]; then
+        echo "Finished driver module load/unload test for $driver"
+        PASS="$PASS,$driver"
+    fi
+    echo
+    echo "Completed driver module load/unload test for $driver"
+    echo
+done
+echo
+if [[  "$PASS"  ]]; then
+    echo "Successfully loaded/unloaded: ${PASS:1}"
+    exit 0
+fi
+if [[  "$ERR"  ]]; then
+    echo "Some modules failed to load/unload: ${ERR:1}"
+    exit 1
+fi

--- a/io/driver/module_unload_load.sh.data/README.txt
+++ b/io/driver/module_unload_load.sh.data/README.txt
@@ -1,0 +1,7 @@
+This Program loads and unloads the kernel driver modules. For the kernel driver modules that have dependencies, the dependant modules should  be listed in the config file (config). The script takescare of unloading the dependant modules, if any, before unloading the core module. It runs for a total of 100 times as stress.
+
+The script picks up the modules listed in lspci and performs the module unload/load operation.
+
+The test will PASS when at least one of the drivers finishes the whole loop. 
+
+This script should be run as root.

--- a/io/driver/module_unload_load.sh.data/config
+++ b/io/driver/module_unload_load.sh.data/config
@@ -1,0 +1,2 @@
+mlx4_core=mlx4_en mlx4_ib
+mlx5_core=mlx5_ib


### PR DESCRIPTION
This test runs only for loaded kernel modules for a total
of 100 counts

Signed-off-by: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>
Signed-off-by: Narasimhan V sim@linux.vnet.ibm.com