### PR TITLE
Software Raid number of disk fixes

### DIFF
--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -51,14 +51,8 @@ class SoftwareRaid(Test):
                 self.skip("Unable to install mdadm")
         cmd = "mdadm -V"
         self.check_pass(cmd, "Unable to get mdadm version")
-        self.disk = self.params.get('disk', default='').strip(" ").split(" ")
-        self.sparedisk = self.disk.pop()
-        self.remadd = ''.join(self.disk[-1:])
+        self.disk = self.params.get('disk', default='').strip(" ")
         self.raidlevel = str(self.params.get('raid', default='0'))
-        self.disk_count = len(self.disk)
-        self.disk = ' '.join(self.disk)
-        if self.disk_count < 4:
-            self.skip("Please give minimum of 5 disk to execute this test case")
 
     def test_run(self):
         """
@@ -73,6 +67,7 @@ class SoftwareRaid(Test):
         """
         Only basic operations are run viz create and delete
         """
+        self.disk_count = len(self.disk.split(" "))
         cmd = "echo 'yes' | mdadm --create --verbose --assume-clean \
             /dev/md/mdsraid --level=%s --raid-devices=%d %s \
             --force" \
@@ -86,6 +81,11 @@ class SoftwareRaid(Test):
         Extensive software raid options are run viz create, delete, assemble,
         create spares, remove and add drives
         """
+        self.disk = self.disk.split(" ")
+        self.sparedisk = self.disk.pop()
+        self.remadd = ''.join(self.disk[-1:])
+        self.disk_count = len(self.disk)
+        self.disk = ' '.join(self.disk)
         cmd = "echo 'yes' | mdadm --create --verbose --assume-clean \
             /dev/md/mdsraid --level=%s --raid-devices=%d %s \
             --spare-devices=1 %s --force" \

--- a/io/disk/softwareraid.py.data/Readme
+++ b/io/disk/softwareraid.py.data/Readme
@@ -6,5 +6,7 @@ Values to be passed in ymal file:
 
 * Raid levels to be created
 
-Note: Please specify minimum of 5 disks, if 5 disks are not available,
-create 5 partitions, and specify those partitions in the yaml file.
+Note: Please specify minimum of 5 disks, for creating all levels of soltware
+raid. If 5 disks are not available, create 5 partitions, and specify those
+partitions in the yaml file.
+Test fails, if number of disks are not applicable for a certain raid level.


### PR DESCRIPTION
Software raid test used to skip if number of disks were less than 4.
Changed this behaviour, so that if number of disks are applicable for a
certain raid level, it works. Else, test fails for that level.
Updated Readme file accordingly.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>