### PR TITLE
Adding test to nvme-cli test

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -106,6 +106,63 @@ class NVMeTest(Test):
         if process.system(cmd, timeout=300, ignore_status=True, shell=True):
             self.fail("Write failed")
 
+    def testcompare(self):
+        """
+        Compares data written on the device with given data.
+        """
+        self.testwrite()
+        cmd = 'echo 1|nvme compare %s -z %d' % (self.id_ns, self.format_size)
+        if process.system(cmd, timeout=300, ignore_status=True, shell=True):
+            self.fail("Compare failed")
+
+    def testflush(self):
+        """
+        flush data on controller.
+        """
+        cmd = 'nvme flush %s -n 1' % self.device
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Flush failed")
+
+    def testwritezeroes(self):
+        """
+        Write zeroes command to the device.
+        """
+        cmd = 'nvme write-zeroes %s -n 1' % self.device
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Writing Zeroes failed")
+
+    def testwriteuncorrectable(self):
+        """
+        Write uncorrectable command to the device.
+        """
+        cmd = 'nvme write-uncor %s -n 1' % self.device
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Writing Uncorrectable failed")
+
+    def testdsm(self):
+        """
+        The Dataset Management command test.
+        """
+        cmd = 'nvme dsm %s -n 1 -a 1 -b 1 -s 1 -d -w -r' % self.device
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Subsystem reset failed")
+
+    def testreset(self):
+        """
+        resets the controller.
+        """
+        cmd = 'nvme reset %s' % self.device
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Reset failed")
+
+    def testsubsystemreset(self):
+        """
+        resets the controller subsystem.
+        """
+        cmd = 'nvme subsystem-reset %s' % self.device
+        if process.system(cmd, ignore_status=True, shell=True):
+            self.fail("Subsystem reset failed")
+
     def tearDown(self):
         """
         Clean up


### PR DESCRIPTION
Added the following tests to nvme-cli test.
*) compare
*) flush
*) writezeroes
*) writeuncorrectable
*) dsm
*) reset
*) subsystemreset

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>