### PR TITLE
Software Raid number of disk fixes

### DIFF
--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -46,19 +46,21 @@ class SoftwareRaid(Test):
 
         smm = SoftwareManager()
         if not smm.check_installed("mdadm"):
-            print("Mdadm must be installed before continuing the test")
+            print "Mdadm must be installed before continuing the test"
             if SoftwareManager().install("mdadm") is False:
                 self.skip("Unable to install mdadm")
         cmd = "mdadm -V"
         self.check_pass(cmd, "Unable to get mdadm version")
-        self.disk = self.params.get('disk', default='').strip(" ").split(" ")
-        self.sparedisk = self.disk.pop()
-        self.remadd = ''.join(self.disk[-1:])
+        self.disk = self.params.get('disk', default='').strip(" ")
         self.raidlevel = str(self.params.get('raid', default='0'))
-        self.disk_count = len(self.disk)
-        self.disk = ' '.join(self.disk)
-        if self.disk_count < 4:
-            self.skip("Please give minimum of 5 disk to execute this test case")
+        if self.raidlevel == 'linear' or self.raidlevel == '0':
+            self.disk_count = len(self.disk.split(" "))
+        else:
+            self.disk = self.disk.split(" ")
+            self.sparedisk = self.disk.pop()
+            self.remadd = ''.join(self.disk[-1:])
+            self.disk_count = len(self.disk)
+            self.disk = ' '.join(self.disk)
 
     def test_run(self):
         """

--- a/io/disk/softwareraid.py.data/Readme
+++ b/io/disk/softwareraid.py.data/Readme
@@ -6,5 +6,7 @@ Values to be passed in ymal file:
 
 * Raid levels to be created
 
-Note: Please specify minimum of 5 disks, if 5 disks are not available,
-create 5 partitions, and specify those partitions in the yaml file.
+Note: Please specify minimum of 5 disks, for creating all levels of soltware
+raid. If 5 disks are not available, create 5 partitions, and specify those
+partitions in the yaml file.
+Test fails, if number of disks are not applicable for a certain raid level.


### PR DESCRIPTION
Software raid test used to skip if number of disks were less than 4.
Changed this behaviour, so that if number of disks are applicable for a
certain raid level, it works. Else, test fails for that level.
Updated Readme file accordingly.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>