### PR TITLE
Add pylint in travis requirement

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,3 @@
 inspektor==0.2.2
 pep8==1.6.2
+pylint==1.6.4


### PR DESCRIPTION
add pylint in travis as enable travis to catch
import main is added in test script

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>