### PR TITLE
Add pylint in travis requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 script:
     - inspekt lint
-    - inspekt indent
+    - inspekt indent --enable W0611,E0602
     - inspekt style
     - |
         error=""

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,3 @@
 inspektor==0.2.2
 pep8==1.6.2
+pylint==1.6.4


### PR DESCRIPTION
add pylint check for Undefined variable (E0602))
in travis as enable travis to catch

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>