### PR TITLE
smartctl test cases - v3

### DIFF
--- a/io/disk/smartctl.py
+++ b/io/disk/smartctl.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+# Copyright: 2016 IBM
+# Author: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>
+
+
+"""
+smartctl - controls  the Self-Monitoring, Analysis and Reporting
+Technology (SMART) system built into most ATA/SATA and SCSI/SAS
+hard drives and solid-state drives
+"""
+
+from avocado import Test
+from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import process
+from avocado import main
+
+
+class SmartctlTest(Test):
+
+    """
+    This scripts performs S.M.A.R.T relavent tests using smartctl tool
+    on one or more disks
+    """
+
+    def setUp(self):
+
+        """
+        Checking if the required packages are installed,
+        if not found packages will be installed
+        """
+
+        smm = SoftwareManager()
+        if not smm.check_installed("smartctl"):
+            self.log.info("smartctl should be installed prior to the test")
+            if smm.install("smartmontools") is False:
+                self.skip("Unable to install smartctl")
+        self.option = self.params.get('option')
+        self.disks = self.params.get('disk')
+        if self.disks is '' or self.option is '':
+            self.skip(" Test skipped!!, please ensure Block device and \
+            options are specified in yaml file")
+        cmd = "df -h /boot | grep %s" % (self.disks)
+        if process.system(cmd, timeout=300, ignore_status=True,
+                          shell=True) == 0:
+            self.skip(" Skipping it's OS disk")
+
+    def test(self):
+        """
+        executes S.M.A.R.T options using smartctl tool
+        """
+        self.log.info("option %s on %s Disks" % (self.option, self.disks))
+        cmd = "smartctl %s %s" % (self.option, self.disks)
+        if self.option == "--test=long":
+            cmd += " && sleep 120 && smartctl -X %s && smartctl -A %s" \
+                % (self.disks, self.disks)
+        if process.system(cmd, timeout=1200, ignore_status=True,
+                          shell=True):
+            self.fail("Smartctl option %s FAILS" % self.option)
+
+
+if __name__ == "__main__":
+    main()

--- a/io/disk/smartctl.py.data/Readme
+++ b/io/disk/smartctl.py.data/Readme
@@ -1,0 +1,11 @@
+smartctl - controls  the Self-Monitoring, Analysis and Reporting
+Technology(SMART) system built into most ATA/SATA and SCSI/SAS
+hard drives and solid-state drives.
+
+Values to be passed in yaml file:
+    1 Name of the devices on which this scripts should be run.
+    2 smartctl tool options.
+
+Note:
+    1. Please do not input OS drives.
+    2. Logical block device drives do not support SMART.

--- a/io/disk/smartctl.py.data/smartctl.yaml
+++ b/io/disk/smartctl.py.data/smartctl.yaml
@@ -1,0 +1,68 @@
+scenario: !mux
+    test1:
+        disk: /dev/sda
+    test2:
+        disk: /dev/sdb
+Options: !mux
+    self_test:
+        option: --test=long
+    info:
+        option: -i
+    device_setting:
+        option: -g all
+    scan_drives:
+        option: --scan
+    scan_drives_open:
+        option: --scan-open
+    quietmode:
+        option: -q errorsonly
+    quietmode:
+        option: -q silent
+    bad_checksum:
+        option: -b warn
+    report_transaction:
+        option: -r ioctl
+    check_mode:
+        option: -n sleep
+    automatic_offline_off:
+        option: -o off
+    automatic_offline_on:
+        option: -o on
+    autosave_attribute_off:
+        option: -S off
+    autosave_attribute_on:
+        option: -S on
+    device_setting:
+        option: -s on
+    tolerance_opt1:
+        option: --smart=off -T verypermissive
+    tolerance_opt2:
+        option: --smart=on -T permissive
+    tolerance_opt3:
+        option: --smart=on -T normal 
+    tolerance_opt4:
+        option: --smart=on -T conservative
+    print_selftest_quietmode:
+        option: --attributes --log=selftest --quietmode=errorsonly
+    captive_mode:
+        option: --captive
+    offlineautotests:
+        option: --smart=on --offlineauto=on --saveauto=on
+    format_opt1:
+        option: -f old 
+    print_format_opt1:
+        option: --all
+    format_opt2:
+        option: -f brief
+    print_format_opt2:
+        option: -x
+    Health:
+        option: -H
+    capabilities:
+        option: -c
+    device_log:
+        option: -l error
+    presets:
+        option: -P showall
+    print_alldata:
+        option: -A


### PR DESCRIPTION

[job.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/580153/job.txt)
[smartctl_run.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/580154/smartctl_run.txt)

smartctl tool checks the SMART statistics of hard drive.
v3 includes the fix for the traces found with timeout.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>