### PR TITLE
arcconf controller specific tests - v3

### DIFF
--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+# Copyright: 2016 IBM
+# Author: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>
+
+
+"""
+arcconf - Array configuration utility for PMC-Sierra
+(Microsemi) Controllers.
+"""
+
+from avocado import Test
+from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import process
+from avocado import main
+from avocado.utils import distro
+
+
+class Arcconftest(Test):
+
+    """
+    Covers functionality relavent to controller settings.
+    """
+
+    def setUp(self):
+
+        """
+        Checking if the required packages are installed,
+        if not found specific packages will be installed.
+        """
+        smm = SoftwareManager()
+        if not smm.check_installed("lsscsi") and not smm.install("lsscsi"):
+            self.skip("Unable to install lsscsi")
+        self.crtl_no = self.params.get('crtl_no')
+        self.pci_id = self.params.get('pci_id', default="").split(",")
+        self.http_path = self.params.get('http_path')
+        self.tool_name = self.params.get('tool_name')
+        self.option = self.params.get("option")
+        self.option_args = self.params.get("option_args")
+
+        # Gets the list of PCIIDs on the system
+        cmd = 'for device in $(lspci | awk \'{print $1}\') ; do echo \
+              $(lspci -vmm -nn -s $device | grep "\[" | awk \'{print $NF}\' \
+              | sed -e "s/\]//g" | sed -e "s/\[//g" | tr \'\\n\' \' \' \
+              | awk \'{print $2,$3,$4,$5}\') ; done'
+        pci_id_formatted = []
+        for i in self.cmdop_list(cmd).splitlines():
+            pci_id_formatted.append(str(i.replace(" ", ":")))
+
+        # check if all the yaml parameters are entered
+        if self.crtl_no is '' or self.pci_id is '' or self.tool_name \
+           is '' or self.http_path is '':
+            self.skip(" please ensure yaml parameters are not empty")
+        elif self.comp(self.pci_id, pci_id_formatted) == 1:
+            self.skip(" Test skipped!!, PMC controller not available")
+
+        detected_distro = distro.detect()
+        if not smm.check_installed("arcconf"):
+            if detected_distro.name == "Ubuntu":
+                http_repo = "%s%s.deb" % (self.http_path, self.tool_name)
+                self.repo = self.fetch_asset(http_repo, expire='10d')
+                cmd = "dpkg -i %s" % self.repo
+            else:
+                http_repo = "%s%s.rpm" % (self.http_path, self.tool_name)
+                self.repo = self.fetch_asset(http_repo, expire='10d')
+                cmd = "rpm -ivh %s" % self.repo
+            if process.system(cmd, ignore_status=True, shell=True) == 0:
+                self.skip("Unable to install arcconf")
+
+    def test(self):
+        """
+        Main function
+        """
+        self.log.info("PMC controller details for ==> %s"
+                      % self.crtl_no)
+        cmd = "arcconf getconfig %s AD" % self.crtl_no
+        self.check_pass(cmd, "Failed to display PMC controller details")
+
+        if "CONFIG" in self.option:
+            cmd = "%s %s" % (self.option, self.option_args)
+        else:
+            cmd = "%s %s %s" % (self.option, self.crtl_no, self.option_args)
+        self.check_pass(cmd, "Failed to run %s" % cmd)
+
+    def cmdop_list(self, cmd):
+        """
+        Function returns the output of a command
+        """
+        val = process.run(cmd, shell=True, allow_output_check='stdout')
+        if val.exit_status:
+            self.fail("cmd %s Failed" % (cmd))
+        return val.stdout.rstrip()
+
+    @classmethod
+    def comp(cls, list1, list2):
+        """
+        compares two lists, if match found returns 0
+        """
+        for val in list1:
+            if val in list2:
+                return 0
+        return 1
+
+    def check_pass(self, cmd, errmsg):
+        """
+        Function to check if the cmd is successful or not
+        """
+        if process.system(cmd, timeout=3200, ignore_status=True,
+                          shell=True) != 0:
+            self.fail(errmsg)
+
+    def tearDown(self):
+        """
+        remove the log files
+        """
+        if "SAVECONFIG" not in self.option:
+            cmd = "rm -rf /tmp/arcconf_cntl*"
+            self.check_pass(cmd, "Failed to remove temporary files")
+
+
+if __name__ == "__main__":
+    main()

--- a/io/disk/arcconf/arcconf_cntl_oper.py.data/Readme
+++ b/io/disk/arcconf/arcconf_cntl_oper.py.data/Readme
@@ -1,0 +1,12 @@
+arcconf - Command line interface to configure PMC-Sierra
+(Microsemi) Controllers.
+
+arcconf_cntl_oper.py covers arcconf functionality 
+specific to controller settings.
+ 
+Note:
+    1. supported controllers pci_ids can be entered 
+       seperated by ",".
+    2. TODO: CPLD, ROMPUPDATE, SETCONFIG, KEY,
+       EXPANDERUPGRADE, SETMAXCACHE, SETPRIORITY,
+       SMP, UARTLOG

--- a/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
+++ b/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
@@ -1,0 +1,171 @@
+Test: !mux
+   Backupunit:
+        option: "arcconf BACKUPUNIT"
+        option_args: "RESET"
+   Consistencycheck1:
+        option: "arcconf CONSISTENCYCHECK"
+        option_args: "off"
+   Consistencycheck2:
+        option: "arcconf CONSISTENCYCHECK"
+        option_args: "on"
+   Consistencycheck3:
+        option: "echo y | arcconf CONSISTENCYCHECK"
+        option_args: "PERIOD 10"
+   Copyback1:
+        option: "arcconf COPYBACK"
+        option_args: "OFF"
+   Copyback2:
+        option: "arcconf COPYBACK"
+        option_args: "ON"
+   Errortunable1:
+        option: "arcconf ERRORTUNABLE"
+        option_args: "SETPROFILE 2"
+   Errortunable2:
+        option: "arcconf ERRORTUNABLE"
+        option_args: "CONFIGPARAMS CRC_ERROR_DURATION_SEC 10"
+   Errortunable3:
+        option: "arcconf ERRORTUNABLE"
+        option_args: "GETPARAMS"
+   Errortunable4:
+        option: "echo y | arcconf ERRORTUNABLE"
+        option_args: "GETPARAMS 2 SAVE /tmp/arcconf_cntl.cfg"
+   Expanderlist:
+        option: "arcconf EXPANDERLIST"
+        option_args: ""
+   Failover1:
+        option: "arcconf FAILOVER"
+        option_args: "off"
+   Failover2:
+        option: "arcconf FAILOVER"
+        option_args: "on"
+   Getexception:
+        option: "arcconf GETEXCEPTION"
+        option_args: "AL"
+   Getlogs:
+        option: "arcconf GETLOGS"
+        option_args: "STATS tabular"
+   Getperform1:
+        option: "arcconf GETPERFORM"
+        option_args: "1"
+   Getperform2:
+        option: "arcconf GETPERFORM"
+        option_args: "1 save /tmp/arcconf_cntl.cfg"
+   Getsmartstats1:
+        option: "arcconf GETSMARTSTATS"
+        option_args: ""
+   Getsmartstats2:
+        option: "arcconf GETSMARTSTATS"
+        option_args: "tabular"
+   Getstatus:
+        option: "arcconf GETSTATUS"
+        option_args: ""
+   Getversion:
+        option: "arcconf GETVERSION"
+        option_args: ""
+   List:
+        option: "arcconf LIST"
+        option_args: ""
+   Saveconfig:
+        option: "arcconf SAVECONFIG"
+        option_args: "/tmp/abc.xml /tmp/arcconf_cntl.log"
+   Playconfig:
+        option: "arcconf PLAYCONFIG"
+        option_args: "/tmp/abc.xml /tmp/arcconf_cntl.log"
+   Preservecache:
+        option: "arcconf PRESERVECACHE"
+        option_args: "ENABLE"
+   Rescan:
+        option: "arcconf RESCAN"
+        option_args: ""
+   Resetstatisticscounters:
+        option: "arcconf RESETSTATISTICSCOUNTERS"
+        option_args: ""
+   Seeprom:
+        option: "arcconf SEEPROM"
+        option_args: "UPDATE"
+   Setalarm1:
+        option: "arcconf SETALARM"
+        option_args: "off"
+   Setalarm2:
+        option: "arcconf SETALARM"
+        option_args: "on"
+   Setalarm3:
+        option: "arcconf SETALARM"
+        option_args: "test"
+   Setbiosparams1:
+        option: "echo y | arcconf SETBIOSPARAMS"
+        option_args: "BIOSHALTONMISSINGDRIVECOUNT 3"
+   Setbiosparams2:
+        option: "echo y | arcconf SETBIOSPARAMS"
+        option_args: "DISPLAYPDONPOST enable"
+   Setbiosparams3:
+        option: "echo y | arcconf SETBIOSPARAMS"
+        option_args: "RUNTIMEBIOS enable"
+   Setbiosparams4:
+        option: "echo y | arcconf SETBIOSPARAMS"
+        option_args: "ARRAYBBSSUPPORT disable"
+   Setbiosparams5:
+        option: "echo y | arcconf SETBIOSPARAMS"
+        option_args: "BACKPLANEMODE 0"
+   Setboot:
+        option: "arcconf setboot"
+        option_args: "enable"
+   Setcontrollermode1:
+        option: "arcconf SETCONTROLLERMODE"
+        option_args: "1"
+   Setcontrollermode2:
+        option: "arcconf SETCONTROLLERMODE"
+        option_args: "2"
+   Setcontrollermode3:
+        option: "arcconf SETCONTROLLERMODE"
+        option_args: "3"
+   Setcontrollermode4:
+        option: "arcconf SETCONTROLLERMODE"
+        option_args: "4"
+   Setcontrollermode5:
+        option: "arcconf SETCONTROLLERMODE"
+        option_args: "5"
+   Setcontrollermode6:
+        option: "arcconf SETCONTROLLERMODE"
+        option_args: "0"
+   Setcustommode:
+        option: "arcconf setcustommode"
+        option_args: "ENABLE IOSORT DISABLE INSLRU"
+   Setncq1:
+        option: "arcconf setncq"
+        option_args: "disable"
+   Setncq2:
+        option: "arcconf setncq"
+        option_args: "enable"
+   Setncq3:
+        option: "arcconf setncq"
+        option_args: "disable"
+   Setperform1:
+        option: "arcconf setperform"
+        option_args: "2"
+   Setperform2:
+        option: "arcconf setperform"
+        option_args: "3"
+   Setperform3:
+        option: "arcconf setperform"
+        option_args: "4"
+   Setperform4:
+        option: "arcconf setperform"
+        option_args: "1"
+   Setstatdatacollection1:
+        option: "arcconf SETSTATSDATACOLLECTION"
+        option_args: "disable"
+   Setstatdatacollection2:
+        option: "arcconf SETSTATSDATACOLLECTION"
+        option_args: "enable"
+   verifywrite1:
+        option: "arcconf verifywrite"
+        option_args: "disable"
+   verifywrite2:
+        option: "arcconf verifywrite"
+        option_args: "enable"
+parameters:
+    crtl_no: "1"
+    pci_id: "9005:028d:9005:0557"
+    http_path: "http://9.47.67.137/repo/firmware/RAID/arcconf/tool/"
+    tool_name: "Arcconf-2.02-22404.ppc64el"


### PR DESCRIPTION
arcconf_cntl_oper.py tests arcconf tools controller specific configs.
addressed all the suggestions in v2.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>

https://github.com/avocado-framework-tests/avocado-misc-tests/pull/191


[results.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/626646/results.txt)
[job.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/626647/job.txt)
