### PR TITLE
New tests added to arcconf controller functionality - v1

### DIFF
--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -88,7 +88,18 @@ class Arcconftest(Test):
         cmd = "arcconf getconfig %s AD" % self.crtl_no
         self.check_pass(cmd, "Failed to display PMC controller details")
 
-        if "CONFIG" in self.option:
+        if "SETCONFIG" in self.option:
+            # reset the config only if no OS drive found
+            cmd = "lsscsi  | grep LogicalDrv | awk \'{print $7}\'"
+            drive = self.cmdop_list(cmd)
+            if drive != "":
+                cmd = "df -h /boot | grep %s" % drive
+                if process.system(cmd, timeout=300, ignore_status=True,
+                                  shell=True) != 0:
+                    self.log.info("Hello")
+                    cmd = "%s %s %s" % (self.option, self.crtl_no,
+                                        self.option_args)
+        elif "CONFIG" in self.option or "SAVESUPPORTARCHIVE" in self.option:
             cmd = "%s %s" % (self.option, self.option_args)
         else:
             cmd = "%s %s %s" % (self.option, self.crtl_no, self.option_args)
@@ -98,7 +109,8 @@ class Arcconftest(Test):
         """
         Function returns the output of a command
         """
-        val = process.run(cmd, shell=True, allow_output_check='stdout')
+        val = process.run(cmd, shell=True, ignore_status=True,
+                          allow_output_check='stdout')
         if val.exit_status:
             self.fail("cmd %s Failed" % (cmd))
         return val.stdout.rstrip()

--- a/io/disk/arcconf/arcconf_cntl_oper.py.data/Readme
+++ b/io/disk/arcconf/arcconf_cntl_oper.py.data/Readme
@@ -7,6 +7,5 @@ specific to controller settings.
 Note:
     1. supported controllers pci_ids can be entered 
        seperated by ",".
-    2. TODO: CPLD, ROMPUPDATE, SETCONFIG, KEY,
-       EXPANDERUPGRADE, SETMAXCACHE, SETPRIORITY,
-       SMP, UARTLOG
+    2. TODO: ROMPUPDATE, KEY, EXPANDERUPGRADE, 
+       SETMAXCACHE, SETPRIORITY, SMP, UARTLOG

--- a/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
+++ b/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
@@ -1,4 +1,10 @@
 Test: !mux
+   setconfig:
+        option: "echo y | arcconf SETCONFIG"
+        option_args: "Default"
+   CPLD:
+        option: "echo y | arcconf CPLD"
+        option_args: "FLASHUPDATE"
    Backupunit:
         option: "arcconf BACKUPUNIT"
         option_args: "RESET"
@@ -71,6 +77,9 @@ Test: !mux
    Playconfig:
         option: "arcconf PLAYCONFIG"
         option_args: "/tmp/abc.xml /tmp/arcconf_cntl.log"
+   savesupportconfig:
+        option: "echo y | arcconf SAVESUPPORTARCHIVE"
+        option_args: "/tmp/"
    Preservecache:
         option: "arcconf PRESERVECACHE"
         option_args: "ENABLE"
@@ -164,6 +173,9 @@ Test: !mux
    verifywrite2:
         option: "arcconf verifywrite"
         option_args: "enable"
+   setpower:
+        option: "arcconf setpower"
+        option_args: "spinup 5 11"
 parameters:
     crtl_no: "1"
     pci_id: "9005:028d:9005:0557"


### PR DESCRIPTION
CPLD, SETPOWER, SAVESUPPORTARCHIVE and SETCONFIG new tests are added to
arcconf controller functionality.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>

[job.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/645768/job.txt)
[results.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/645769/results.txt)
