### PR TITLE
firmware upgrade functionality for PMC adapters -v1

### DIFF
--- a/io/disk/arcconf/arcconf_cntl_oper.py.data/Readme
+++ b/io/disk/arcconf/arcconf_cntl_oper.py.data/Readme
@@ -7,5 +7,5 @@ specific to controller settings.
 Note:
     1. supported controllers pci_ids can be entered 
        seperated by ",".
-    2. TODO: ROMPUPDATE, KEY, EXPANDERUPGRADE, 
-       SETMAXCACHE, SETPRIORITY, SMP, UARTLOG
+    2. TODO: KEY, EXPANDERUPGRADE, SETMAXCACHE,
+       SETPRIORITY, SMP, UARTLOG.

--- a/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
+++ b/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
@@ -1,4 +1,7 @@
 Test: !mux
+   Firmwareflash:
+        option: "echo y | arcconf ROMUPDATE"
+        option_args: ""
    setconfig:
         option: "echo y | arcconf SETCONFIG"
         option_args: "Default"
@@ -179,5 +182,7 @@ Test: !mux
 parameters:
     crtl_no: "1"
     pci_id: "9005:028d:9005:0557"
-    http_path: "http://9.47.67.137/repo/firmware/RAID/arcconf/tool/"
+    tool_path: "http://9.47.67.137/repo/firmware/RAID/arcconf/tool/"
     tool_name: "Arcconf-2.02-22404.ppc64el"
+    firmware_path: "http://9.47.67.137/repo/firmware/RAID/PMC_Sierra/"
+    firmware_name: "latest"


### PR DESCRIPTION
firmware upgrade functionality for PMC adapter using arcconf

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>

[job.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/648922/job.txt)
[results.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/648923/results.txt)

