### PR TITLE
kselftest fails to compile on redhat due to wrong dependency check

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -51,13 +51,10 @@ class kselftest(Test):
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['git-core', 'popt', 'glibc', 'glibc-devel', 'popt-devel',
                          'libcap1', 'libcap1-devel', 'libcap-ng', 'libcap-ng-devel'])
-        elif 'redhat' in detected_distro.name:
-            deps.extend(['git', 'popt', 'popt-static', 'glibc', 'glibc-devel', 'glibc-static',
-                         'libcap-ng', 'libcap-ng-devel', 'libcap1', 'libcap1-devel'])
         elif 'SuSE' in detected_distro.name:
             deps.extend(['git-core', 'popt', 'glibc', 'glibc-devel', 'popt-devel',
                          'libcap1', 'libcap1-devel', 'libcap-ng', 'libcap-ng-devel'])
-        elif detected_distro.name in ['centos', 'fedora']:
+        elif detected_distro.name in ['centos', 'fedora', 'redhat']:
             deps.extend(['git', 'popt', 'popt-static', 'glibc', 'glibc-devel', 'glibc-static',
                          'libcap-ng', 'libcap-ng-devel', 'libcap', 'libcap-devel'])
 


### PR DESCRIPTION
Test checks for libcap1 & libcap1-devel packages. Correct dependency check should
be for libcap & libcap-devel.

Merge redhat package dependency list with fedora & centos.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>