### PR TITLE
kselftest - fix compile error on Ubuntu

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -49,8 +49,8 @@ class kselftest(Test):
         deps = ['gcc', 'make', 'automake', 'autoconf']
 
         if 'Ubuntu' in detected_distro.name:
-            deps.extend(['git-core', 'popt', 'glibc', 'glibc-devel', 'popt-devel',
-                         'libcap1', 'libcap1-devel', 'libcap-ng', 'libcap-ng-devel'])
+            deps.extend(['git', 'libpopt0', 'libc6', 'libc6-dev', 'libpopt-dev',
+                         'libcap-ng0', 'libcap-ng-dev'])
         elif 'SuSE' in detected_distro.name:
             deps.extend(['git-core', 'popt', 'glibc', 'glibc-devel', 'popt-devel',
                          'libcap1', 'libcap1-devel', 'libcap-ng', 'libcap-ng-devel'])


### PR DESCRIPTION
kselftest - fix compile error on Ubuntu

Package Dependency listed against Ubuntu was incorrect. Updated
correct packages in deps.extend statement.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>