### PR TITLE
Avocado fixes for network tests

### DIFF
--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -23,6 +23,7 @@ from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
+from avocado.utils import distro
 
 
 class ReceiveMulticastTest(Test):
@@ -36,7 +37,13 @@ class ReceiveMulticastTest(Test):
         To check and install dependencies for the test
         '''
         sm = SoftwareManager()
-        for pkg in ["openssh-clients", "net-tools"]:
+        pkgs = ["net-tools"]
+        detected_distro = distro.detect()
+        if detected_distro.name == "Ubuntu":
+            pkgs.append('openssh-client')
+        else:
+            pkgs.append('openssh-clients')
+        for pkg in pkgs:
             if not sm.check_installed(pkg) and not sm.install(pkg):
                 self.skip("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()

--- a/io/net/multicast.py.data/multicast.yaml
+++ b/io/net/multicast.py.data/multicast.yaml
@@ -1,4 +1,4 @@
 Parameters:
-    peerip: ""
+    peerip: "103.1.1.60"
     user_name: "root"
-    interface: ""
+    interface: "enP5p1s0f1"

--- a/io/net/net_data.py
+++ b/io/net/net_data.py
@@ -96,7 +96,8 @@ class NetDataTest(Test):
             self.log.info("trying with mtu %s" % (mtu))
             # ping the peer machine with different maximum transfers unit sizes
             # and finally set maximum transfer unit size to 1500 Bytes
-            msg = "ssh %s \"ifconfig %s mtu %s\"" % (self.peer, self.peer_interface, mtu)
+            msg = "ssh %s \"ifconfig %s mtu %s\"" % (self.peer,
+                                                     self.peer_interface, mtu)
             process.system(msg, shell=True)
             con_msg = "ifconfig %s mtu %s" % (self.interface, mtu)
             process.system(con_msg, shell=True)
@@ -132,13 +133,13 @@ class NetDataTest(Test):
         '''
         self.log.info("Largest Receive Offload")
         tmp = "ethtool -K %s lro off" % self.interface
-        if process.system(tmp, shell=True)!= 0:
+        if process.system(tmp, shell=True) != 0:
             self.fail("LRO Test failed")
         ret = process.system("ping -c 1 %s" % self.peer, shell=True)
         if ret != 0:
             self.fail("lro test failed")
             msg = "ethtool -K %s lro on" % self.interface
-            if process.system(msg, shell=True)!= 0:
+            if process.system(msg, shell=True) != 0:
                 self.fail("LRO Test failed")
                 ret = process.system("ping -c 1 %s" % self.peer, shell=True)
                 if ret != 0:

--- a/io/net/net_data.py
+++ b/io/net/net_data.py
@@ -40,12 +40,16 @@ class NetDataTest(Test):
             To check and install dependencies for the test
         '''
         smm = SoftwareManager()
-        pkgs = ["iputils", "ethtool", "net-tools"]
+        pkgs = ["ethtool", "net-tools"]
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             pkgs.append('openssh-client')
         else:
             pkgs.append('openssh-clients')
+        if detected_distro.name == "Ubuntu":
+            pkgs.append('iputils-ping')
+        else:
+            pkgs.append('iputils')
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.skip("%s package is need to test" % pkg)
@@ -83,13 +87,16 @@ class NetDataTest(Test):
         '''
         check with different maximum transfer unit values
         '''
-        cmd = "grep -w -B 1 %s" % self.peer
-        cmd = "`ifconfig | %s | head -1 | cut -f1 -d' '`" % cmd
+        msg = "ip addr show  | grep %s | grep -oE '[^ ]+$'"\
+               % self.peer
+        cmd = "ssh %s %s" % (self.peer, msg)
+        self.peer_interface = process.system_output(cmd, shell=True
+                                                    ).strip()
         for mtu in self.mtu_list:
             self.log.info("trying with mtu %s" % (mtu))
             # ping the peer machine with different maximum transfers unit sizes
             # and finally set maximum transfer unit size to 1500 Bytes
-            msg = "ssh %s \"ifconfig %s mtu %s\"" % (self.peer, cmd, mtu)
+            msg = "ssh %s \"ifconfig %s mtu %s\"" % (self.peer, self.peer_interface, mtu)
             process.system(msg, shell=True)
             con_msg = "ifconfig %s mtu %s" % (self.interface, mtu)
             process.system(con_msg, shell=True)
@@ -125,13 +132,13 @@ class NetDataTest(Test):
         '''
         self.log.info("Largest Receive Offload")
         tmp = "ethtool -K %s lro off" % self.interface
-        if not process.system(tmp, shell=True):
+        if process.system(tmp, shell=True)!= 0:
             self.fail("LRO Test failed")
         ret = process.system("ping -c 1 %s" % self.peer, shell=True)
         if ret != 0:
             self.fail("lro test failed")
             msg = "ethtool -K %s lro on" % self.interface
-            if not process.system(msg, shell=True):
+            if process.system(msg, shell=True)!= 0:
                 self.fail("LRO Test failed")
                 ret = process.system("ping -c 1 %s" % self.peer, shell=True)
                 if ret != 0:

--- a/io/net/net_data.py.data/net_data.yaml
+++ b/io/net/net_data.py.data/net_data.yaml
@@ -1,6 +1,6 @@
 Interfaces:
     Interface1:
-        peerip: "10.10.10.11"
-        iface: "enP2p1s0f4"
+        peerip: ""
+        iface: ""
 MTU:
     size_val: 2000 3000 4000 5000 6000 7000 8000 9000 1500


### PR DESCRIPTION
patch for BigPing and LRO tests which will now work on Ubuntu and Rhel