### PR TITLE
Added proper check for the script arcconf_cntl_oper

### DIFF
--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -15,7 +15,6 @@
 # Copyright: 2016 IBM
 # Author: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>
 
-
 """
 arcconf - Array configuration utility for PMC-Sierra
 (Microsemi) Controllers.
@@ -83,7 +82,7 @@ class Arcconftest(Test):
                 http_repo = "%s%s.rpm" % (self.http_path, self.tool_name)
                 self.repo = self.fetch_asset(http_repo, expire='10d')
                 cmd = "rpm -ivh %s" % self.repo
-            if process.system(cmd, ignore_status=True, shell=True) == 0:
+            if process.system(cmd, ignore_status=True, shell=True) != 0:
                 self.skip("Unable to install arcconf")
 
     def test(self):


### PR DESCRIPTION
Firmware flash test case was skipping due to im-proper check,
fixed the same

Signed-off-by: Venkat R B <vrbagal1@linux.vnet.ibm.com>