### PR TITLE
Added install libraries for aiostress test [v2]

### DIFF
--- a/perf/aiostress.py
+++ b/perf/aiostress.py
@@ -13,6 +13,7 @@
 #
 # Copyright: 2016 Red Hat, Inc
 # Author: Amador Pahim <apahim@redhat.com>
+#         Harish <harish@linux.vnet.ibm.com>
 #
 # Based on code by Masoud Asgharifard Sharbiani <masouds@google.com>
 #   copyright 2006 Google
@@ -23,7 +24,8 @@ import os
 
 from avocado import Test
 from avocado import main
-from avocado.utils import process
+from avocado.utils import process, distro
+from avocado.utils.software_manager import SoftwareManager
 
 
 class Aiostress(Test):
@@ -38,10 +40,26 @@ class Aiostress(Test):
         Source:
          https://oss.oracle.com/~mason/aio-stress/aio-stress.c
         """
-        aiostress = self.fetch_asset('https://oss.oracle.com/~mason/aio-stress/aio-stress.c')
+        smm = SoftwareManager()
+        packages = []
+        dist_name = distro.detect().name.lower()
+        if dist_name == 'ubuntu':
+            packages.extend(['libaio1', 'libaio-dev'])
+        elif dist_name in ['centos', 'fedora', 'redhat']:
+            packages.extend(['libaio', 'libaio-devel'])
+        elif dist_name == 'suse':
+            self.skip("Test currently does not support distro %s" % dist_name)
+
+        for package in packages:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.error('%s is needed for the test to be run' % package)
+
+        aiostress = self.fetch_asset(
+            'https://oss.oracle.com/~mason/aio-stress/aio-stress.c')
         os.chdir(self.srcdir)
         # This requires libaio.h in order to build
-        process.run('gcc -Wall -laio -lpthread -o aio-stress %s' % aiostress)
+        # -laio -lpthread is provided at end as a workaround for Ubuntu
+        process.run('gcc -Wall -o aio-stress %s -laio -lpthread' % aiostress)
 
     def test(self):
         """


### PR DESCRIPTION
This patch adds library required to be installed to run on
different distros. This also includes a workaround for compiling
aiostress in Ubuntu.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>