### PR TITLE
Made changes to dma_memtest

### DIFF
--- a/memory/dma_memtest.py.data/dma_memtest.yaml
+++ b/memory/dma_memtest.py.data/dma_memtest.yaml
@@ -7,3 +7,4 @@ setup:
     parallel:
         default:
             parallel: True
+dir_to_extract: '/tmp/'


### PR DESCRIPTION
-Provided options to pass tmpdir from yaml file
-Disk space check is made
-Avoid printing output buffer when comparison error occurs

Signed-off-by: Santhosh G <santhog4@linux.vnet.ibm.com>