### PR TITLE
Changed os.system to process.system in lmbench

### DIFF
--- a/perf/lmbench.py
+++ b/perf/lmbench.py
@@ -79,7 +79,7 @@ class Lmbench(Test):
         # configure lmbench
         os.chdir(self.srcdir)
 
-        os.system('yes "" | make config')
+        process.system('yes "" | make config', shell=True, ignore_status=True)
 
         # find the lmbench config file
         output = os.popen('ls -1 bin/*/CONFIG*').read()


### PR DESCRIPTION
os.system logs the output out of log file and has been
replaced by process.system

Signed-off-by: Harish <harish@linux.vnet.ibm.com>