### PR TITLE
Fix posixtest runtime failure

### DIFF
--- a/kernel/posixtest.py
+++ b/kernel/posixtest.py
@@ -47,7 +47,7 @@ class Posixtest(Test):
                                    '/sourceforge/posixtest/posixtestsuite-1.5.2.tar.gz')
         data_dir = os.path.abspath(self.datadir)
         archive.extract(tarball, self.srcdir)
-        version = os.path.basename(tarball.split('-')[0])
+        version = os.path.basename(tarball.split('-1.')[0])
         self.srcdir = os.path.join(self.srcdir, version)
 
         patch = self.params.get(


### PR DESCRIPTION
posixtest fails to run due to following error

    Command 'rpm -q gcc' finished with 0 after 0.164994955063s
    Fetching http://ufpr.dl.sourceforge.net/sourceforge/posixtest/posixtestsuite-1.5.2.tar.gz -> /home/avocado-fvt-wrapper/data/cache/posixtestsuite-1.5.2.tar.gz.0JvAha
    PARAMS (key=patch, path=*, default=posix-linux.patch) => 'posix-linux.patch'

    Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_framework-44.0-py2.7.egg/avocado/core/test.py:469
    Traceback (most recent call last):
      File "/home/avocado-misc-tests/kernel/posixtest.py", line 55, in setUp
        os.chdir(self.srcdir)
    OSError: [Errno 2] No such file or directory: '/var/tmp/avocado_yGDhUM/1-kernel_posixtest.py_Posixtest.test/src/avocado'

Fix the failure by using a correct delimiter to extract version string.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>