### PR TITLE
Enhanced the module unload test

### DIFF
--- a/io/driver/module_unload_load.sh.data/module_unload_load.yaml
+++ b/io/driver/module_unload_load.sh.data/module_unload_load.yaml
@@ -1,0 +1,1 @@
+ITERATIONS: 10


### PR DESCRIPTION
Enhanced the test to run for all loaded modules.
Fixed the module test to skip the modules which have
dependencies.
Also, changed the way exit status is given, to check for errors
first.

Enhanced as per suggestion by @sacsant 

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>