### PR TITLE
rping -v1

### DIFF
--- a/io/net/infiniband/rping.py
+++ b/io/net/infiniband/rping.py
@@ -25,7 +25,7 @@ from netifaces import AF_INET
 from avocado import Test
 from avocado import main
 from avocado.utils.software_manager import SoftwareManager
-from avocado.utils import process
+from avocado.utils import process, distro
 
 
 class Rping(Test):
@@ -64,31 +64,46 @@ class Rping(Test):
             self.skip("%s peer machine is not available" % self.peer_ip)
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
-        self.option = self.option.replace("peer_ip", self.peer_ip)
-        self.option = self.option.replace("local_ip", self.local_ip)
         self.option = self.option.replace("peer_ipv6", self.ipv6_peer)
+        self.option = self.option.replace("peer_ip", self.peer_ip)
+        self.option = self.option.replace("IFACE", self.iface)
         self.option_list = self.option.split(",")
+
+        detected_distro = distro.detect()
+        if detected_distro.name == "Ubuntu":
+            cmd = "service ufw stop && ssh %s \"service ufw stop \" \
+                " % self.peer_ip
+        elif detected_distro.name == "redhat":
+            cmd = "systemctl stop firewalld && ssh %s \"systemctl stop \
+                firewalld \" " % self.peer_ip
+        elif detected_distro.name == "Suse":
+            cmd = "rcSuSEfirewall2 stop && ssh %s \"rcSuSEfirewall2 stop \" \
+                " % self.peer_ip
+        if process.system(cmd, ignore_status=True, shell=True) != 0:
+            self.skip("Unable to disable firewall")
 
     def test(self):
         """
         Test rping
         """
         self.log.info(self.test_name)
-        self.log.info("Client data - %s(%s)" % (self.test_name, self.option))
         logs = "> /tmp/ib_log 2>&1 &"
-        cmd = "ssh %s timeout %s %s -s %s -c %s %s %s" \
+        cmd = "ssh %s \" timeout %s %s -s %s %s\" " \
             % (self.peer_ip, self.timeout, self.test_name,
-               self.option_list[0], self.option_list[1], self.option, logs)
+               self.option_list[0], logs)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("SSH connection (or) Server command failed")
         time.sleep(5)
+        self.log.info("Client data - %s(%s)" %
+                      (self.test_name, self.option_list[1]))
         cmd = "timeout %s %s -c %s" \
             % (self.timeout, self.test_name, self.option_list[1])
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("Client command failed")
         time.sleep(5)
-        self.log.info("Server data - %s(%s)" % (self.test_name, self.option))
-        cmd = "ssh %s timeout %s cat /tmp/ib_log; rm -rf /tmp/ib_log" \
+        self.log.info("Server data - %s(%s)" %
+                      (self.test_name, self.option_list[0]))
+        cmd = "ssh %s \" timeout %s cat /tmp/ib_log && rm -rf /tmp/ib_log\" " \
             % (self.peer_ip, self.timeout)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("Server output retrieval failed")

--- a/io/net/infiniband/rping.py.data/rping.yaml
+++ b/io/net/infiniband/rping.py.data/rping.yaml
@@ -5,12 +5,12 @@ Test: !mux
         second:
             basic_option: -v -C 100 -S 2048 , -a peer_ip -v -C 100 -S 2048
         third:
-            basic_option: -a ::0 , -C300 -a peer_ipv6%local_ip -v
+            basic_option: -a ::0 , -C300 -a peer_ipv6%IFACE -v
 # Placeholder for exended option
 #        fourth:
 #            ext_option:
 Parameters:
     ext_flag: "1"
     interface: "ib0"
-    peer_ip: "13.13.13.15"
-    peer_ipv6: "fe80::f652:1403:e2:c753"
+    peer_ip: "15.15.15.16"
+    peer_ipv6: "fe80::5265:7bd:840a:31bf"


### PR DESCRIPTION
fixed couple of issues:

1. rping didn't work, made changes to better handle client and
server data.
2. server data from /tmp/ib_log is now printed.
3. Disabled firewall before the test start, which is an prerequisite.

Signed-off-by: Manvanthara Puttashankar <manvanth@linux.vnet.ibm.com>
[rping_test_run.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/764175/rping_test_run.txt)
[job.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/764177/job.txt)

