### PR TITLE
rping -v2

### DIFF
--- a/io/net/infiniband/rping.py.data/rping.yaml
+++ b/io/net/infiniband/rping.py.data/rping.yaml
@@ -5,12 +5,12 @@ Test: !mux
         second:
             basic_option: -v -C 100 -S 2048 , -a peer_ip -v -C 100 -S 2048
         third:
-            basic_option: -a ::0 , -C300 -a peer_ipv6%local_ip -v
+            basic_option: -a ::0 , -C300 -a peer_ipv6%interface -v
 # Placeholder for exended option
 #        fourth:
 #            ext_option:
 Parameters:
     ext_flag: "1"
     interface: "ib0"
-    peer_ip: "13.13.13.15"
-    peer_ipv6: "fe80::f652:1403:e2:c753"
+    peer_ip: "15.15.15.16"
+    peer_ipv6: "fe80::5265:7bd:840a:31bf"


### PR DESCRIPTION
fixed couple of issues:

1. rping didn't work, made changes to better handle client and
   server data.
2. server data from /tmp/ib_log is now printed.
3. Disabled firewall before the test start, which is an prerequisite.

Signed-off-by: Manvanthara Puttashankar <manvanth@linux.vnet.ibm.com>
[rping_test_run.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/765897/rping_test_run.txt)
[job.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/765898/job.txt)
