### PR TITLE
Added uninstall flag for mofed install test

### DIFF
--- a/io/net/infiniband/mofed_install_test.py
+++ b/io/net/infiniband/mofed_install_test.py
@@ -40,6 +40,7 @@ class MOFEDInstallTest(Test):
         if self.iso_location is '':
             self.skip("No ISO location given")
         self.option = self.params.get('option', default='')
+        self.uninstall_flag = self.params.get('uninstall', default=True)
         self.iso = self.fetch_asset(self.iso_location, expire='10d')
         cmd = "mount -o loop %s %s" % (self.iso, self.srcdir)
         process.run(cmd, shell=True)
@@ -49,6 +50,7 @@ class MOFEDInstallTest(Test):
         """
         Installs MOFED with given options.
         """
+        self.log.info("Starting installation")
         os.chdir(self.srcdir)
         cmd = './mlnxofedinstall %s --force' % self.option
         if process.system(cmd, ignore_status=True, shell=True):
@@ -58,6 +60,7 @@ class MOFEDInstallTest(Test):
         """
         Uninstalls MOFED, if installed fine.
         """
+        self.log.info("Starting uninstallation")
         cmd = "/etc/init.d/openibd restart"
         if not process.system(cmd, ignore_status=True, shell=True):
             return
@@ -73,7 +76,8 @@ class MOFEDInstallTest(Test):
         Tests install and uninstall of MOFED.
         """
         self.install()
-        self.uninstall()
+        if self.uninstall_flag:
+            self.uninstall()
 
     def tearDown(self):
         """

--- a/io/net/infiniband/mofed_install_test.py.data/README.txt
+++ b/io/net/infiniband/mofed_install_test.py.data/README.txt
@@ -13,3 +13,4 @@ Inputs Needed (in multiplexer file):
 ------------------------------------
 iso_location -  HTTP location of MOFED ISO (Available from Mellanox website)
 option -        installation parameters
+uninstall -     Indicate whether to uninstall or not (True/False, default=True)

--- a/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
+++ b/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
@@ -46,3 +46,4 @@ Options: !mux
         option: -c docs/conf/ofed-basic.conf -n docs/conf/ofed_net.conf-example
     add-kernel-support:
         option: --add-kernel-support --skip-repo --force --kmp
+        uninstall: False


### PR DESCRIPTION
Added an uninstall flag, so that user can decide if mofed should be
uninstalled or not. This is useful when user needs to run tests which
uses installed mofed after this test.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>