### PR TITLE
edited the script to order the script execution

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -38,11 +38,6 @@ class MultipathTest(Test):
         """
         Set up.
         """
-        # Check if multipath devices are present in system
-        self.wwids = multipath.get_multipath_wwids()
-        if self.wwids == ['']:
-            self.skip("No Multipath Devices")
-
         # Install needed packages
         dist = distro.detect()
         pkg_name = ""
@@ -59,6 +54,12 @@ class MultipathTest(Test):
 
         # Create service object
         self.mpath_svc = service.SpecificServiceManager(svc_name)
+        self.mpath_svc.restart()
+
+        # Check if multipath devices are present in system
+        self.wwids = multipath.get_multipath_wwids()
+        if self.wwids == ['']:
+            self.skip("No Multipath Devices")
 
         # Take a backup of current config file
         self.mpath_file = "/etc/multipath.conf"


### PR DESCRIPTION
ordered the script execution. the script was directly checking the
multipath device without installing the required packages and then
it is installing the required packages. so made it first install
multipath package and then check for the multipath devices.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>