### PR TITLE
Handle packages for different distributions

### DIFF
--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -46,10 +46,16 @@ class Fsfuzzer(Test):
         https://github.com/stevegrubb/fsfuzzer.git
         '''
         detected_distro = distro.detect()
+        d_name = detected_distro.name.lower()
 
         smm = SoftwareManager()
+        deps = ['gcc']
+        if d_name == 'ubuntu':
+            deps.extend(['libattr1-dev'])
+        else:
+            deps.extend(['libattr-devel'])
 
-        for package in ('gcc', 'libattr-devel'):
+        for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.error("Fail to install/check %s, which is needed for"
                            "fsfuzz to run" % package)
@@ -60,7 +66,7 @@ class Fsfuzzer(Test):
         archive.extract(tarball, self.srcdir)
         os.chdir(os.path.join(self.srcdir, "fsfuzzer-master"))
 
-        if detected_distro.name == "Ubuntu":
+        if d_name == "ubuntu":
             # Patch for ubuntu
             fuzz_fix_patch = 'patch -p1 < %s' % (
                 os.path.join(self.datadir, 'fsfuzz_fix.patch'))
@@ -81,7 +87,6 @@ class Fsfuzzer(Test):
                       ' is unsupported in ' + detected_distro.name)
 
     def test(self):
-
         '''
         Runs the fsfuzz test suite. By default uses all supported fstypes,
         but you can specify only one by `fstype` param.


### PR DESCRIPTION
This patch handles packages required for fsfuzzer test to execute on different distros

Signed-off-by: Harish <harish@linux.vnet.ibm.com>