### PR TITLE
FIx Xfstest v2

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -40,6 +40,8 @@ class Xfstests(Test):
         """
         sm = SoftwareManager()
 
+        detected_distro = distro.detect()
+
         packages = ['e2fsprogs', 'automake', 'gcc', 'quota', 'attr',
                     'make',  'xfsprogs',  'gawk', 'fio', 'dbench']
 
@@ -71,6 +73,9 @@ class Xfstests(Test):
 
         shutil.copyfile(os.path.join(data_dir, 'group'),
                         os.path.join(self.srcdir, 'group'))
+        shutil.copyfile(os.path.join(data_dir, 'local.config'),
+                        os.path.join(self.srcdir, 'local.config'))
+
         build.make(self.srcdir)
         self.available_tests = self._get_available_tests()
 

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -27,7 +27,7 @@ import shutil
 
 from avocado import Test
 from avocado import main
-from avocado.utils import process, build, git
+from avocado.utils import process, build, git, distro
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -39,15 +39,26 @@ class Xfstests(Test):
         Source: git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
         """
         sm = SoftwareManager()
-        packages = ['xfslibs-dev', 'uuid-dev', 'libtool-bin', 'e2fsprogs',
-                    'automake', 'gcc', 'libuuid1', 'quota', 'attr',
-                    'libattr1-dev', 'make', 'libacl1-dev', 'xfsprogs',
-                    'libgdbm-dev', 'gawk', 'fio', 'dbench', 'uuid-runtime']
+
+        packages = ['e2fsprogs', 'automake', 'gcc', 'quota', 'attr',
+                    'make',  'xfsprogs',  'gawk', 'fio', 'dbench']
+
+        if 'Ubuntu' in detected_distro.name:
+            packages.extend(['xfslibs-dev', 'uuid-dev', 'libtool-bin', 'libuuid1',
+                             'libattr1-dev', 'libacl1-dev', 'libgdbm-dev', 'uuid-runtime'])
+
+        elif detected_distro.name in ['centos', 'fedora', 'redhat']:
+            packages.extend(['acl', 'bc', 'dump', 'indent', 'libtool', 'lvm2',
+                             'xfsdump', 'psmisc', 'sed', 'libacl-devel', 'libattr-devel',
+                             'libaio-devel', 'libuuid-devel', 'openssl-devel', 'xfsprogs-devel',
+                             'btrfs-progs-devel'])
+        else:
+            self.skip("test not supported in %s" % detected_distro.name)
+
         for package in packages:
             if not sm.check_installed(package) and not sm.install(package):
-                self.error("Fail to install %s required for this test." %
-                           package)
-
+                self.skip("Fail to install %s required for this test." %
+                          package)
         self.test_range = self.params.get('test_range', default=None)
         if self.test_range is None:
             self.fail('Please provide a test_range.')

--- a/fs/xfstests.py.data/README
+++ b/fs/xfstests.py.data/README
@@ -5,9 +5,11 @@ started are really simple:
 1.1) The variables 'TEST_DEV' and 'TEST_DIR' are mandatory and should be set to
      a block device path and mount point path, respectively, that will be used
      *exclusively* for xfstests. It must have the filesystem of your choice
-     previously created.
-     ex : export TEST_DEV =/dev/vda1 , export TEST_DIR=/mnt
-
+     previously created .Please refer local.config and edit local.config 
+     as ex:  create  entry TEST_DEV =/dev/vda1
+		     	   TEST_DIR=/mnt
+     for xfs test SCRATCH_DEV and SCRATCH_MNT can also be set 
+	but that can be optional 
      DO NOT USE A BLOCK DEVICE WITH IMPORTANT DATA!!!
 
 1.2) In yaml file set test_number which test need to run  and skip_dangerous
@@ -39,3 +41,8 @@ virtual partition depends on the following programs to be available:
      * kpartx
 Make sure you have them or a real spare device to test things.
 """
+TODO:
+1- Device will be given as yaml input
+2- creating FS, mounting the disk/loop device
+3- Write local.cofig dynamic way 
+4- test will able to run only specfic file system type test case

--- a/fs/xfstests.py.data/local.config
+++ b/fs/xfstests.py.data/local.config
@@ -1,0 +1,4 @@
+export TEST_DEV=/dev/loop0
+export TEST_DIR=/mnt/test
+export SCRATCH_DEV=/dev/loop1
+export SCRATCH_MNT=/mnt/scratch


### PR DESCRIPTION
Fix xfstest

1- enable xfstest to run fedora/centos/RHEL
2- enable local.config file to handle environment variable
3-  Rectify README File

