### PR TITLE
Fix the default disk size typo in the test

### DIFF
--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -92,7 +92,7 @@ class Disktest(Test):
 
         gigabytes = self.params.get('gigabytes', default=None)
         if gigabytes is None:
-            free = 100  # cap it at 100GB by default
+            free = 107374182400  # cap it at 100GB by default
             for disk in self.disks:
                 free = min(utils_disk.freespace(disk) / 1073741824, free)
             gigabytes = free


### PR DESCRIPTION
The testscript is hardcoded as 100 GB as the default disk size.
test works for all disks <= 100GB and fails if the disk is larger size
like 1TB it fails with this
error "Free disk space is lower than chunk size (10240, 261409)"

the code says free as 100 byte, and in comment it says 100G

Please refer to:
https://github.com/avocado-framework-tests/avocado-misc-tests/issues/291

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>