### PR TITLE
Added missing packages in tests

### DIFF
--- a/perf/unixbench.py
+++ b/perf/unixbench.py
@@ -33,7 +33,7 @@ class unixbench(Test):
         sm = SoftwareManager()
         detected_distro = distro.detect()
         # Check for basic utilities
-        deps = ['gcc', 'make']
+        deps = ['gcc', 'make', 'patch']
         self.tmpdir = data_dir.get_tmp_dir()
         self.build_dir = self.params.get('build_dir', default=self.tmpdir)
         for package in deps:

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -18,6 +18,7 @@ from avocado import main
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
+from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -34,7 +35,13 @@ class Valgrind(Test):
         smm = SoftwareManager()
         self.failures = []
 
-        for package in ['gcc', 'make']:
+        dist = distro.detect()
+        deps = ['gcc', 'make']
+        if dist.name == 'Ubuntu':
+            deps.extend(['g++'])
+        elif dist.name in ['SuSe', 'redhat', 'fedora', 'centos']:
+            deps.extend(['gcc-c++'])
+        for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.skip('%s is needed for the test to be run' % package)
         tarball = self.fetch_asset(


### PR DESCRIPTION
Unixbench test fails without patch command. Valgrind requires g++ package.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>