### PR TITLE
Added perf test and perf-test suite.Providing fix to install perf tool.

### DIFF
--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado import main
-from avocado.utils import archive, build
+from avocado.utils import archive, build, process
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -77,8 +77,7 @@ class Perftool(Test):
         self.srcdir = os.path.join(self.srcdir, 'perf_event_tests-master')
         build.make(self.srcdir)
         os.chdir(self.srcdir)
-        process.system_output("echo -1 >/proc/sys/kernel/"
-                              "perf_event_paranoid")
+        os.system("echo -1 >/proc/sys/kernel/perf_event_paranoid")
         process.system_output("./run_tests.sh")
 
 

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -35,13 +35,22 @@ class Perftool(Test):
         Build perftool Test
         Source:
         https://github.com/rfmvh/perftool-testsuite
+        Run perf test
+        Execute perf tests
+        Source : https://github.com/deater/perf_event_tests
+
         '''
 
         # Check for basic utilities
         smm = SoftwareManager()
-        for package in ['gcc', 'make', 'perf']:
+        for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.error('%s is needed for the test to be run' % package)
+        if SoftwareManager().check_installed("linux-tools-common") is False:
+            if SoftwareManager().install("linux-tools-common") is False:
+                self.skip("linux-tools-common is not installing")
+        if SoftwareManager().install("linux-tools-$(uname-r)") is False:
+            self.skip("linux-tools-$(uname-r) is not installing")
 
         locations = ["https://github.com/rfmvh/perftool-testsuite/archive/"
                      "master.zip"]
@@ -57,9 +66,20 @@ class Perftool(Test):
             if '-- [ FAIL ] --' in line:
                 self.count += 1
                 self.log.info(line)
-
         if self.count > 0:
             self.fail("%s Test failed" % self.count)
+
+        process.system_output("perf test")
+        tarball = self.fetch_asset('https://github.com/deater/'
+                                   'perf_event_tests/archive/'
+                                   'master.zip', expire='7d')
+        archive.extract(tarball, self.srcdir)
+        self.srcdir = os.path.join(self.srcdir, 'perf_event_tests-master')
+        build.make(self.srcdir)
+        os.chdir(self.srcdir)
+        process.system_output("echo -1 >/proc/sys/kernel/"
+                              "perf_event_paranoid")
+        process.system_output("./run_tests.sh")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Perf test assorted sanity tests, initially through linked routines but also will look for a directory with more tests in the form of scripts.
perf-test suite contains series of test to validate that the perf_event subsystem is working.
Fix will install perf using linux-tools-common and linux-tools-<kernel-version>.

Signed-off-by: Shriya <shriyak@linux.vnet.ibm.com>