### PR TITLE
Updated rt_tests tar path

### DIFF
--- a/perf/rt_tests.py
+++ b/perf/rt_tests.py
@@ -51,10 +51,12 @@ class rt_tests(Test):
         for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.error(package + ' is needed for the test to be run')
-        locations = ["https://kernel.googlesource.com/pub/scm/utils/rt-tests/"
-                     "rt-tests/+archive/master.tar.gz"]
-        tarball = self.fetch_asset("rt-tests.tar.gz", locations=locations)
+        tarball = self.fetch_asset(
+            "https://www.kernel.org/pub/linux/utils/rt-tests/"
+            "rt-tests-1.0.tar.gz")
         archive.extract(tarball, self.srcdir)
+        self.srcdir = os.path.join(
+            self.srcdir, os.path.basename(tarball.split('.tar.')[0]))
         build.make(self.srcdir)
 
     def test(self):


### PR DESCRIPTION
As the old path was not in use, test case failed without expected files in tar. Updated newer tar path.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>