### PR TITLE
Support for running xfstests on loop device

### DIFF
--- a/fs/xfstests.py.data/README
+++ b/fs/xfstests.py.data/README
@@ -15,7 +15,9 @@ started are really simple:
 1.2) In yaml file set test_number which test need to run  and skip_dangerous
      (it will check with group ) and    will skip all the test .
 
-1.3) In Yaml file test range also can be set like test_range='12-89' 
+1.3) In Yaml file test range also can be set like test_range='4,12-89'
+Note that range is optional. If not provided, complete generic and specified
+file systems tests would execute
 
 General notes
 -------------
@@ -42,7 +44,4 @@ virtual partition depends on the following programs to be available:
 Make sure you have them or a real spare device to test things.
 """
 TODO:
-1- Device will be given as yaml input
-2- creating FS, mounting the disk/loop device
-3- Write local.cofig dynamic way 
-4- test will able to run only specfic file system type test case
+1- Replace local.cofig for real disks

--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -1,4 +1,16 @@
 setup:
-    runargs : !mux
-        skip_dangerous: True
-        test_range: '2,12,34-87,91,99-112'
+    skip_dangerous: True
+    file_system: 'ext4'
+
+    # Uncomment and edit test_range for running specific tests
+    # test_range: '73,217-415'
+
+    # Run with either loop_type (or) disk_type
+    loop_type: !mux
+        type: 'loop'
+        base_disk: /dev/sdj2
+    # TODO: Support for real disks
+    # disk_type: !mux
+    #    type: 'disk'
+    #    test_dev: /dev/sdx1
+    #    scrath_dev: /dev/sdx2


### PR DESCRIPTION
1.Enables tests to be run on loop device
2.Runs all tests for given file system
(or)
Runs specific tests for given file system if range is provided

Signed-off-by: Harish <harish@linux.vnet.ibm.com>