### PR TITLE
Update kselftest to always use latest kernel source code.

### DIFF
--- a/kernel/kselftest.py.data/README
+++ b/kernel/kselftest.py.data/README
@@ -1,3 +1,2 @@
-This program runs the selftest available with the linux kernel source,
-the script takes input as tarball url with version or a git repository link
-of linux source, compile and run the tests available at /tools/testing/selftests
+This program runs the selftest available with the linux kernel source.
+Compile and run the tests available at /tools/testing/selftests

--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -1,7 +1,0 @@
-setup:
-    url: !mux
-        default:
-            url: 'https://www.kernel.org/pub/linux/kernel'
-    version: !mux
-        default:
-            version: '4.8.6'


### PR DESCRIPTION
kselftest takes linux kernel source repository link and version as input.
Update the test to use master.zip instead. This ensures any new tests included
into kselftest will be available for execution.

With this change kselftest.yaml is no longer required, so remove it.
In addition the patch also fixes pep8 compliance warnings (length > 79)

git module import is not required, git package installation is no longer a
requirement. Cleanup the related code.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>