### PR TITLE
Support for running xfstests on loop device [v2]

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -14,6 +14,7 @@
 #
 # Copyright: 2016 IBM
 # Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+# Author: Harish <harish@linux.vnet.ibm.com>
 #
 # Based on code by Cleber Rosa <crosa@redhat.com>
 #   copyright: 2011 Redhat
@@ -27,7 +28,7 @@ import shutil
 
 from avocado import Test
 from avocado import main
-from avocado.utils import process, build, git, distro
+from avocado.utils import process, build, git, distro, partition
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -43,17 +44,20 @@ class Xfstests(Test):
         detected_distro = distro.detect()
 
         packages = ['e2fsprogs', 'automake', 'gcc', 'quota', 'attr',
-                    'make',  'xfsprogs',  'gawk', 'fio', 'dbench']
+                    'make',  'xfsprogs',  'gawk']
 
         if 'Ubuntu' in detected_distro.name:
             packages.extend(['xfslibs-dev', 'uuid-dev', 'libtool-bin', 'libuuid1',
-                             'libattr1-dev', 'libacl1-dev', 'libgdbm-dev', 'uuid-runtime'])
+                             'libattr1-dev', 'libacl1-dev', 'libgdbm-dev',
+                             'uuid-runtime', 'libaio-dev', 'fio', 'dbench'])
 
         elif detected_distro.name in ['centos', 'fedora', 'redhat']:
             packages.extend(['acl', 'bc', 'dump', 'indent', 'libtool', 'lvm2',
-                             'xfsdump', 'psmisc', 'sed', 'libacl-devel', 'libattr-devel',
-                             'libaio-devel', 'libuuid-devel', 'openssl-devel', 'xfsprogs-devel',
-                             'btrfs-progs-devel'])
+                             'xfsdump', 'psmisc', 'sed', 'libacl-devel',
+                             'libattr-devel', 'libaio-devel', 'libuuid-devel',
+                             'openssl-devel', 'xfsprogs-devel', 'btrfs-progs-devel'])
+            if detected_distro.name != 'redhat':
+                packages.extend(['fio', 'dbench'])
         else:
             self.skip("test not supported in %s" % detected_distro.name)
 
@@ -61,11 +65,25 @@ class Xfstests(Test):
             if not sm.check_installed(package) and not sm.install(package):
                 self.skip("Fail to install %s required for this test." %
                           package)
-        self.test_range = self.params.get('test_range', default=None)
-        if self.test_range is None:
-            self.fail('Please provide a test_range.')
-
         self.skip_dangerous = self.params.get('skip_dangerous', default=True)
+        self.test_range = self.params.get('test_range', default=None)
+        self.scratch_mnt = self.params.get(
+            'scratch_mnt', default='/mnt/scratch')
+        self.test_mnt = self.params.get('test_mnt', default='/mnt/test')
+        self.disk_mnt = self.params.get('disk_mnt', default='/mnt/loop_device')
+        self.dev_type = self.params.get('type', default='loop')
+        self.fs_to_test = self.params.get('fs', default='ext4')
+        if self.dev_type == 'loop':
+            self.loop_devices = []
+            base_disk = self.params.get('disk', default=None)
+            loop_size = self.params.get('loop_size', default='9GiB')
+            if not base_disk:
+                self.skip('Please provide a base disk to create loop device')
+            self._create_loop_device(base_disk, loop_size)
+        else:
+            self.test_dev = self.params.get('disk_test', default=None)
+            self.scratch_dev = self.params.get('disk_scratch', default=None)
+            # TODO: Overwirte the disk in local.config
 
         git.get_repo('git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git',
                      destination_dir=self.srcdir)
@@ -84,42 +102,88 @@ class Xfstests(Test):
                       ", ".join(self.available_tests))
         process.run('useradd fsgqa', sudo=True)
         process.run('useradd 123456-fsgqa', sudo=True)
+        if not os.path.exists(self.scratch_mnt):
+            os.makedirs(self.scratch_mnt)
+        if not os.path.exists(self.test_mnt):
+            os.makedirs(self.test_mnt)
 
     def test(self):
         failures = False
         os.chdir(self.srcdir)
-        for test in self.test_list:
-            test = '*/' + test
-            cmd = './check %s' % test
-            result = process.run(cmd, ignore_status=True)
+        if not self.test_list:
+            self.log.info('Running all tests')
+            cmd = './check -g auto'
+            result = process.run(cmd, ignore_status=True, verbose=True)
             if result.exit_status == 0:
-                self.log.info('OK: Test %s passed.', test)
+                self.log.info('OK: All Tests passed.')
             else:
                 msg = self._parse_error_message(result.stdout)
-                self.log.info('ERR: %s failed. Message: %s', test, msg)
+                self.log.info('ERR: Test(s) failed. Message: %s', msg)
                 failures = True
+
+        else:
+            self.log.info('Running only specified tests')
+            for test in self.test_list:
+                test = '%s/%s' % (self.fs_to_test, test)
+                cmd = './check %s' % test
+                result = process.run(cmd, ignore_status=True, verbose=True)
+                if result.exit_status == 0:
+                    self.log.info('OK: Test %s passed.', test)
+                else:
+                    msg = self._parse_error_message(result.stdout)
+                    self.log.info('ERR: %s failed. Message: %s', test, msg)
+                    failures = True
         if failures:
             self.fail('One or more tests failed. Please check the logs.')
 
     def tearDown(self):
         process.system('userdel fsgqa', sudo=True)
         process.system('userdel 123456-fsgqa', sudo=True)
+        # In case if any test has been interrupted
+        process.system('umount %s %s' % (self.scratch_mnt, self.test_mnt),
+                       sudo=True, ignore_status=True)
+        if os.path.exists(self.scratch_mnt):
+            os.rmdir(self.scratch_mnt)
+        if os.path.exists(self.test_mnt):
+            os.rmdir(self.test_mnt)
+        if self.dev_type == 'loop':
+            for dev in self.loop_devices:
+                process.system('losetup -d %s' % dev, shell=True,
+                               sudo=True, ignore_status=True)
+        self.part.unmount()
+
+    def _create_loop_device(self, base_disk, loop_size):
+        self.part = partition.Partition(
+            base_disk, mountpoint=self.disk_mnt)
+        self.part.mount()
+        if process.system('which mkfs.%s' % self.fs_to_test, ignore_status=True):
+            self.skip('Unknown filesystem %s' % self.fs_to_test)
+        # Creating two loop devices
+        for i in range(2):
+            process.run('fallocate -o 0 -l %s %s/file-%s.img' %
+                        (loop_size, self.disk_mnt, i), shell=True, sudo=True)
+            dev = process.system_output('losetup -f').strip()
+            self.loop_devices.append(dev)
+            process.run('losetup %s %s/file-%s.img' %
+                        (dev, self.disk_mnt, i), shell=True, sudo=True)
+            # mkfs for two loop device
+            loop_dev = partition.Partition(dev)
+            loop_dev.mkfs(fstype=self.fs_to_test)
 
     def _create_test_list(self):
         test_list = []
         dangerous_tests = []
         if self.skip_dangerous:
             dangerous_tests = self._get_tests_for_group('dangerous')
-
-        for test in self._parse_test_range(self.test_range):
-            if test in dangerous_tests:
-                self.log.debug('Test %s is dangerous. Skipping.', test)
-                continue
-            if not self._is_test_valid(test):
-                self.log.debug('Test %s invalid. Skipping.', test)
-                continue
-
-            test_list.append(test)
+        if self.test_range:
+            for test in self._parse_test_range(self.test_range):
+                if test in dangerous_tests:
+                    self.log.debug('Test %s is dangerous. Skipping.', test)
+                    continue
+                if not self._is_test_valid(test):
+                    self.log.debug('Test %s invalid. Skipping.', test)
+                    continue
+                test_list.append(test)
 
         return test_list
 
@@ -194,7 +258,7 @@ class Xfstests(Test):
             else:
                 error_msg = 'Test dependency failed, test will not run.'
         elif failed_re.match(result_line):
-            error_msg = 'Test error. Please check the logs.'
+            error_msg = 'Test error. %s.' % result_line
         else:
             error_msg = 'Could not verify test result. Please check the logs.'
 

--- a/fs/xfstests.py.data/README
+++ b/fs/xfstests.py.data/README
@@ -15,7 +15,9 @@ started are really simple:
 1.2) In yaml file set test_number which test need to run  and skip_dangerous
      (it will check with group ) and    will skip all the test .
 
-1.3) In Yaml file test range also can be set like test_range='12-89' 
+1.3) In Yaml file test range also can be set like test_range='4,12-89'
+Note that range is optional. If not provided, complete generic and specified
+file systems tests would execute
 
 General notes
 -------------
@@ -42,7 +44,4 @@ virtual partition depends on the following programs to be available:
 Make sure you have them or a real spare device to test things.
 """
 TODO:
-1- Device will be given as yaml input
-2- creating FS, mounting the disk/loop device
-3- Write local.cofig dynamic way 
-4- test will able to run only specfic file system type test case
+1- Replace local.cofig for real disks

--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -1,4 +1,18 @@
 setup:
-    runargs : !mux
-        skip_dangerous: True
-        test_range: '2,12,34-87,91,99-112'
+    skip_dangerous: True
+    fs: 'ext4'
+    scratch_mnt: '/mnt/scratch'
+    test_mnt: '/mnt/test'
+    disk_mnt: '/mnt/loop-device'
+    # Uncomment and edit test_range for running specific tests
+    # test_range: '73,217-415'
+    # Run with either loop_type (or) disk_type
+    loop_type: !mux
+        type: 'loop'
+        loop_size: '5GiB'
+        disk: /dev/sdj2
+    # TODO: Support for real disks
+    # disk_type: !mux
+    #    type: 'disk'
+    #    disk_test: /dev/sdx1
+    #    disk_scratch: /dev/sdx2


### PR DESCRIPTION
Enables tests to be run on loop device
Runs all tests for given file system
(or)
Runs specific tests for given file system if range is provided.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>