### PR TITLE
Fix suse distro name for tests

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -47,7 +47,7 @@ class Bonding(Test):
             depends.append("openssh-client")
         if detected_distro.name in ["redhat", "fedora", "centos"]:
             depends.append("openssh-clients")
-        if detected_distro.name == "Suse":
+        if detected_distro.name == "SuSE":
             depends.append("openssh")
         for pkg in depends:
             if not sm.check_installed(pkg) and not sm.install(pkg):

--- a/io/net/infiniband/ib_bw_perf.py
+++ b/io/net/infiniband/ib_bw_perf.py
@@ -70,7 +70,7 @@ class Bandwidth_Perf(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/ib_latency_perf.py
+++ b/io/net/infiniband/ib_latency_perf.py
@@ -67,7 +67,7 @@ class Latency_Perf(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -64,7 +64,7 @@ class pingpong(Test):
         elif detected_distro.name in ['redhat', 'fedora']:
             depends.append("libibverbs")
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/ip_over_ib.py
+++ b/io/net/infiniband/ip_over_ib.py
@@ -60,7 +60,7 @@ class ip_over_ib(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/mckey.py
+++ b/io/net/infiniband/mckey.py
@@ -74,7 +74,7 @@ class Mckey(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/ping6.py
+++ b/io/net/infiniband/ping6.py
@@ -82,7 +82,7 @@ class Ping6(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/rping.py
+++ b/io/net/infiniband/rping.py
@@ -74,7 +74,7 @@ class Rping(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/ucmatose.py
+++ b/io/net/infiniband/ucmatose.py
@@ -70,7 +70,7 @@ class Ucmatose(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/io/net/infiniband/udaddy.py
+++ b/io/net/infiniband/udaddy.py
@@ -69,7 +69,7 @@ class Udady(Test):
             cmd = "service ufw stop"
         elif detected_distro.name in ['redhat', 'fedora']:
             cmd = "systemctl stop firewalld"
-        elif detected_distro.name == "Suse":
+        elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"

--- a/perf/rt_tests.py
+++ b/perf/rt_tests.py
@@ -39,7 +39,7 @@ class rt_tests(Test):
         sm = SoftwareManager()
         detected_distro = distro.detect()
         deps = ["gcc", "make"]
-        if detected_distro.name == "Suse":
+        if detected_distro.name == "SuSE":
             deps.append("git-core")
         else:
             deps.append("git")

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -39,7 +39,7 @@ class Valgrind(Test):
         deps = ['gcc', 'make']
         if dist.name == 'Ubuntu':
             deps.extend(['g++'])
-        elif dist.name in ['SuSe', 'redhat', 'fedora', 'centos']:
+        elif dist.name in ['SuSE', 'redhat', 'fedora', 'centos']:
             deps.extend(['gcc-c++'])
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
This patch fixes suse distro name as 'SuSE' in some of the tests

Signed-off-by: Harish <harish@linux.vnet.ibm.com>