### PR TITLE
Fix nvmetest error if no previous nvme installed

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -51,7 +51,8 @@ class NVMeTest(Test):
         archive.extract(tarball, self.srcdir)
         os.chdir("%s/nvme-cli-master" % self.srcdir)
         process.system("./NVME-VERSION-GEN", ignore_status=True)
-        if process.system_output("cat NVME-VERSION-FILE").strip("\n").\
+        if process.system("which nvme", ignore_status=True) != 0 or \
+            process.system_output("cat NVME-VERSION-FILE").strip("\n").\
             split()[-1] != process.system_output("nvme version").\
                 strip("\n").split()[-1]:
             build.make(".")


### PR DESCRIPTION
nvmetest errors out if no nvme-cli is installed previously.
Added a check for it and installing nvme-cli in that case.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>