### PR TITLE
Update ppc64_cpu test with processor generation check.

### DIFF
--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -53,9 +53,11 @@ class PPC64Test(Test):
         self.smt_values = {1: "off"}
         self.key = 0
         self.value = ""
-        self.max_smt_value = 4
-        if cpu.get_cpu_arch().lower() == 'power8':
-            self.max_smt_value = 8
+        self.max_smt_value = 8
+        if cpu.get_cpu_arch().lower() == 'power7':
+            self.max_smt_value = 4
+        if cpu.get_cpu_arch().lower() == 'power6':
+            self.max_smt_value = 2
 
     def equality_check(self, test_name, cmd1, cmd2):
         """


### PR DESCRIPTION
On a POWER6 based system smt level upto 2 is supported, while on a POWER7
based system smt level upto 4 is supported. Depending on the processor
generation some of the smt tests fails.

This patch adds a check for smt level support and limits the runtime values.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>