### PR TITLE
Support to run xfstests with real disk

### DIFF
--- a/fs/xfstests.py.data/README
+++ b/fs/xfstests.py.data/README
@@ -43,5 +43,3 @@ virtual partition depends on the following programs to be available:
      * kpartx
 Make sure you have them or a real spare device to test things.
 """
-TODO:
-1- Replace local.cofig for real disks

--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -11,7 +11,6 @@ setup:
         type: 'loop'
         loop_size: '5GiB'
         disk: /dev/sdj2
-    # TODO: Support for real disks
     # disk_type: !mux
     #    type: 'disk'
     #    disk_test: /dev/sdx1


### PR DESCRIPTION
This patch allows to run xfstests on real disks

Signed-off-by: Harish <harish@linux.vnet.ibm.com>