### PR TITLE
Fixup lsvpd test if slot from sysfs not found

### DIFF
--- a/io/pci/pci_info_lsvpd.py
+++ b/io/pci/pci_info_lsvpd.py
@@ -51,7 +51,9 @@ class PciLsvpdInfo(Test):
                 Slot Match
                 '''
                 if vpd_output.has_key('slot'):
-                    sys_slot = pci.get_slot_from_sysfs(pci_adres).strip('\0')
+                    sys_slot = pci.get_slot_from_sysfs(pci_adres)
+                    if sys_slot:
+                        sys_slot = sys_slot.strip('\0')
                     vpd_slot = vpd_output['slot']
                     self.log.info("Slot from sysfs:%s", sys_slot)
                     self.log.info("Slot from lsvpd:%s", vpd_slot)


### PR DESCRIPTION
Slot from sysfs returns a string.
strip() would fail if the string returned is None.
So, need to check if string exists before strip()

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>