### PR TITLE
Print error log properly

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -119,8 +119,7 @@ class MultipathTest(Test):
         # Print errors
         if msg:
             msg = "Following Tests Failed\n" + msg
-            self.log.debug(msg)
-            self.fail("Some tests failed")
+            self.fail("Some tests failed. Find details below:\n%s", msg)
 
     def tearDown(self):
         """


### PR DESCRIPTION
Printing errors in self.fail, so that it is easier to view.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>