### PR TITLE
Fixing issue in printing error log

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -118,8 +118,7 @@ class MultipathTest(Test):
 
         # Print errors
         if msg:
-            msg = "Following Tests Failed\n" + msg
-            self.fail("Some tests failed. Find details below:\n%s", msg)
+            self.fail("Some tests failed. Find details below:\n%s" % msg)
 
     def tearDown(self):
         """


### PR DESCRIPTION
io/disk/multipath_test: Fixed the syntax error with self.fail()
and removed unwanted messages in error.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>