### PR TITLE
sensors testcase fixups

### DIFF
--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -102,7 +102,8 @@ class Sensors(Test):
             except process.CmdError:
                 self.error(
                     'Starting Service Failed. Make sure module is loaded')
-        det_op = process.run('yes | sudo sensors-detect', shell=True, ignore_status=True).stdout
+        cmd = "yes | sudo sensors-detect"
+        det_op = process.run(cmd, shell=True, ignore_status=True).stdout
         if 'no sensors were detected' in det_op:
             self.skip('No sensors found to test !')
 

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -25,6 +25,7 @@ from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import cpu
 
 # TODO: Add possible errors of sensors command
 ERRORS = ['I/O error']
@@ -51,7 +52,10 @@ class Sensors(Test):
     def setUp(self):
         """
         Check pre-requisites before running sensors command
+        Testcase should be executed only on bare-metal environment.
         """
+        if 'platform\t: PowerNV\n' not in cpu._get_cpu_info():
+            self.skip('sensors test is applicable to bare-metal environment.')
         s_mg = SoftwareManager()
         d_distro = distro.detect()
         if d_distro.name == "Ubuntu":


### PR DESCRIPTION
Fix sensors test case to run only on bare-metal and a minor pep8 compliance fixup.

0fbc116: Add platform check for sensors testcase.
b21c214: Fix pep8 warning for sensors

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>