### PR TITLE
Added code to Flush All multipath in multipath_test.py

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -21,10 +21,11 @@ Needs to be run as root.
 
 import os
 import shutil
+import time
 from pprint import pprint
 from avocado import Test
 from avocado import main
-from avocado.utils import distro
+from avocado.utils import distro, process
 from avocado.utils import multipath
 from avocado.utils import service
 from avocado.utils.software_manager import SoftwareManager
@@ -128,6 +129,10 @@ class MultipathTest(Test):
         if os.path.isfile(self.mpath_file):
             shutil.copyfile("%s.bkp" % self.mpath_file, self.mpath_file)
         self.mpath_svc.restart()
+
+        # Need to wait for some time to make sure multipaths are loaded.
+        time.sleep(5)
+        process.run('multipath -F')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
multipaths were not stopped or flushed after the test run complete.
so added multipath flush in tearDown method.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>