### PR TITLE
Fixed path flush error in multupath_test

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -117,6 +117,9 @@ class MultipathTest(Test):
                 if disk in multipath.get_paths(path_dic["wwid"]):
                     msg += "Blacklist of %s fails\n" % disk
 
+        # Need to give time for the multipath service to get stable
+        time.sleep(5)
+
         # Print errors
         if msg:
             self.fail("Some tests failed. Find details below:\n%s" % msg)


### PR DESCRIPTION
When more than one multipath device was present, needed some
time after services are stable for flushing the paths. So, added
a sleep.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>