### PR TITLE
Fix sensors test to run on x86

### DIFF
--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -60,6 +60,10 @@ class Sensors(Test):
             if not s_mg.check_installed("lm-sensors") and not s_mg.install(
                     "lm-sensors"):
                 self.error('Need sensors to run the test')
+        elif d_distro.name == "SuSE":
+            if not s_mg.check_installed("sensors") and not s_mg.install(
+                    "sensors"):
+                self.skip('Need sensors to run the test')
         else:
             if not s_mg.check_installed("lm_sensors") and not s_mg.install(
                     "lm_sensors"):

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -59,7 +59,7 @@ class Sensors(Test):
         if d_distro.name == "Ubuntu":
             if not s_mg.check_installed("lm-sensors") and not s_mg.install(
                     "lm-sensors"):
-                self.error('Need sensors to run the test')
+                self.skip('Need sensors to run the test')
         elif d_distro.name == "SuSE":
             if not s_mg.check_installed("sensors") and not s_mg.install(
                     "sensors"):
@@ -67,7 +67,7 @@ class Sensors(Test):
         else:
             if not s_mg.check_installed("lm_sensors") and not s_mg.install(
                     "lm_sensors"):
-                self.error('Need sensors to run the test')
+                self.skip('Need sensors to run the test')
         if d_distro.arch in ["ppc64", "ppc64le"]:
             if 'platform\t: PowerNV\n' not in cpu._get_cpu_info():
                 self.skip('sensors test is applicable to bare-metal environment.')

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -54,8 +54,6 @@ class Sensors(Test):
         Check pre-requisites before running sensors command
         Testcase should be executed only on bare-metal environment.
         """
-        if 'platform\t: PowerNV\n' not in cpu._get_cpu_info():
-            self.skip('sensors test is applicable to bare-metal environment.')
         s_mg = SoftwareManager()
         d_distro = distro.detect()
         if d_distro.name == "Ubuntu":
@@ -67,6 +65,8 @@ class Sensors(Test):
                     "lm_sensors"):
                 self.error('Need sensors to run the test')
         if d_distro.arch in ["ppc64", "ppc64le"]:
+            if 'platform\t: PowerNV\n' not in cpu._get_cpu_info():
+                self.skip('sensors test is applicable to bare-metal environment.')
             kernel_ver = platform.uname()[2]
             l_config = "CONFIG_SENSORS_IBMPOWERNV"
             config_op = process.system_output(


### PR DESCRIPTION
1. Platform check specific to power arch 
2. Fixed sensors package name for Suse
3. Skip test if pre-requiste fails

Signed-off-by: Harish <harish@linux.vnet.ibm.com>