### PR TITLE
Fix will provide support to execute pmqa tests on bare metal environme…

### DIFF
--- a/cpu/pmqa.py
+++ b/cpu/pmqa.py
@@ -38,7 +38,8 @@ class Pmqa(Test):
         Source:
         git://git.linaro.org/power/pm-qa.git
         '''
-
+        if not os.path.exists('/sys/devices/system/cpu/cpu0/cpufreq'):
+            self.cancel('sysfs directory for cpufreq is unavailable.')
         # Check for basic utilities
         smm = SoftwareManager()
         if not smm.check_installed("gcc") and not smm.install("gcc"):


### PR DESCRIPTION
Fix will provide support to excute pmqa tests on bare metal environment only.

pmqa tests run sanity tests to check /sys/devices/system/cpu0/cpufreq path exists.
All frequency operations are supported on bare metal, hence included a check,
which verifies the path exists and cancel the test if path does not exist.

Signed-off-by: Shriya <shriyak@linux.vnet.ibm.com>