### PR TITLE
Added ignore_status in user creation.

### DIFF
--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -40,9 +40,10 @@ class Trinity(Test):
         """
         Add not root user
         """
-        process.run('groupadd trinity', sudo=True)
+        process.run('groupadd trinity', sudo=True, ignore_status=True)
         process.run(
-            'useradd -g trinity  -m -d /home/trinity  trinity', sudo=True)
+            'useradd -g trinity  -m -d /home/trinity  trinity',
+            ignore_status=True, sudo=True)
         process.run('usermod -a -G trinity  trinity', sudo=True)
 
         smm = SoftwareManager()


### PR DESCRIPTION
The test failed already if a group and username trinity already exists.
So added ignore_status in group and user creation step.

Signed-off-by: Santhosh G <santhog4@linux.vnet.ibm.com>