### PR TITLE
Skip test if disk space is insufficient

### DIFF
--- a/generic/interbench.py
+++ b/generic/interbench.py
@@ -24,7 +24,7 @@ from avocado import Test
 from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
-from avocado.utils import build
+from avocado.utils import build, disk, memory
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -48,6 +48,10 @@ class Interbench(Test):
             if (not sm_manager.check_installed(pkg) and not
                     sm_manager.install(pkg)):
                 self.cancel("%s is needed for the test to be run" % pkg)
+
+        disk_free_mb = (disk.freespace(self.teststmpdir) / 1024) / 1024
+        if memory.memtotal()/1024 > disk_free_mb:
+            self.cancel('Disk space is less than total memory. Skipping test')
 
         tarball = self.fetch_asset('http://slackware.cs.utah.edu/pub/kernel'
                                    '.org/pub/linux/kernel/people/ck/apps/'


### PR DESCRIPTION
Test skips if disk space is less than total memory of the system

Signed-off-by: Harish <harish@linux.vnet.ibm.com>