### PR TITLE
Fix common zip names for tests

### DIFF
--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -55,7 +55,7 @@ class HtxTest(Test):
                 self.skip("Can not install %s" % pkg)
 
         url = "https://github.com/open-power/HTX/archive/master.zip"
-        tarball = self.fetch_asset("master.zip", locations=[url], expire='7d')
+        tarball = self.fetch_asset("htx.zip", locations=[url], expire='7d')
         archive.extract(tarball, self.teststmpdir)
         htx_path = os.path.join(self.teststmpdir, "HTX-master")
         os.chdir(htx_path)

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -61,7 +61,7 @@ class kselftest(Test):
                     '%s is needed for the test to be run !!' % (package))
 
         location = ["https://github.com/torvalds/linux/archive/master.zip"]
-        tarball = self.fetch_asset("master.zip", locations=location,
+        tarball = self.fetch_asset("kselftest.zip", locations=location,
                                    expire='1d')
         archive.extract(tarball, self.srcdir)
         self.buldir = os.path.join(self.srcdir, 'linux-master')


### PR DESCRIPTION
As zip names are common in cache dir, tests fail with expected files. Provided unique names for zip files

Signed-off-by: Harish <harish@linux.vnet.ibm.com>