### PR TITLE
Check for trinity group/user before creation

### DIFF
--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -40,9 +40,11 @@ class Trinity(Test):
         """
         Add not root user
         """
-        process.run('groupadd trinity', sudo=True)
-        process.run(
-            'useradd -g trinity  -m -d /home/trinity  trinity', sudo=True)
+        if process.system('getent group trinity', ignore_status=True):
+            process.run('groupadd trinity', sudo=True)
+        if process.system('getent passwd trinity', ignore_status=True):
+            process.run(
+                'useradd -g trinity  -m -d /home/trinity  trinity', sudo=True)
         process.run('usermod -a -G trinity  trinity', sudo=True)
 
         smm = SoftwareManager()


### PR DESCRIPTION
Used getent command to check whether the user and group
'trinity' exists before creating it.

Signed-off-by: Santhosh G <santhog4@linux.vnet.ibm.com>