### PR TITLE
Changed the default mountpoint to teststmpdir

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -48,7 +48,7 @@ class FioTest(Test):
         default_url = "http://brick.kernel.dk/snaps/fio-2.1.10.tar.gz"
         url = self.params.get('fio_tool_url', default=default_url)
         self.disk = self.params.get('disk', default=None)
-        self.dir = self.params.get('dir', default=self.srcdir)
+        self.dir = self.params.get('dir', default=self.teststmpdir)
         fstype = self.params.get('fs', default='ext4')
         tarball = self.fetch_asset(url)
         archive.extract(tarball, self.srcdir)

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -62,7 +62,7 @@ class fs_mark(Test):
         # Just provide a sample run parameters
         num_files = self.params.get('num_files', default='1024')
         size = self.params.get('size', default='1000')
-        self.dir = self.params.get('dir', default='/var/tmp')
+        self.dir = self.params.get('dir', default=self.teststmpdir)
 
         self.part_obj = Partition(self.disk, mountpoint=self.dir)
         self.log.info("Test will run on %s", self.dir)

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -43,7 +43,7 @@ class Ltp_Fs(Test):
             if not sm.check_installed(package) and not sm.install(package):
                 self.error("%s is needed for the test to be run", package)
         self.disk = self.params.get('disk', default=None)
-        self.mount_point = self.params.get('dir', default=self.srcdir)
+        self.mount_point = self.params.get('dir', default=self.teststmpdir)
         self.script = self.params.get('script')
         fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -64,7 +64,7 @@ class Tiobench(Test):
         :params num_runs: This number specifies over how many runs
                           each test should be averaged.
         """
-        self.target = self.params.get('dir', default=self.workdir)
+        self.target = self.params.get('dir', default=self.teststmpdir)
         self.disk = self.params.get('disk', default=None)
         fstype = self.params.get('fs', default='ext4')
         blocks = self.params.get('blocks', default=4096)


### PR DESCRIPTION
Some tests were using self.srcdir for multiple purposes.
Changed the tests which mount a disk as well as download a
tarball, to use default mountpoint as self.teststmpdir.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>