### PR TITLE
Script to run IO parallely on multiple interfaces

### DIFF
--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2017 IBM
+# Author: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>
+
+import netifaces
+from avocado import main
+from avocado import Test
+from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import process
+
+
+class MultiportStress(Test):
+    '''
+    To perform IO stress on multiple ports on a NIC adapter
+    '''
+
+    def setUp(self):
+        '''
+        To check and install dependencies for the test
+        '''
+        self.host_interfaces = self.params.get("host_interfaces",
+                                               default="").split(",")
+        if not self.host_interfaces:
+            self.skip("user should specify host interfaces")
+        smm = SoftwareManager()
+        if not smm.check_installed("iputils-ping") and not\
+                smm.install("iputils-ping"):
+            self.skip("iputils-ping package is need to test")
+        self.peer_ips = self.params.get("peer_ips",
+                                        default="").split(",")
+        interfaces = netifaces.interfaces()
+        for self.host_interface in self.host_interfaces:
+            if self.host_interface not in interfaces:
+                self.skip("interface is not available")
+        self.count = self.params.get("count", default="1000")
+
+    def test_multiport_stress(self):
+        '''
+        Ping to multiple peers parallely
+        '''
+        parallel_procs = []
+        for host, peer in map(None, self.host_interfaces, self.peer_ips):
+            self.log.info('Starting Ping test')
+            cmd = "ping -I %s %s -c %s" % (host, peer, self.count)
+            obj = process.SubProcess(cmd, verbose=False, shell=True)
+            obj.start()
+            parallel_procs.append(obj)
+        self.log.info('Wait for background processes to finish'
+                      ' before proceeding')
+        for proc in parallel_procs:
+            proc.wait()
+        errors = []
+        for proc in parallel_procs:
+            out_buf = proc.get_stdout()
+            out_buf += proc.get_stderr()
+            for val in out_buf.splitlines():
+                if 'packet loss' in val and ', 0% packet loss,' not in val:
+                    errors.append(out_buf)
+                    break
+        if errors:
+            self.fail("\n".join(errors))
+
+
+if __name__ == "__main__":
+    main()

--- a/io/net/multiport_stress.py.data/README.txt
+++ b/io/net/multiport_stress.py.data/README.txt
@@ -1,0 +1,7 @@
+This is a test to run multiport stress on the NIC adapter.
+To begin with, the test runs a Ping test on multiple interfaces parallely
+
+The yaml files has 3 parameters:
+    host_interfaces takes multiple NIC interface names separated by comma.
+    peer_ips takes multiple peer ip's separated by comma.
+    count is the number of packets to be transferred. Default value is 1000.

--- a/io/net/multiport_stress.py.data/multiport_stress.yaml
+++ b/io/net/multiport_stress.py.data/multiport_stress.yaml
@@ -1,0 +1,3 @@
+host_interfaces: "enP4p1s0f1,enP4p1s0f2"
+peer_ips: "100.10.10.12,200.20.20.22"
+count: "1100" 


### PR DESCRIPTION
Script will run a ping test on multiple interfaces parallely
with user specified number of packets. Default is 1000

Signed-off-by: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>