### PR TITLE
Module_unload_load can run only for IO drivers too

### DIFF
--- a/io/driver/module_unload_load.sh
+++ b/io/driver/module_unload_load.sh
@@ -16,7 +16,11 @@
 
 CONFIG_FILE="$AVOCADO_TEST_DATADIR"/config
 BUILT_IN_DRIVERS=`cat /lib/modules/$(uname -r)/modules.builtin |awk -F"/" '{print $NF}'|sed 's/\.ko//g'`
-DRIVERS=`find /lib/modules/$(uname -r)/ -name \*.ko | awk -F"/" '{print $NF}'|sed 's/\.ko//g'`
+if [[ $ONLY_IO == True ]]; then
+    DRIVERS=`lspci -k | grep -iw "Kernel driver in use" | cut -d ':' -f2 | sort | uniq`
+else
+    DRIVERS=`find /lib/modules/$(uname -r)/ -name \*.ko | awk -F"/" '{print $NF}'|sed 's/\.ko//g'`
+fi
 ERR=""
 PASS=""
 [[ -z $ITERATIONS ]] && ITERATIONS=10

--- a/io/driver/module_unload_load.sh.data/module_unload_load.yaml
+++ b/io/driver/module_unload_load.sh.data/module_unload_load.yaml
@@ -1,1 +1,2 @@
 ITERATIONS: 10
+ONLY_IO: True


### PR DESCRIPTION
module_unload_load.sh ran for all modules in the system.
Now, added a parameter in yaml file to specify it to run only for
IO drivers for the PCI devices in the system.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>