### PR TITLE
Fixed exfiotest output dir parameter

### DIFF
--- a/io/disk/ssd/ezfiotest.py
+++ b/io/disk/ssd/ezfiotest.py
@@ -63,7 +63,7 @@ class EzfioTest(Test):
         Performs ezfio test on the block device'.
         """
         os.chdir(self.ezfio_path)
-        cmd = './ezfio.py -d %s -o %s -u %s --yes' \
+        cmd = './ezfio.py -d %s -o "%s" -u %s --yes' \
             % (self.disk, self.outputdir, self.utilization)
         process.run(cmd, shell=True)
 


### PR DESCRIPTION
Output dir was having ';'.
-o option was taking the directory without "", and thus was
parsing them as 2 commands.
Fixed it.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>