### PR TITLE
Remove unwanted image files created by fiotest

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -72,18 +72,22 @@ class FioTest(Test):
         """
         self.log.info("Test will run on %s", self.dir)
         fio_job = self.params.get('fio_job', default='fio-simple.job')
-        cmd = '%s/fio %s %s' % (self.srcdir,
-                                os.path.join(self.datadir, fio_job), self.dir)
+        self.fio_file = 'fiotest-image'
+        cmd = '%s/fio %s %s --filename=%s' % (self.srcdir,
+                                              os.path.join(
+                                                  self.datadir, fio_job),
+                                              self.dir, self.fio_file)
         process.system(cmd)
 
     def tearDown(self):
-
         '''
         Cleanup of disk used to perform this test
         '''
         if self.disk is not None:
             self.log.info("Unmounting directory %s", self.dir)
             self.part_obj.unmount()
+        if os.path.exists(self.fio_file):
+            os.remove(self.fio_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tests create unwanted files as file-1.0.0.. and does not delete after test completes. Using same file for all variants and deleting at end.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>