### PR TITLE
Provide file name for master zip files

### DIFF
--- a/io/net/infiniband/ip_over_ib.py
+++ b/io/net/infiniband/ip_over_ib.py
@@ -88,8 +88,9 @@ class ip_over_ib(Test):
         build.make(self.neperf)
         self.perf = os.path.join(self.neperf, 'src')
         time.sleep(5)
-        tarball = self.fetch_asset('https://github.com/esnet/'
-                                   'iperf/archive/master.zip', expire='7d')
+        tarball = self.fetch_asset('iperf.zip', locations=[
+                                   'https://github.com/esnet/'
+                                   'iperf/archive/master.zip'], expire='7d')
         archive.extract(tarball, self.iper)
         self.ipe = os.path.join(self.iper, 'iperf-master')
         tmp = "scp -r %s root@%s:" % (self.ipe, self.PEER_IP)

--- a/memory/memtester.py
+++ b/memory/memtester.py
@@ -41,9 +41,10 @@ class Memtester(Test):
         for pkg in ['gcc', 'make']:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.skip('%s is needed for the test to be run' % pkg)
-        tarball = self.fetch_asset(
-            'https://github.com/jnavila/memtester/archive/master.zip',
-            expire='7d')
+        tarball = self.fetch_asset('memtester.zip', locations=[
+                                   'https://github.com/jnavila/'
+                                   'memtester/archive/master.zip'],
+                                   expire='7d')
         archive.extract(tarball, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'memtester-master')
         os.chdir(self.srcdir)

--- a/memory/stress-ng.py
+++ b/memory/stress-ng.py
@@ -59,8 +59,10 @@ class stressng(Test):
                     '%s is needed, get the source and build' % package)
 
         if 'Ubuntu' not in detected_distro.name:
-            tarball = self.fetch_asset(
-                'https://github.com/ColinIanKing/stress-ng/archive/master.zip', expire='7d')
+            tarball = self.fetch_asset('stressng.zip', locations=[
+                                       'https://github.com/ColinIanKing/'
+                                       'stress-ng/archive/master.zip'],
+                                       expire='7d')
             archive.extract(tarball, self.srcdir)
             self.srcdir = os.path.join(self.srcdir, 'stress-ng-master')
             os.chdir(self.srcdir)

--- a/perf/perf_events_test.py
+++ b/perf/perf_events_test.py
@@ -34,7 +34,7 @@ class Perf_subsystem(Test):
         '''
         Install the packages
         '''
-        #Check for basic utilities
+        # Check for basic utilities
         smm = SoftwareManager()
         detected_distro = distro.detect()
         kernel_ver = platform.uname()[2]
@@ -56,9 +56,10 @@ class Perf_subsystem(Test):
         Execute the perf tests
         Source : https://github.com/deater/perf_event_tests
         '''
-        tarball = self.fetch_asset('https://github.com/deater/'
+        tarball = self.fetch_asset('perf-event.zip', locations=[
+                                   'https://github.com/deater/'
                                    'perf_event_tests/archive/'
-                                   'master.zip', expire='7d')
+                                   'master.zip'], expire='7d')
         archive.extract(tarball, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'perf_event_tests-master')
         build.make(self.srcdir)

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -63,8 +63,9 @@ class GCC(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.skip(
                     "Failed to install %s required for this test." % package)
-        tarball = self.fetch_asset(
-            "https://github.com/gcc-mirror/gcc/archive/master.zip", expire='7d')
+        tarball = self.fetch_asset('gcc.zip', locations=[
+                                   'https://github.com/gcc-mirror/gcc/archive'
+                                   '/master.zip'], expire='7d')
         archive.extract(tarball, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'gcc-master')
 

--- a/toolchain/libvecpf.py
+++ b/toolchain/libvecpf.py
@@ -44,9 +44,9 @@ class Libvecpf(Test):
         for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.error('%s is needed for the test to be run' % package)
-        tarball = self.fetch_asset(
-            "https://github.com/Libvecpf/libvecpf/archive/master.zip",
-            expire='7d')
+        tarball = self.fetch_asset('libvecpf.zip', locations=[
+                                   'https://github.com/Libvecpf/libvecpf'
+                                   '/archive/master.zip'], expire='7d')
         archive.extract(tarball, self.srcdir)
         self.srcdir = os.path.join(self.srcdir, 'libvecpf-master')
 


### PR DESCRIPTION
To avoid clash of zip names in cache dir, unique zip names are added for missed tests.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>