### PR TITLE
Use root space by default to create loop device

### DIFF
--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -1,6 +1,5 @@
 setup:
     skip_dangerous: True
-    fs: 'ext4'
     scratch_mnt: '/mnt/scratch'
     test_mnt: '/mnt/test'
     disk_mnt: '/mnt/loop-device'
@@ -9,8 +8,15 @@ setup:
     # Run with either loop_type (or) disk_type
     loop_type: !mux
         type: 'loop'
-        loop_size: '5GiB'
-        disk: /dev/sdj2
+        loop_size: '7GiB'
+        # Option to provide disk for loop device creation,
+        # Uses '/' by default for file creation
+        disk:
+    fs_type: !mux
+        fs_ext4:
+            fs: 'ext4'
+        fs_xfs:
+            fs: 'xfs'
     # disk_type: !mux
     #    type: 'disk'
     #    disk_test: /dev/sdx1


### PR DESCRIPTION
Test now runs with loopdevice creation under root if base disk is not provided.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>