### PR TITLE
Usage of srcdir and teststmpdir in a better way

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -49,7 +49,7 @@ class Bonnie(Test):
 
         self.disk = self.params.get('disk', default=None)
         fstype = self.params.get('fs', default='ext4')
-        self.scratch_dir = self.params.get('dir', default=self.teststmpdir)
+        self.scratch_dir = self.params.get('dir', default=self.srcdir)
         self.uid_to_use = self.params.get('uid-to-use',
                                           default=getpass.getuser())
         self.number_to_stat = self.params.get('number-to-stat', default=2048)
@@ -57,12 +57,12 @@ class Bonnie(Test):
 
         tarball = self.fetch_asset('http://www.coker.com.au/bonnie++/'
                                    'bonnie++-1.03e.tgz', expire='7d')
-        archive.extract(tarball, self.srcdir)
-        self.srcdir = os.path.join(self.srcdir,
+        archive.extract(tarball, self.teststmpdir)
+        self.source = os.path.join(self.teststmpdir,
                                    os.path.basename(tarball.split('.tgz')[0]))
-        os.chdir(self.srcdir)
+        os.chdir(self.source)
         process.run('./configure')
-        build.make(self.srcdir)
+        build.make(self.source)
 
         if self.disk is not None:
             self.part_obj = Partition(self.disk, mountpoint=self.scratch_dir)
@@ -87,7 +87,7 @@ class Bonnie(Test):
         args.append('-s %s' % self.data_size)
         args.append('-u %s' % self.uid_to_use)
 
-        cmd = ('%s/bonnie++ %s' % (self.srcdir, " ".join(args)))
+        cmd = ('%s/bonnie++ %s' % (self.source, " ".join(args)))
         if process.system(cmd, shell=True, ignore_status=True):
             self.fail("test failed")
 

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -48,13 +48,13 @@ class FioTest(Test):
         default_url = "http://brick.kernel.dk/snaps/fio-2.1.10.tar.gz"
         url = self.params.get('fio_tool_url', default=default_url)
         self.disk = self.params.get('disk', default=None)
-        self.dir = self.params.get('dir', default=self.teststmpdir)
+        self.dir = self.params.get('dir', default=self.srcdir)
         fstype = self.params.get('fs', default='ext4')
         tarball = self.fetch_asset(url)
-        archive.extract(tarball, self.srcdir)
+        archive.extract(tarball, self.teststmpdir)
         fio_version = os.path.basename(tarball.split('.tar.')[0])
-        self.srcdir = os.path.join(self.srcdir, fio_version)
-        build.make(self.srcdir)
+        self.sourcedir = os.path.join(self.teststmpdir, fio_version)
+        build.make(self.sourcedir)
 
         if self.disk is not None:
             self.part_obj = Partition(self.disk, mountpoint=self.dir)
@@ -73,7 +73,7 @@ class FioTest(Test):
         self.log.info("Test will run on %s", self.dir)
         fio_job = self.params.get('fio_job', default='fio-simple.job')
         self.fio_file = 'fiotest-image'
-        cmd = '%s/fio %s %s --filename=%s' % (self.srcdir,
+        cmd = '%s/fio %s %s --filename=%s' % (self.sourcedir,
                                               os.path.join(
                                                   self.datadir, fio_job),
                                               self.dir, self.fio_file)

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -43,7 +43,7 @@ class Ltp_Fs(Test):
             if not sm.check_installed(package) and not sm.install(package):
                 self.error("%s is needed for the test to be run", package)
         self.disk = self.params.get('disk', default=None)
-        self.mount_point = self.params.get('dir', default=self.teststmpdir)
+        self.mount_point = self.params.get('dir', default=self.srcdir)
         self.script = self.params.get('script')
         fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
@@ -61,8 +61,8 @@ class Ltp_Fs(Test):
         url += "archive/master.zip"
         tarball = self.fetch_asset("ltp-master.zip",
                                    locations=[url], expire='7d')
-        archive.extract(tarball, self.srcdir)
-        ltp_dir = os.path.join(self.srcdir, "ltp-master")
+        archive.extract(tarball, self.teststmpdir)
+        ltp_dir = os.path.join(self.teststmpdir, "ltp-master")
         os.chdir(ltp_dir)
         build.make(ltp_dir, extra_args='autotools')
         ltpbin_dir = os.path.join(ltp_dir, 'bin')
@@ -83,7 +83,7 @@ class Ltp_Fs(Test):
             self.args += (" -q -p -l %s -C %s -d %s"
                           % (logfile, failcmdfile, self.mount_point))
             self.log.info("Args = %s", self.args)
-            ltpbin_dir = os.path.join(self.srcdir, "ltp-master", 'bin')
+            ltpbin_dir = os.path.join(self.teststmpdir, "ltp-master", 'bin')
             cmd = '%s %s' % (os.path.join(ltpbin_dir, self.script), self.args)
             result = process.run(cmd, ignore_status=True)
             # Walk the stdout and try detect failed tests from lines

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -27,7 +27,6 @@ using a given policy.
 
 For details about the policy see README.
 """
-import os
 import avocado
 from avocado import Test
 from avocado import main
@@ -82,8 +81,7 @@ class Lvsetup(Test):
         self.lv_name = lv_name
         if lv_utils.lv_check(vg_name, lv_snapshot_name):
             self.skip('Snapshot %s already exists' % lv_snapshot_name)
-        self.mount_loc = 'avocado_%s' % self.fs_name
-        os.mkdir(self.mount_loc)
+        self.mount_loc = self.srcdir
         self.lv_snapshot_name = lv_snapshot_name
 
     @avocado.fail_on(lv_utils.LVException)
@@ -121,7 +119,6 @@ class Lvsetup(Test):
                 errs.append("Fail to cleanup ramdisk %s: %s" % (ramdisk, exc))
         if errs:
             self.error("\n".join(errs))
-        os.removedirs(self.mount_loc)
 
 
 if __name__ == "__main__":

--- a/io/disk/ssd/ezfiotest.py
+++ b/io/disk/ssd/ezfiotest.py
@@ -48,13 +48,13 @@ class EzfioTest(Test):
         cmd = 'ls %s' % self.disk
         if process.system(cmd, ignore_status=True) is not 0:
             self.skip("%s does not exist" % self.disk)
-        fio_path = os.path.join(self.srcdir, 'fio')
+        fio_path = os.path.join(self.teststmpdir, 'fio')
         fio_link = 'https://github.com/axboe/fio.git'
         git.get_repo(fio_link, destination_dir=fio_path)
         build.make(fio_path, make='./configure')
         build.make(fio_path)
         build.make(fio_path, extra_args='install')
-        self.ezfio_path = os.path.join(self.srcdir, 'ezfio')
+        self.ezfio_path = os.path.join(self.teststmpcdir, 'ezfio')
         ezfio_link = 'https://github.com/earlephilhower/ezfio.git'
         git.get_repo(ezfio_link, destination_dir=self.ezfio_path)
         self.utilization = self.params.get('utilization', default='100')

--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -48,8 +48,8 @@ class NVMeTest(Test):
                      "master.zip"]
         tarball = self.fetch_asset("nvme-cli.zip", locations=locations,
                                    expire='15d')
-        archive.extract(tarball, self.srcdir)
-        os.chdir("%s/nvme-cli-master" % self.srcdir)
+        archive.extract(tarball, self.teststmpdir)
+        os.chdir("%s/nvme-cli-master" % self.teststmpdir)
         process.system("./NVME-VERSION-GEN", ignore_status=True)
         if process.system("which nvme", ignore_status=True) != 0 or \
             process.system_output("cat NVME-VERSION-FILE").strip("\n").\

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -64,7 +64,7 @@ class Tiobench(Test):
         :params num_runs: This number specifies over how many runs
                           each test should be averaged.
         """
-        self.target = self.params.get('dir', default=self.teststmpdir)
+        self.target = self.params.get('dir', default=self.srcdirdir)
         self.disk = self.params.get('disk', default=None)
         fstype = self.params.get('fs', default='ext4')
         blocks = self.params.get('blocks', default=4096)

--- a/io/net/infiniband/ip_over_ib.py
+++ b/io/net/infiniband/ip_over_ib.py
@@ -53,8 +53,8 @@ class ip_over_ib(Test):
         self.to = self.params.get("timeout", default="600")
         self.IPERF_RUN = self.params.get("IPERF_RUN", default="0")
         self.NETSERVER_RUN = self.params.get("NETSERVER_RUN", default="0")
-        self.iper = os.path.join(self.srcdir, 'iperf')
-        self.netperf = os.path.join(self.srcdir, 'netperf')
+        self.iper = os.path.join(self.teststmpdir, 'iperf')
+        self.netperf = os.path.join(self.teststmpdir, 'netperf')
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -64,7 +64,7 @@ class Netperf(Test):
         self.peer_user = self.params.get("peer_user_name", default="root")
         self.timeout = self.params.get("timeout", default="600")
         self.netperf_run = self.params.get("NETSERVER_RUN", default="0")
-        self.netperf = os.path.join(self.srcdir, 'netperf')
+        self.netperf = os.path.join(self.teststmpdir, 'netperf')
         tarball = self.fetch_asset('ftp://ftp.netperf.org/netperf/'
                                    'netperf-2.7.0.tar.bz2', expire='7d')
         archive.extract(tarball, self.netperf)


### PR DESCRIPTION
teststmpdir is common for all variants of a test. So, it is the
ideal location to extract repos / tar-balls, for reuse by other
variants of the test.
So, changed the usage of some IO tests accordingly.

This is in line with the discussion at https://github.com/avocado-framework/avocado/issues/1924

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>