### PR TITLE
Fix for btrfs package issue for Ubuntu distribution

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -28,8 +28,9 @@ from avocado import Test
 from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils.partition import Partition
+from avocado.utils.software_manager import SoftwareManager
 
 
 class Bonnie(Test):
@@ -46,6 +47,12 @@ class Bonnie(Test):
         Source:
          http://www.coker.com.au/bonnie++/experimental/bonnie++-1.03e.tgz
         """
+
+        smm = SoftwareManager()
+        if distro.detect().name == 'Ubuntu':
+            if not smm.check_installed("btrfs-tools") and not \
+                    smm.install("btrfs-tools"):
+                self.skip('btrfs-tools is needed for the test to be run')
 
         self.disk = self.params.get('disk', default=None)
         fstype = self.params.get('fs', default='ext4')

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -25,8 +25,9 @@ from avocado import Test
 from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils.partition import Partition
+from avocado.utils.software_manager import SoftwareManager
 
 
 class FioTest(Test):
@@ -45,6 +46,12 @@ class FioTest(Test):
         """
         Build 'fio'.
         """
+        if distro.detect().name == 'Ubuntu':
+            smm = SoftwareManager()
+            if not smm.check_installed("btrfs-tools") and not \
+                    smm.install("btrfs-tools"):
+                self.skip("btrfs-tools is needed for the test to be run")
+
         default_url = "http://brick.kernel.dk/snaps/fio-2.1.10.tar.gz"
         url = self.params.get('fio_tool_url', default=default_url)
         self.disk = self.params.get('disk', default=None)

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -29,7 +29,7 @@ from avocado import Test
 from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.partition import Partition
 
@@ -44,9 +44,13 @@ class Tiobench(Test):
         Source:
         https://github.com/mkuoppal/tiobench.git
         """
-        s_mngr = SoftwareManager()
-        if not s_mngr.check_installed("gcc") and not s_mngr.install("gcc"):
-            self.error('Gcc is needed for the test to be run')
+        smm = SoftwareManager()
+        if distro.detect().name == 'Ubuntu':
+            if not smm.check_installed("btrfs-tools") and not \
+                    smm.install("btrfs-tools"):
+                self.skip('btrfs-tools is needed for the test to be run')
+        if not smm.check_installed("gcc") and not smm.install("gcc"):
+            self.skip('Gcc is needed for the test to be run')
         locations = ["https://github.com/mkuoppal/tiobench/archive/master.zip"]
         tarball = self.fetch_asset("tiobench.zip", locations=locations)
         archive.extract(tarball, self.srcdir)
@@ -64,7 +68,7 @@ class Tiobench(Test):
         :params num_runs: This number specifies over how many runs
                           each test should be averaged.
         """
-        self.target = self.params.get('dir', default=self.srcdirdir)
+        self.target = self.params.get('dir', default=self.srcdir)
         self.disk = self.params.get('disk', default=None)
         fstype = self.params.get('fs', default='ext4')
         blocks = self.params.get('blocks', default=4096)


### PR DESCRIPTION
The package for btrfs file system is different in ubuntu. hence it
was failing while running for btrfs file system. added the code to
fix the same issue. now it is working fine.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>