### PR TITLE
sleep time is set in the utils itself, so removing sleep here

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -121,9 +121,6 @@ class MultipathTest(Test):
                 if disk in multipath.get_paths(path_dic["wwid"]):
                     msg += "Blacklist of %s fails\n" % disk
 
-        # Need to give time for the multipath service to get stable
-        time.sleep(5)
-
         # Print errors
         if msg:
             self.fail("Some tests failed. Find details below:\n%s" % msg)


### PR DESCRIPTION
utility is taking care of waiting time after the service is
started. hence no need here.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>