### PR TITLE
Fix for btrfs package issue for Ubuntu distribution

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -28,8 +28,9 @@ from avocado import Test
 from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils.partition import Partition
+from avocado.utils.software_manager import SoftwareManager
 
 
 class Bonnie(Test):
@@ -46,9 +47,15 @@ class Bonnie(Test):
         Source:
          http://www.coker.com.au/bonnie++/experimental/bonnie++-1.03e.tgz
         """
+        fstype = self.params.get('fs', default='ext4')
+        smm = SoftwareManager()
+        if fstype == 'btrfs':
+            if distro.detect().name == 'Ubuntu':
+                if not smm.check_installed("btrfs-tools") and not \
+                        smm.install("btrfs-tools"):
+                    self.skip('btrfs-tools is needed for the test to be run')
 
         self.disk = self.params.get('disk', default=None)
-        fstype = self.params.get('fs', default='ext4')
         self.scratch_dir = self.params.get('dir', default=self.srcdir)
         self.uid_to_use = self.params.get('uid-to-use',
                                           default=getpass.getuser())

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -25,8 +25,9 @@ from avocado import Test
 from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils.partition import Partition
+from avocado.utils.software_manager import SoftwareManager
 
 
 class FioTest(Test):
@@ -55,6 +56,13 @@ class FioTest(Test):
         fio_version = os.path.basename(tarball.split('.tar.')[0])
         self.sourcedir = os.path.join(self.teststmpdir, fio_version)
         build.make(self.sourcedir)
+
+        smm = SoftwareManager()
+        if fstype == 'btrfs':
+            if distro.detect().name == 'Ubuntu':
+                if not smm.check_installed("btrfs-tools") and not \
+                        smm.install("btrfs-tools"):
+                    self.skip('btrfs-tools is needed for the test to be run')
 
         if self.disk is not None:
             self.part_obj = Partition(self.disk, mountpoint=self.dir)

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -25,8 +25,9 @@ from avocado import Test
 from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils.partition import Partition
+from avocado.utils.software_manager import SoftwareManager
 
 
 class fs_mark(Test):
@@ -42,6 +43,7 @@ class fs_mark(Test):
         fs_mark
         """
 
+        smm = SoftwareManager()
         tarball = self.fetch_asset('http://prdownloads.source'
                                    'forge.net/fsmark/fs_mark-3.3.tar.gz')
         archive.extract(tarball, self.srcdir)
@@ -52,6 +54,12 @@ class fs_mark(Test):
         build.make(self.srcdir)
         self.disk = self.params.get('disk', default=None)
         self.fstype = self.params.get('fs', default='ext4')
+
+        if self.fstype == 'btrfs':
+            if distro.detect().name == 'Ubuntu':
+                if not smm.check_installed("btrfs-tools") and not \
+                        smm.install("btrfs-tools"):
+                    self.skip('btrfs-tools is needed for the test to be run')
 
     def test(self):
         """


### PR DESCRIPTION
The package for btrfs file system is different in ubuntu. hence it
was failing while running for btrfs file system. added the code to
fix the same issue. now it is working fine.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>