### PR TITLE
RHEL distro name: adapt tests to change in Avocado's definition

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -51,12 +51,18 @@ class Xfstests(Test):
                              'libattr1-dev', 'libacl1-dev', 'libgdbm-dev',
                              'uuid-runtime', 'libaio-dev', 'fio', 'dbench'])
 
-        elif detected_distro.name in ['centos', 'fedora', 'redhat']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['centos', 'fedora', 'rhel', 'redhat']:
             packages.extend(['acl', 'bc', 'dump', 'indent', 'libtool', 'lvm2',
                              'xfsdump', 'psmisc', 'sed', 'libacl-devel',
                              'libattr-devel', 'libaio-devel', 'libuuid-devel',
                              'openssl-devel', 'xfsprogs-devel', 'btrfs-progs-devel'])
-            if detected_distro.name != 'redhat':
+            # FIXME: "redhat" as the distro name for RHEL is deprecated
+            # on Avocado versions >= 50.0.  This is a temporary compatibility
+            # enabler for older runners, but should be removed soon
+            if detected_distro.name not in ['rhel', 'redhat']:
                 packages.extend(['fio', 'dbench'])
         else:
             self.skip("test not supported in %s" % detected_distro.name)

--- a/generic/criu.py
+++ b/generic/criu.py
@@ -32,7 +32,10 @@ class CRIU(Test):
         packages = ['gcc', 'make', 'protobuf', 'protobuf-c', 'protobuf-c-devel',
                     'protobuf-compiler', 'protobuf-devel', 'protobuf-python',
                     'libnl3-devel', 'libcap-devel', 'libaio-devel']
-        if dist.name != 'redhat':
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        if dist.name not in ['rhel', 'redhat']:
             self.skip('Currently test is supported only on RHEL')
         for package in packages:
             if not sm.check_installed(package) and not sm.install(package):

--- a/generic/gdb.py
+++ b/generic/gdb.py
@@ -33,7 +33,10 @@ class GDB(Test):
         packages = ['gcc', 'dejagnu', 'flex', 'bison']
         if dist.name == 'Ubuntu':
             packages.extend(['g++', 'binutils-dev'])
-        elif dist.name in ['SuSE', 'redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif dist.name in ['SuSE', 'rhel', 'fedora', 'redhat']:
             packages.extend(['gcc-c++', 'binutils-devel'])
         else:
             self.fail('no packages list for your distro.')

--- a/generic/hwinfo.py
+++ b/generic/hwinfo.py
@@ -34,7 +34,10 @@ class Hwinfo(Test):
         return
 
     def setUp(self):
-        if distro.detect().name == 'redhat':
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        if distro.detect().name in ['rhel', 'redhat']:
             self.skip('Hwinfo not supported on RHEL')
         sm = SoftwareManager()
         if not sm.check_installed("hwinfo") and not sm.install("hwinfo"):

--- a/generic/service_check.py.data/services.cfg
+++ b/generic/service_check.py.data/services.cfg
@@ -1,10 +1,15 @@
 [Ubuntu]
 services = sshd,ufw,networking,libvirtd
-[redhat]
+[rhel]
 services = sshd,firewalld,network,libvirtd
 [SuSE]
 services = sshd,SuSEfirewall2,network,libvirtd
 [fedora]
 services = sshd
 [centos]
+services = sshd,firewalld,network,libvirtd
+# FIXME: "redhat" as the distro name for RHEL is deprecated
+# on Avocado versions >= 50.0.  This is a temporary compatibility
+# enabler for older runners, but should be removed soon
+[redhat]
 services = sshd,firewalld,network,libvirtd

--- a/generic/sosreport.py
+++ b/generic/sosreport.py
@@ -46,7 +46,10 @@ class sosreport_test(Test):
             self.log.info("sosreport is installed")
         elif dist.name == 'Ubuntu':
             sos_pkg = 'sosreport'
-        elif dist.name == 'redhat':
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif dist.name in ['rhel', 'redhat']:
             sos_pkg = 'sos'
         else:
             self.skip("sosreport is not supported on this distro ")

--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -45,7 +45,10 @@ class Bonding(Test):
         depends = []
         if detected_distro.name == "Ubuntu":
             depends.append("openssh-client")
-        if detected_distro.name in ["redhat", "fedora", "centos"]:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        if detected_distro.name in ["rhel", "fedora", "centos", "redhat"]:
             depends.append("openssh-clients")
         if detected_distro.name == "SuSE":
             depends.append("openssh")

--- a/io/net/infiniband/ib_bw_perf.py
+++ b/io/net/infiniband/ib_bw_perf.py
@@ -68,7 +68,10 @@ class Bandwidth_Perf(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/io/net/infiniband/ib_latency_perf.py
+++ b/io/net/infiniband/ib_latency_perf.py
@@ -65,7 +65,10 @@ class Latency_Perf(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -61,7 +61,10 @@ class pingpong(Test):
         if detected_distro.name == "Ubuntu":
             depends.append("ibverbs")
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             depends.append("libibverbs")
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":

--- a/io/net/infiniband/ip_over_ib.py
+++ b/io/net/infiniband/ip_over_ib.py
@@ -58,7 +58,10 @@ class ip_over_ib(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/io/net/infiniband/mckey.py
+++ b/io/net/infiniband/mckey.py
@@ -72,7 +72,10 @@ class Mckey(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/io/net/infiniband/ping6.py
+++ b/io/net/infiniband/ping6.py
@@ -80,7 +80,10 @@ class Ping6(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/io/net/infiniband/rping.py
+++ b/io/net/infiniband/rping.py
@@ -72,7 +72,10 @@ class Rping(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/io/net/infiniband/ucmatose.py
+++ b/io/net/infiniband/ucmatose.py
@@ -68,7 +68,10 @@ class Ucmatose(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/io/net/infiniband/udaddy.py
+++ b/io/net/infiniband/udaddy.py
@@ -67,7 +67,10 @@ class Udady(Test):
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
-        elif detected_distro.name in ['redhat', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'fedora', 'redhat']:
             cmd = "systemctl stop firewalld"
         elif detected_distro.name == "SuSE":
             cmd = "rcSuSEfirewall2 stop"

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -51,7 +51,10 @@ class kselftest(Test):
             deps.extend(['popt', 'glibc', 'glibc-devel',
                          'popt-devel', 'libcap1', 'libcap1-devel',
                          'libcap-ng', 'libcap-ng-devel'])
-        elif detected_distro.name in ['centos', 'fedora', 'redhat']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['centos', 'fedora', 'rhel', 'redhat']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'glibc-static',
                          'libcap-ng', 'libcap', 'libcap-devel'])
 

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -103,8 +103,10 @@ class libhugetlbfs(Test):
         patch = self.params.get('patch', default='elflink.patch')
         process.run('patch -p1 < %s' % data_dir + '/' + patch, shell=True)
 
-        if (detected_distro.name == "redhat" or
-                detected_distro.name == "fedora"):
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        if detected_distro.name in ["rhel", "fedora", "redhat"]:
             falloc_patch = 'patch -p1 < %s ' % (
                 os.path.join(data_dir, 'falloc.patch'))
             process.run(falloc_patch, shell=True)

--- a/memory/memcached.py
+++ b/memory/memcached.py
@@ -43,14 +43,20 @@ class Memcached(Test):
         sm = SoftwareManager()
         detected_distro = distro.detect()
 
-        if detected_distro.name not in ['Ubuntu', 'redhat']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        if detected_distro.name not in ['Ubuntu', 'rhel', 'redhat']:
             self.skip('Test Not applicable')
 
         if detected_distro.name == "Ubuntu":
             deps = ['memcached', 'libmemcached-tools']
             stress_tool = 'memcslap'
 
-        if detected_distro.name == "redhat":
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        if detected_distro.name in ["rhel", "redhat"]:
             deps = ['memcached', 'libmemcached']
             stress_tool = 'memslap'
 

--- a/perf/aiostress.py
+++ b/perf/aiostress.py
@@ -45,7 +45,10 @@ class Aiostress(Test):
         dist_name = distro.detect().name.lower()
         if dist_name == 'ubuntu':
             packages.extend(['libaio1', 'libaio-dev'])
-        elif dist_name in ['centos', 'fedora', 'redhat']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif dist_name in ['centos', 'fedora', 'rhel', 'redhat']:
             packages.extend(['libaio', 'libaio-devel'])
         elif dist_name == 'suse':
             self.skip("Test currently does not support distro %s" % dist_name)

--- a/perf/perf_events_test.py
+++ b/perf/perf_events_test.py
@@ -42,7 +42,10 @@ class Perf_subsystem(Test):
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['linux-tools-common', 'linux-tools-%s'
                          % kernel_ver])
-        elif detected_distro.name in ['redhat', 'SuSE', 'fedora']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'redhat']:
             deps.extend(['perf'])
         else:
             self.skip("Install the package for perf supported by %s"

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -40,7 +40,10 @@ class Perftool(Test):
         deps = ['gcc', 'make']
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['linux-tools-common', 'linux-tools-%s' % kernel_ver])
-        elif detected_distro.name in ['redhat', 'SuSE', 'fedora', 'centos']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos', 'redhat']:
             deps.extend(['perf'])
         else:
             self.skip("Install the package for perf supported\

--- a/toolchain/atlas.py
+++ b/toolchain/atlas.py
@@ -36,7 +36,10 @@ class Atlas(Test):
         for package in ['gcc', 'make', 'gfortran']:
             if detected_distro.name == "SuSE" and package == "gfortran":
                 package = 'gcc-fortran'
-            if detected_distro.name == "redhat" and package == "gfortran":
+            # FIXME: "redhat" as the distro name for RHEL is deprecated
+            # on Avocado versions >= 50.0.  This is a temporary compatibility
+            # enabler for older runners, but should be removed soon
+            if detected_distro.name in ["rhel", "redhat"] and package == "gfortran":
                 package = 'gcc-gfortran'
             if not sm.check_installed(package) and not sm.install(package):
                 self.error(package + ' is needed for the test to be run')

--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -55,7 +55,10 @@ class Ltrace(Test):
                          'elfutils', 'binutils-devel', 'libtool', 'gcc-c++']
             pkgs += sles_deps
 
-        elif dist_name in ("redhat", "fedora"):
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif dist_name in ("rhel", "fedora", "redhat"):
             rhel_deps = ['elfutils-devel', 'elfutils-libelf-devel',
                          'elfutils-libelf', 'elfutils-libs', 'libtool-ltdl']
             pkgs += rhel_deps

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -39,7 +39,10 @@ class Valgrind(Test):
         deps = ['gcc', 'make']
         if dist.name == 'Ubuntu':
             deps.extend(['g++'])
-        elif dist.name in ['SuSE', 'redhat', 'fedora', 'centos']:
+        # FIXME: "redhat" as the distro name for RHEL is deprecated
+        # on Avocado versions >= 50.0.  This is a temporary compatibility
+        # enabler for older runners, but should be removed soon
+        elif dist.name in ['SuSE', 'rhel', 'fedora', 'centos', 'redhat']:
             deps.extend(['gcc-c++'])
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
Avocado has a change proposed for inclusion during the 50.0
development time that will change the distro name for Red Hat
Enterprise Linux from "redhat" to "rhel".

These changes keep the old name ("redhat"), while adding the new name
and a very verbose FIXME message explaining the deprecation.  Then, at
a later time, the support for the "redhat" name can be dropped without
causing compatibility issues.

Signed-off-by: Cleber Rosa <crosa@redhat.com>