### PR TITLE
Enhanced PowerVMEEH script

### DIFF
--- a/io/pci/PowerVMEEH.data/PowerVMEEH.yaml
+++ b/io/pci/PowerVMEEH.data/PowerVMEEH.yaml
@@ -1,3 +1,3 @@
 scenario:
-    maxFreeze: 1
+    max_freeze: 1
     function: 4


### PR DESCRIPTION
Now script will be able to inject one error more than the
eeh_max-freeze bit, so that we can test adapter failure.
Also, if there is EEH miss for more than 5 times for a perticular
function, it continues with next adapter throwing a warning

Signed-off-by: Venkat R B <vrbagal1@linux.vnet.ibm.com>