### PR TITLE
Fixed the script to skip cached WWID

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -75,6 +75,10 @@ class MultipathTest(Test):
 
         # Find all details of multipath devices
         for wwid in self.wwids:
+            if wwid not in process.system_output('multipath -ll',
+                                                 ignore_status=True,
+                                                 shell=True):
+                continue
             self.mpath_dic = {}
             self.mpath_dic["wwid"] = wwid
             self.mpath_dic["name"] = multipath.get_mpath_name(wwid)


### PR DESCRIPTION
Script was throwing an error, for WWID which are not present,
but were cached. So we need to skip the older WWID

Suggested-by:  Narasimhan V sim@linux.vnet.ibm.com
Signed-off-by: Venkat R B <vrbagal1@linux.vnet.ibm.com>