### PR TITLE
SMT Changes in HTX now runs once every hour

### DIFF
--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -35,7 +35,7 @@ class HtxTest(Test):
     :see:https://github.com/open-power/HTX.git
     :param block_devices: names of block_devices on which you want to run HTX
     :param mdt_file: mdt file used to trigger HTX
-    :params time_limit: how much time you want to run this stress.
+    :params time_limit: how much time(hours) you want to run this stress.
     """
 
     def setUp(self):
@@ -49,7 +49,7 @@ class HtxTest(Test):
             self.skip("Distro does not support")
 
         self.mdt_file = self.params.get('mdt_file', default='mdt.hd')
-        self.time_limit = self.params.get('time_limit', default=600)
+        self.time_limit = int(self.params.get('time_limit', default=2)) * 3600
         self.block_devices = self.params.get('disk', default=None)
         if self.block_devices is None:
             self.skip("Needs the block devices to run the HTX")
@@ -118,8 +118,10 @@ class HtxTest(Test):
         self.log.info("Running the HTX on %s", self.block_device)
         cmd = "htxcmdline -run %s -mdt %s" % (self.block_device, self.mdt_file)
         process.system(cmd, ignore_status=True)
-        for _ in range(0, self.time_limit, 60):
-            self.run_smt()
+        for time_loop in range(0, self.time_limit, 60):
+            # Running SMT changes every hour
+            if time_loop % 3600 == 0:
+                self.run_smt()
             self.log.info("HTX Error logs")
             process.run('htxcmdline -geterrlog')
             if os.stat('/tmp/htxerr').st_size != 0:

--- a/io/disk/htx_block_devices.py.data/Readme.txt
+++ b/io/disk/htx_block_devices.py.data/Readme.txt
@@ -14,6 +14,6 @@ user in yaml file.
 Inputs:
 ------
 disk: '/dev/sdb /dev/sdc'
-time_limit: 240
+time_limit: 2 (In hours)
 mdt_file: 'mdt.io'
 smt_change: True or False

--- a/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
@@ -1,4 +1,4 @@
 disk: '/dev/sdb'
-time_limit: 240
+time_limit: 2
 mdt_file: 'mdt.hd'
 smt_change: True


### PR DESCRIPTION
Enhanced HTX test to run SMT changes once every hour,
since running it very frequently is not a proper use case.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>