### PR TITLE
Use whiteboard for performance data

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -87,12 +87,10 @@ class Ebizzy(Test):
         usr_time = pattern.findall(results)[0]
         pattern = re.compile(r"sys (.*?) s")
         sys_time = pattern.findall(results)[0]
-
-        perf_json = {'records': records, 'real_time':
-                     real, 'user': usr_time, 'sys': sys_time}
-        output_path = os.path.join(self.outputdir, "perf.json")
-        json.dump(perf_json, open(output_path, "w"))
-
+        self.whiteboard = json.dumps({'records': records,
+                                      'real_time': real,
+                                      'user': usr_time,
+                                      'sys': sys_time})
 
 if __name__ == "__main__":
     main()

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -81,9 +81,8 @@ class Dbench(Test):
         self.results = process.system_output(cmd)
         pattern = re.compile(r"Throughput (.*?) MB/sec (.*?) procs")
         (throughput, procs) = pattern.findall(self.results)[0]
-        perf_json = {'throughput': throughput, 'procs': procs}
-        output_path = os.path.join(self.outputdir, "perf.json")
-        json.dump(perf_json, open(output_path, "w"))
+        self.whiteboard = json.dumps({'throughput': throughput,
+                                      'procs': procs})
 
 
 if __name__ == "__main__":

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -530,8 +530,7 @@ class IOZone(Test):
                             result = match.group(1)
                             key_name = "%s-%d-%s" % (section, w_count, basekey)
                             keylist[key_name] = result
-        output_path = os.path.join(self.outputdir, "perf.json")
-        json.dump(keylist, open(output_path, "w"), indent=1)
+        self.whiteboard = json.dumps(keylist, indent=1)
 
     def test(self):
         '''

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -202,14 +202,10 @@ class ParallelDd(Test):
         self.fs_read()
         self.fs_read_rate = operation
 
-        result_json = ({
-            'raw_write': self.raw_write_rate,
-            'raw_read': self.raw_read_rate,
-            'fs_write': self.fs_write_rate,
-            'fs_read': self.fs_read_rate})
-
-        output_path = os.path.join(self.logdir, "results.json")
-        json.dump(result_json, open(output_path, "w"))
+        self.whiteboard = json.dumps({'raw_write': self.raw_write_rate,
+                                      'raw_read': self.raw_read_rate,
+                                      'fs_write': self.fs_write_rate,
+                                      'fs_read': self.fs_read_rate})
 
     def cleanup(self):
         """

--- a/kernel/tlbflush.py
+++ b/kernel/tlbflush.py
@@ -77,9 +77,7 @@ class Tlbflush(Test):
 
             out = self.run()
             self.perf_json.append({'Test time' + str(ite): out})
-
-        output_path = os.path.join(self.outputdir, "perf.json")
-        json.dump(self.perf_json, open(output_path, "w"))
+        self.whiteboard = json.dumps(self.perf_json)
 
     def run(self):
 

--- a/perf/hackbench.py
+++ b/perf/hackbench.py
@@ -71,8 +71,7 @@ class Hackbench(Test):
             if line.startswith('Time:'):
                 time_spent = line.split()[1]
                 perf_json = {'time': time_spent}
-        output_path = os.path.join(self.outputdir, "perf.json")
-        json.dump(perf_json, open(output_path, "w"))
+        self.whiteboard = json.dumps(perf_json)
         self.log.info("Time Taken:" + time_spent)
         if self._threshold_time:
             if self._threshold_time <= time_spent:


### PR DESCRIPTION
The following five tests use a custom file to record performance
data.  Avocado test API makes an attribute available that will
automatically preserve test data in any arbitraty format, the
whiteboard, documented here:

  http://avocado-framework.readthedocs.io/en/49.0/WritingTests.html#saving-test-generated-custom-data

This patch is a suggestion/RFC to just use the whiteboard instead of
yet another external file.  The upside is less code and possible
future goodies that the framework may bring (for instance, we may show
the whiteboard by default on job reports).  The downside of this
change is that, if there are scripts consuming this performance data,
they'd have to be adjusted to use the whiteboard file path.

Signed-off-by: Cleber Rosa <crosa@redhat.com>