### PR TITLE
Check the Arcconf package and remove the http repo path in yaml file

### DIFF
--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -73,7 +73,7 @@ class Arcconftest(Test):
         self.repo1 = "%s.ufi" % self.repo1
 
         detected_distro = distro.detect()
-        if not smm.check_installed("arcconf"):
+        if not smm.check_installed("Arcconf"):
             if detected_distro.name == "Ubuntu":
                 http_repo = "%s%s.deb" % (self.http_path, self.tool_name)
                 self.repo = self.fetch_asset(http_repo, expire='10d')

--- a/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
+++ b/io/disk/arcconf/arcconf_cntl_oper.py.data/arcconf_cntl_oper.yaml
@@ -182,7 +182,7 @@ Test: !mux
 parameters:
     crtl_no: "1"
     pci_id: "9005:028d:9005:0557"
-    http_path: "http://9.47.67.137/repo/firmware/RAID/arcconf/tool/"
+    http_path: ""
     tool_name: "Arcconf-2.02-22404.ppc64el"
-    firmware_path: "http://9.47.67.137/repo/firmware/RAID/PMC_Sierra/"
-    firmware_name: "latest"
+    firmware_path: ""
+    firmware_name: "AS816Z01.ufi"

--- a/io/disk/arcconf/arcconf_drive_oper.py
+++ b/io/disk/arcconf/arcconf_drive_oper.py
@@ -73,7 +73,7 @@ class Arcconftest(Test):
             self.skip(" Test skipped!!, PMC controller not available")
 
         detected_distro = distro.detect()
-        if not smm.check_installed("arcconf"):
+        if not smm.check_installed("Arcconf"):
             if detected_distro.name == "Ubuntu":
                 http_repo = "%s%s.deb" % (self.http_path, self.tool_name)
                 self.repo = self.fetch_asset(http_repo, expire='10d')

--- a/io/disk/arcconf/arcconf_drive_oper.py.data/arcconf_drive_oper.yaml
+++ b/io/disk/arcconf/arcconf_drive_oper.py.data/arcconf_drive_oper.yaml
@@ -50,5 +50,5 @@ parameters:
     pci_id: "9005:028d:9005:0557"
     logicaldrive: "0"
     diskoverwrite: "Y"
-    http_path: "http://9.47.67.137/repo/firmware/RAID/arcconf/tool/"
+    http_path: ""
     tool_name: "Arcconf-2.02-22404.ppc64el"

--- a/io/disk/arcconf/arcconf_migration.py
+++ b/io/disk/arcconf/arcconf_migration.py
@@ -86,7 +86,7 @@ class Arcconftest(Test):
             self.skip("Cannot Migrate, please check the prerequisite")
 
         detected_distro = distro.detect()
-        if not smm.check_installed("arcconf"):
+        if not smm.check_installed("Arcconf"):
             if detected_distro.name == "Ubuntu":
                 http_repo = "%s%s.deb" % (self.http_path, self.tool_name)
                 self.repo = self.fetch_asset(http_repo, expire='10d')

--- a/io/disk/arcconf/arcconf_migration.py.data/arcconf_migration.yaml
+++ b/io/disk/arcconf/arcconf_migration.py.data/arcconf_migration.yaml
@@ -38,5 +38,5 @@ parameters:
     diskoverwrite: "Y"
     disk_size: "100"
     migration_sleep: "60"
-    http_path: "http://9.47.67.137/repo/firmware/RAID/arcconf/tool/"
+    http_path: ""
     tool_name: "Arcconf-2.02-22404.ppc64el"

--- a/io/disk/arcconf/arcconf_raid_oper.py
+++ b/io/disk/arcconf/arcconf_raid_oper.py
@@ -77,7 +77,7 @@ class Arcconftest(Test):
             self.skip(" Test skipped!!, PMC controller not available")
 
         detected_distro = distro.detect()
-        if not smm.check_installed("arcconf"):
+        if not smm.check_installed("Arcconf"):
             if detected_distro.name == "Ubuntu":
                 http_repo = "%s%s.deb" % (self.http_path, self.tool_name)
                 self.repo = self.fetch_asset(http_repo, expire='10d')

--- a/io/disk/arcconf/arcconf_raid_oper.py.data/arcconf_raid_oper.yaml
+++ b/io/disk/arcconf/arcconf_raid_oper.py.data/arcconf_raid_oper.yaml
@@ -54,5 +54,5 @@ parameters:
     diskoverwrite: "Y"
     fs_type: "ext4"
     mount_point: "/mnt"
-    http_path: "http://9.47.67.137/repo/firmware/RAID/arcconf/tool/"
+    http_path: ""
     tool_name: "Arcconf-2.02-22404.ppc64el"


### PR DESCRIPTION
This patch will check the Arcconf package with correct case letter,
also will remove the default tool and firmware path for the adapter.

Signed-off-by: Naveed Ahmed U S <naveedus@linux.vnet.ibm.com>