### PR TITLE
Fix cpupower cpu_freq_path function return value

### DIFF
--- a/cpu/cpupower.py
+++ b/cpu/cpupower.py
@@ -80,7 +80,7 @@ class cpupower(Test):
         :param: cpu_num is value for cpu
         """
         filename = "/sys/devices/system/cpu/cpu%s/cpufreq/%s" % (cpu_num, file)
-        return open(filename, 'r').readline().strip('\n')
+        return open(filename, 'r').readline().strip('\n').strip(' ')
 
     def get_list_governors(self):
         """


### PR DESCRIPTION
scaling_available_frequencies file had a space in the end, which
when split, returned an empty element in array.
Fixed that with returning after stripping the space in the end.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>