### PR TITLE
Support to exclude tests run in xfstest suite

### DIFF
--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -17,6 +17,9 @@ setup:
             fs: 'ext4'
         fs_xfs:
             fs: 'xfs'
+            # Exclude only if test_range not provided
+            # exclude: '2,4-7,203'
+            # gen_exclude: '1-10,30-45'
     # disk_type: !mux
     #    type: 'disk'
     #    disk_test: /dev/sdx1


### PR DESCRIPTION
This patch provides support to exclude a range of xfstests specific to a filesystem running as a whole.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>