### PR TITLE
7th floortypo error fix in pci_hotplug.py script

### DIFF
--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -47,7 +47,7 @@ class PCIHotPlugTest(Test):
             for mdl in ['rpaphp', 'rpadlpar_io']:
                 if not linux_modules.module_is_loaded(mdl):
                     linux_modules.load_module(mdl)
-        elif cpu._list_matches(cpu._get_cpuinfo(), 'PowerNV'):
+        elif cpu._list_matches(cpu._get_cpu_info(), 'PowerNV'):
             if not linux_modules.module_is_loaded("pnv_php"):
                 linux_modules.load_module("pnv_php")
         self.return_code = 0


### PR DESCRIPTION
there was a typo error in pci_hotplug.py where cpu_info should there,
it was a cpuinfo, hence test was failing. so edited the same and now
it works fine.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>