### PR TITLE
Fixing an issue with previous change ltp_fs

### DIFF
--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -68,9 +68,9 @@ class Ltp_Fs(Test):
         self.ltpbin_dir = os.path.join(ltp_dir, 'bin')
         if not os.path.isdir(self.ltpbin_dir):
             os.mkdir(self.ltpbin_dir)
-        process.system('./configure --prefix=%s' % self.ltpbin_dir)
-        build.make(ltp_dir)
-        build.make(ltp_dir, extra_args='install')
+            process.system('./configure --prefix=%s' % self.ltpbin_dir)
+            build.make(ltp_dir)
+            build.make(ltp_dir, extra_args='install')
 
     def test_fs_run(self):
 


### PR DESCRIPTION
configure was throwing an error when trying for second variant
onwards, due to a change in the previous commit.
Fixed that.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>