### PR TITLE
SKIP : THP tests are not supported for 4K pages

### DIFF
--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -18,10 +18,14 @@
 import os
 from avocado import Test
 from avocado import main
+from avocado import skipIf
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.core import data_dir
 from avocado.utils.partition import Partition
+
+
+PAGESIZE = '4096' in str(memory.get_page_size())
 
 
 class Thp(Test):
@@ -31,8 +35,8 @@ class Thp(Test):
     and verifies whether THP has been allocated for usage or not
     '''
 
+    @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
     def setUp(self):
-
         '''
         Sets all the reqd parameter and also
         mounts the tmpfs to be used in test.
@@ -54,7 +58,6 @@ class Thp(Test):
                           args='-o size=%dM' % free_mem)
 
     def test(self):
-
         '''
         Enables THP , Runs the dd workload and checks whether THP
         has been allocated.
@@ -105,7 +108,6 @@ class Thp(Test):
                           thp_fault_alloc, thp_split, thp_collapse_alloc)
 
     def tearDown(self):
-
         '''
         Removes the files created and unmounts the tmpfs.
         '''

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -21,11 +21,15 @@ import mmap
 import avocado
 from avocado import Test
 from avocado import main
+from avocado import skipIf
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.utils import disk
 from avocado.core import data_dir
 from avocado.utils.partition import Partition
+
+
+PAGESIZE = '4096' in str(memory.get_page_size())
 
 
 class Thp_Defrag(Test):
@@ -35,8 +39,8 @@ class Thp_Defrag(Test):
     and turns on THP defrag and checks whether defrag occured.
     '''
 
+    @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
     def setUp(self):
-
         '''
         Sets required params for dd workload and mounts the tmpfs
         '''
@@ -54,7 +58,6 @@ class Thp_Defrag(Test):
 
     @avocado.fail_on
     def test(self):
-
         '''
         Enables THP, Turns off the defrag and fragments the memory.
         Once the memory gets fragmented turns on the defrag and checks
@@ -78,7 +81,7 @@ class Thp_Defrag(Test):
 
         total = memory.memtotal()
         hugepagesize = memory.get_huge_page_size()
-        nr_full = int(0.8 * (total/hugepagesize))
+        nr_full = int(0.8 * (total / hugepagesize))
 
         # Sets max possible hugepages before defrag on
         nr_hp_before = self.set_max_hugepages(nr_full)
@@ -103,7 +106,6 @@ class Thp_Defrag(Test):
 
     @staticmethod
     def set_max_hugepages(nr_full):
-
         '''
         Tries to set the hugepages to the nr_full value and returns the
         max possible value set.
@@ -113,7 +115,6 @@ class Thp_Defrag(Test):
         return memory.get_num_huge_pages()
 
     def tearDown(self):
-
         '''
         Removes files and unmounts the tmpfs.
         '''

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -19,10 +19,14 @@
 import os
 from avocado import Test
 from avocado import main
+from avocado import skipIf
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.core import data_dir
 from avocado.utils.partition import Partition
+
+
+PAGESIZE = '4096' in str(memory.get_page_size())
 
 
 class Thp_Swapping(Test):
@@ -31,8 +35,8 @@ class Thp_Swapping(Test):
     The test fills out the total avl memory and tries to swap the thp out.
     '''
 
+    @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
     def setUp(self):
-
         '''
         Sets the Required params for dd and mounts the tmpfs dir
         '''
@@ -65,7 +69,6 @@ class Thp_Swapping(Test):
                               args="-o size=%sM" % tmpfs_size)
 
     def test(self):
-
         '''
         Enables THP Runs dd, fills out the available memory and checks whether
         THP is swapped out.
@@ -92,7 +95,6 @@ class Thp_Swapping(Test):
             self.fail("Swap Space remains untouched")
 
     def tearDown(self):
-
         '''
         Removes directories in tmpfs and unmounts it.
         '''


### PR DESCRIPTION
If the linux pagesize of the given system is 4K than skip
the THP testcases, as the transparent huge pages are not supported
if the PAGESIZE is 4096

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>