### PR TITLE
Extend test category using tags [v2]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,6 @@ This repository is dedicated to host any tests written using the avocado [1]
 API. It is being initially populated with tests ported from autotest
 client tests repository, but it's not limited by that.
 
-Tests will be organized per category basis, each category  with its own
-directory.
-
 Once you have the avocado installed, you can run the tests like below::
 
     $ avocado run avocado-misc-tests/perf/stress.py
@@ -19,4 +16,26 @@ Once you have the avocado installed, you can run the tests like below::
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-18T15.32-0018adb/html/results.html
     TIME       : 62.67 s
 
+
+Tests are be organized per category basis, each category with its own
+directory.  Additionally, the tests are categorized by the use of the
+following tags[2] by functional area:
+
+ * cpu - Exercises a system's CPU
+ * net - Exercises a system's network devices or networking stack
+ * storage - Exercises a system's local storage
+ * fs - Exercises a system's file system
+
+Tags by architecture:
+
+ * x86_64 - Requires a x86_64 architecture
+ * power - Requires a Power architecture
+
+Tags by access privileges:
+
+ * privileged - requires the test to be run with the most privileged,
+   unrestricted privileges.  For Linux systems, this usually means the
+   root account
+
 [1] https://github.com/avocado-framework/avocado
+[2] http://avocado-framework.readthedocs.io/en/latest/WritingTests.html#categorizing-tests

--- a/cpu/cpupower.py
+++ b/cpu/cpupower.py
@@ -27,6 +27,8 @@ class cpupower(Test):
 
     """
     Testing cpupower command
+
+    :avocado: tags=cpu,power,privileged
     """
     def setUp(self):
         if not os.path.exists('/sys/devices/system/cpu/cpu0/cpufreq'):

--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -36,6 +36,8 @@ class Ebizzy(Test):
     ebizzy is designed to generate a workload resembling common web application
     server workloads. It is highly threaded, has a large in-memory working set,
     and allocates and deallocates memory frequently.
+
+    :avocado: tags=cpu
     '''
 
     def setUp(self):

--- a/cpu/linsched.py
+++ b/cpu/linsched.py
@@ -28,6 +28,8 @@ class Linsched(Test):
 
     """
     linux-scheduler-testing Testsuite
+
+    :avocado: tags=cpu
     """
 
     def setUp(self):

--- a/cpu/pmqa.py
+++ b/cpu/pmqa.py
@@ -30,6 +30,8 @@ class Pmqa(Test):
     pmqa Testsuite these cpu test
     cpufreq, cpuhotplug, cputopology
     cpuidlee, thermal
+
+    :avocado: tags=cpu,privileged
     """
 
     def setUp(self):

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -29,6 +29,8 @@ from avocado.utils.software_manager import SoftwareManager
 class PPC64Test(Test):
     """
     Test to verify ppc64_cpu command for different supported values.
+
+    :avocado: tags=cpu,power,privileged
     """
 
     def setUp(self):

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -33,6 +33,8 @@ class Sensors(Test):
 
     """
     Test covers  various command input of sensors utility(Linux monitoring sensors)
+
+    :avocado: tags=cpu,privileged
     """
 
     @staticmethod


### PR DESCRIPTION
The tests on this repo are already well categorized by the directory
structure, but that can only give so much info about them. Let's also
make use of some basic (initially) tags.

Some exampels of the immediate benefits include listing/running only
tests that can run as regular users:

 $ avocado list --filter-by-tags=-privileged cpu/
 INSTRUMENTED cpu/ebizzy.py:Ebizzy.test
 INSTRUMENTED cpu/linsched.py:Linsched.test

Listing/running tests that require a Power architecture:

 $ avocado list --filter-by-tags=power cpu/
 INSTRUMENTED cpu/cpupower.py:cpupower.test
 INSTRUMENTED cpu/ppc64_cpu_test.py:PPC64Test.test

This is a *partial* implementation (only includes tests under the
"cpu" directory) of the extended information using tags, intended as
an RFC (or initial step).  This is related to an RFC posted on
the mailing list.

Reference: https://www.redhat.com/archives/avocado-devel/2017-May/msg00007.html
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#517):
 * Removed `power` tag from `sensors` test