### PR TITLE
Stress-ng : Improved test to cover all test scenarios

### DIFF
--- a/generic/stress-ng.py.data/readme.rst
+++ b/generic/stress-ng.py.data/readme.rst
@@ -1,0 +1,23 @@
+stress-ng test
+--------------
+Stress-ng exercises various subsystems as well as kernel interfaces. 
+It has 175 stressor covering CPU, MEMORY, IO, INTERUPT, SCHEDULER, VM code paths.
+
+Running stress-ng with root privileges will adjust out of memory settings on Linux systems 
+to make the stressors unkillable in low memory situations, so use this judiciously. 
+
+Test can be run to cover all subsystems using class parameter from yaml
+class: 'all'
+
+To run for a specific component
+class: 'cpu'
+
+To run for specific stressors
+stressors: 'mmap numa stack'
+
+To exclude few test:
+exclude: 'stack,brk,io'
+
+To run random 60 test:
+stressors: 'random'
+workers: '60'

--- a/generic/stress-ng.py.data/stress-ng.yaml
+++ b/generic/stress-ng.py.data/stress-ng.yaml
@@ -1,0 +1,61 @@
+workers: null
+ttimeout: '5m'
+verify: True
+syslog: True
+metrics: True
+maximize: True
+times: True
+aggressive: True
+subsystem: !mux
+    all:
+        stressors: null
+        class: 'all'
+        exclude: null
+    memory:
+        class: 'memory'
+        stressors: null
+        exclude: null
+    cpu:
+        class: 'cpu'
+        stressors: null
+        exclude: null
+    cpu-cache:
+        class: 'cpu-cache'
+        stressors: null
+        exclude: null
+    io:
+        class: 'io'
+        stressors: null
+        exclude: null
+    device:
+        class: 'device'
+        stressors: null
+        exclude: null
+    interrupt:
+        class: 'interrupt'
+        stressors: null
+        exclude: null
+    filesystem:
+        class: 'filesystem'
+        stressors: null
+        exclude: null
+    network:
+        class: 'network'
+        stressors: null
+        exclude: null
+    os:
+        class: 'os'
+        stressors: null
+        exclude: null
+    pipe:
+        class: 'pipe'
+        stressors: null
+        exclude: null
+    scheduler:
+        class: 'scheduler'
+        stressors: null
+        exclude: null
+    vm: 
+        class: 'vm'
+        stressors: null
+        exclude: null


### PR DESCRIPTION
stress-ng can now by default run test for all linux components like
cpu, memory, scheduler, io, kernel .etc user can also run individual
components from yaml supplied.

stress-ng removed from memory and added generic tag

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>