### PR TITLE
Patch to check arcconf/Arcconf for respective OS

### DIFF
--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -73,7 +73,10 @@ class Arcconftest(Test):
         self.repo1 = "%s.ufi" % self.repo1
 
         detected_distro = distro.detect()
-        if not smm.check_installed("Arcconf"):
+        installed_package = "Arcconf"
+        if detected_distro.name == "Ubuntu":
+            installed_package = "arcconf"
+        if not smm.check_installed(installed_package):
             if detected_distro.name == "Ubuntu":
                 http_repo = "%s%s.deb" % (self.http_path, self.tool_name)
                 self.repo = self.fetch_asset(http_repo, expire='10d')


### PR DESCRIPTION
This patch will help in checking arcconf/Arcconf tool with
right case according to the installed OS.

Signed-off-by: Naveed Ahmed U S <naveedus@linux.vnet.ibm.com>