### PR TITLE
Fix Spelling in yaml files in Avago test

### DIFF
--- a/io/disk/Avago_storage_adapter/avago3008.py.data/avago3008.yaml
+++ b/io/disk/Avago_storage_adapter/avago3008.py.data/avago3008.yaml
@@ -1,5 +1,5 @@
 cenario:
-    contorller: 
+    controller:
     disk: 
     spare: ""
     size: 10000

--- a/io/disk/Avago_storage_adapter/avago9361.py.data/avago9361.yaml
+++ b/io/disk/Avago_storage_adapter/avago9361.py.data/avago9361.yaml
@@ -1,3 +1,3 @@
 cenario:
-    contorller: 0
+    controller: 0
     tool_location: /root/storcli64


### PR DESCRIPTION
Fix Spelling in yaml files in Avago test

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>