### PR TITLE
generic/rcutorture: Reuse cpu functions for offline and online

### DIFF
--- a/generic/rcutorture.py
+++ b/generic/rcutorture.py
@@ -23,7 +23,7 @@ import multiprocessing
 
 from avocado import Test
 from avocado import main
-from avocado.utils import process
+from avocado.utils import process, cpu
 from avocado.utils import linux_modules
 
 
@@ -33,6 +33,8 @@ class Rcutorture(Test):
     CONFIG_RCU_TORTURE_TEST enables an intense torture test of the RCU
     infratructure. It creates an rcutorture kernel module that can be
     loaded to run a torture test.
+
+    :avocado: tags=kernel,privileged
     """
 
     def setUp(self):
@@ -43,7 +45,7 @@ class Rcutorture(Test):
         self.log.info("Check if CONFIG_RCU_TORTURE_TEST is enabled\n")
         ret = linux_modules.check_kernel_config('CONFIG_RCU_TORTURE_TEST')
         if ret == 0:
-            self.skip("CONFIG_RCU_TORTURE_TEST is not set in .config !!\n")
+            self.cancel("CONFIG_RCU_TORTURE_TEST is not set in .config !!\n")
 
         self.log.info("Check rcutorture module is already  loaded\n")
         if linux_modules.module_is_loaded('rcutorture'):
@@ -61,38 +63,31 @@ class Rcutorture(Test):
         scpu = "%s - %s" % (shalf_count, full_count)
 
         self.log.info("Online all cpus %s", totalcpus)
-        for cpu in range(0, full_count):
-            online = 'echo 1 > /sys/devices/system/cpu/cpu%s/online' % cpu
-            process.system(online)
+        for cpus in range(0, full_count):
+            cpu.online(cpu)
         time.sleep(10)
 
         self.log.info("Offline all cpus 0 - %s\n", full_count)
-        for cpu in range(0, full_count):
-            offline = 'echo 0 > /sys/devices/system/cpu/cpu%s/online' % cpu
-            process.system(offline)
+        for cpus in range(0, full_count):
+            cpu.offline(cpu)
         time.sleep(10)
 
         self.log.info("Online all cpus 0 - %s\n", full_count)
-        for cpu in range(0, full_count):
-            online = 'echo 1 > /sys/devices/system/cpu/cpu%s/online' % cpu
-            process.system(online)
+        for cpus in range(0, full_count):
+            cpu.online(cpu)
 
         self.log.info(
             "Offline and online first half cpus %s\n", fcpu)
-        for cpu in range(0, half_count):
-            offline = 'echo 0 > /sys/devices/system/cpu/cpu%s/online' % cpu
-            process.system(offline)
+        for cpus in range(0, half_count):
+            cpu.offline(cpu)
             time.sleep(10)
-            online = 'echo 1 > /sys/devices/system/cpu/cpu%s/online' % cpu
-            process.system(online)
+            cpu.online(cpu)
 
         self.log.info("Offline and online second half cpus %s\n", scpu)
-        for cpu in range(shalf_count, full_count):
-            offline = 'echo 0 > /sys/devices/system/cpu/cpu%s/online' % cpu
-            process.system(offline)
+        for cpus in range(shalf_count, full_count):
+            cpu.offline(cpu)
             time.sleep(10)
-            online = 'echo 1 > /sys/devices/system/cpu/cpu%s/online' % cpu
-            process.system(online)
+            cpu.online(cpu)
 
     def test(self):
         """


### PR DESCRIPTION
CPU off-on commands from process.system() function never got
executed, replace with cpu off on functions in utils.py
Also added tags to be a kernel tests and replace skip with cancel

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>