### PR TITLE
tags: memory and kernel tests are grouped under respective components

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -32,6 +32,8 @@ class kselftest(Test):
 
     :see: https://www.kernel.org/doc/Documentation/kselftest.txt
     :source: https://github.com/torvalds/linux/archive/master.zip
+
+    :avocado: tags=kernel,privileged
     """
 
     testdir = 'tools/testing/selftests'

--- a/kernel/posixtest.py
+++ b/kernel/posixtest.py
@@ -31,7 +31,9 @@ from avocado.utils.software_manager import SoftwareManager
 class Posixtest(Test):
 
     '''
-     posix test  provides conformance, functional, and stress testing on Os Threads, Clocks & Timers, Signals, Message Queues, and Semaphores.
+    posix test  provides conformance, functional, and stress testing on Os Threads, Clocks & Timers, Signals, Message Queues, and Semaphores.
+
+    :avocado: tags=kernel
     '''
 
     def setUp(self):

--- a/kernel/rmaptest.py
+++ b/kernel/rmaptest.py
@@ -33,6 +33,8 @@ class Rmaptest(Test):
     """
     Create lots of VMAs mapped by lots of tasks.  To tickle objrmap and the
     virtual scan.
+
+    :avocado: tags:kernel
     """
 
     def setUp(self):

--- a/kernel/tlbflush.py
+++ b/kernel/tlbflush.py
@@ -29,6 +29,8 @@ class Tlbflush(Test):
 
     """
     This is a macrobenchmark for TLB flush range testing.
+
+    :avocado: tags=kernel,privileged
     """
 
     def setUp(self):

--- a/memory/dma_memtest.py
+++ b/memory/dma_memtest.py
@@ -38,6 +38,8 @@ class DmaMemtest(Test):
     It will uncompress several copies of the linux kernel in a way that will
     force the system to go swap, then will compare the trees generated for
     differences.
+
+    :avocado: tags=memory,privileged
     """
 
     def setUp(self):

--- a/memory/eatmemory.py
+++ b/memory/eatmemory.py
@@ -25,6 +25,11 @@ from avocado.utils.software_manager import SoftwareManager
 
 
 class eatmemory(Test):
+    '''
+    Memory stress test
+
+    :avocado: tags=memory
+    '''
 
     def setUp(self):
         sm = SoftwareManager()

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -32,7 +32,12 @@ from avocado.utils import distro
 
 
 class libhugetlbfs(Test):
+    '''
+    libhugetlbfs: libhugetlbfs is a library which provides easy
+    access to huge pages of memory. test to excersize libhugetlbfs library
 
+    :avocado: tags=memory,privileged
+    '''
     def setUp(self):
         # Check for root permission
         if os.geteuid() != 0:

--- a/memory/memcached.py
+++ b/memory/memcached.py
@@ -32,6 +32,8 @@ class Memcached(Test):
     stress tool which generates a load against memcached server.
     For more options on memcached:
     Refer - https://linux.die.net/man/1/memcached
+
+    :avocado: tags=memory,privileged
     """
 
     def setUp(self):

--- a/memory/memtester.py
+++ b/memory/memtester.py
@@ -30,6 +30,8 @@ class Memtester(Test):
     2.memtester must be run with  root  privileges  to  mlock(3)  its  pages.
       Testing  memory  without locking the pages in place is mostly pointless
       and slow.
+
+    :avocado: tags=memory,privileged
     """
 
     def setUp(self):

--- a/memory/stutter.py
+++ b/memory/stutter.py
@@ -28,6 +28,8 @@ class Stutter(Test):
 
     """
     stutter benchmark
+
+    :avocado: tags=memory,privileged
     """
 
     def setUp(self):

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -33,6 +33,8 @@ class Thp(Test):
     '''
     The test enables THP and stress the system using dd load
     and verifies whether THP has been allocated for usage or not
+
+    :avocado: tags=memory,privileged
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -37,6 +37,8 @@ class Thp_Defrag(Test):
     '''
     Defrag test enables THP and fragments the system memory using dd load
     and turns on THP defrag and checks whether defrag occured.
+
+    :avocado: tags=memory,privileged
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -33,6 +33,8 @@ class Thp_Swapping(Test):
 
     '''
     The test fills out the total avl memory and tries to swap the thp out.
+
+    :avocado: tags=memory,privileged
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")


### PR DESCRIPTION
Each tests have been tagged under its components for kernel and memory

missing doc strings are added for few tests along with tags

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>