### PR TITLE
Replace self.skip with self.cancel

### DIFF
--- a/cpu/cpupower.py
+++ b/cpu/cpupower.py
@@ -32,7 +32,7 @@ class cpupower(Test):
     """
     def setUp(self):
         if not os.path.exists('/sys/devices/system/cpu/cpu0/cpufreq'):
-            self.skip('sysfs directory for cpufreq is unavailable.')
+            self.cancel('sysfs directory for cpufreq is unavailable.')
         smm = SoftwareManager()
         detected_distro = distro.detect()
         kernel_ver = platform.uname()[2]
@@ -43,7 +43,7 @@ class cpupower(Test):
 
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip('%s is needed for the test to be run' % package)
+                self.cancel('%s is needed for the test to be run' % package)
 
     def test(self):
         self.error_count = 0

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -39,12 +39,12 @@ class PPC64Test(Test):
         """
         command = "uname -p"
         if 'ppc' not in process.system_output(command, ignore_status=True):
-            self.skip("Processor is not ppc64")
+            self.cancel("Processor is not ppc64")
         if SoftwareManager().check_installed("powerpc-utils") is False:
             if SoftwareManager().install("powerpc-utils") is False:
-                self.skip("powerpc-utils is not installing")
+                self.cancel("powerpc-utils is not installing")
         if "is not SMT capable" in process.system_output("ppc64_cpu --smt"):
-            self.skip("Machine is not SMT capable")
+            self.cancel("Machine is not SMT capable")
         self.curr_smt = process.system_output("ppc64_cpu --smt | awk -F'=' \
                 '{print $NF}' | awk '{print $NF}'", shell=True)
         self.smt_subcores = 0

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -59,30 +59,30 @@ class Sensors(Test):
         if d_distro.name == "Ubuntu":
             if not s_mg.check_installed("lm-sensors") and not s_mg.install(
                     "lm-sensors"):
-                self.skip('Need sensors to run the test')
+                self.cancel('Need sensors to run the test')
         elif d_distro.name == "SuSE":
             if not s_mg.check_installed("sensors") and not s_mg.install(
                     "sensors"):
-                self.skip('Need sensors to run the test')
+                self.cancel('Need sensors to run the test')
         else:
             if not s_mg.check_installed("lm_sensors") and not s_mg.install(
                     "lm_sensors"):
-                self.skip('Need sensors to run the test')
+                self.cancel('Need sensors to run the test')
         if d_distro.arch in ["ppc64", "ppc64le"]:
             if 'platform\t: PowerNV\n' not in cpu._get_cpu_info():
-                self.skip(
+                self.cancel(
                     'sensors test is applicable to bare-metal environment.')
 
             config_check = linux_modules.check_kernel_config(
                 'CONFIG_SENSORS_IBMPOWERNV')
             if config_check == 0:
-                self.skip('Config is not set')
+                self.cancel('Config is not set')
             elif config_check == 1:
                 if linux_modules.load_module('ibmpowernv'):
                     if linux_modules.module_is_loaded('ibmpowernv'):
                         self.log.info('Module Loaded Successfully')
                     else:
-                        self.skip('Module Loading Failed')
+                        self.cancel('Module Loading Failed')
             else:
                 self.log.info('Module is Built In')
 
@@ -97,7 +97,7 @@ class Sensors(Test):
         cmd = "yes | sudo sensors-detect"
         det_op = process.run(cmd, shell=True, ignore_status=True).stdout
         if 'no sensors were detected' in det_op:
-            self.skip('No sensors found to test !')
+            self.cancel('No sensors found to test !')
 
     def test(self):
         """

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -46,7 +46,7 @@ class Xfstests(Test):
         Source: git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
         """
         if process.system_output("df -T / | awk 'END {print $2}'", shell=True) == 'ext3':
-            self.skip('Test does not support ext3 root file system')
+            self.cancel('Test does not support ext3 root file system')
         sm = SoftwareManager()
 
         self.detected_distro = distro.detect()
@@ -54,9 +54,10 @@ class Xfstests(Test):
         packages = ['e2fsprogs', 'automake', 'gcc', 'quota', 'attr',
                     'make', 'xfsprogs', 'gawk']
         if 'Ubuntu' in self.detected_distro.name:
-            packages.extend(['xfslibs-dev', 'uuid-dev', 'libtool-bin', 'libuuid1',
-                             'libattr1-dev', 'libacl1-dev', 'libgdbm-dev',
-                             'uuid-runtime', 'libaio-dev', 'fio', 'dbench', 'btrfs-tools'])
+            packages.extend(
+                ['xfslibs-dev', 'uuid-dev', 'libtool-bin', 'libuuid1',
+                 'libattr1-dev', 'libacl1-dev', 'libgdbm-dev',
+                 'uuid-runtime', 'libaio-dev', 'fio', 'dbench', 'btrfs-tools'])
 
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
@@ -74,12 +75,12 @@ class Xfstests(Test):
             if self.detected_distro.name in ['centos', 'fedora']:
                 packages.extend(['fio', 'dbench'])
         else:
-            self.skip("test not supported in %s" % self.detected_distro.name)
+            self.cancel("test not supported in %s" % self.detected_distro.name)
 
         for package in packages:
             if not sm.check_installed(package) and not sm.install(package):
-                self.skip("Fail to install %s required for this test." %
-                          package)
+                self.cancel("Fail to install %s required for this test." %
+                            package)
 
         self.skip_dangerous = self.params.get('skip_dangerous', default=True)
         self.test_range = self.params.get('test_range', default=None)
@@ -90,7 +91,7 @@ class Xfstests(Test):
         self.dev_type = self.params.get('type', default='loop')
         self.fs_to_test = self.params.get('fs', default='ext4')
         if process.system('which mkfs.%s' % self.fs_to_test, ignore_status=True):
-            self.skip('Unknown filesystem %s' % self.fs_to_test)
+            self.cancel('Unknown filesystem %s' % self.fs_to_test)
         mount = True
         self.devices = []
         shutil.copyfile(os.path.join(self.datadir, 'local.config'),
@@ -107,7 +108,7 @@ class Xfstests(Test):
                     self.disk_mnt = ''
                     mount = False
                 else:
-                    self.skip('Need 15 GB to create loop devices')
+                    self.cancel('Need 15 GB to create loop devices')
             self._create_loop_device(base_disk, loop_size, mount)
         else:
             self.test_dev = self.params.get('disk_test', default=None)

--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -83,8 +83,8 @@ class Fsfuzzer(Test):
         fs_sup = process.system_output('%s %s' % (self._fsfuzz, ' --help'))
         match = re.search(r'%s' % self._args, fs_sup, re.M | re.I)
         if not match:
-            self.skip('File system ' + self._args +
-                      ' is unsupported in ' + detected_distro.name)
+            self.cancel('File system ' + self._args +
+                        ' is unsupported in ' + detected_distro.name)
 
     def test(self):
         '''

--- a/generic/criu.py
+++ b/generic/criu.py
@@ -36,7 +36,7 @@ class CRIU(Test):
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
         if dist.name not in ['rhel', 'redhat']:
-            self.skip('Currently test is supported only on RHEL')
+            self.cancel('Currently test is supported only on RHEL')
         for package in packages:
             if not sm.check_installed(package) and not sm.install(package):
                 self.error("Fail to install %s required for this test." %

--- a/generic/hwinfo.py
+++ b/generic/hwinfo.py
@@ -38,7 +38,7 @@ class Hwinfo(Test):
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
         if distro.detect().name in ['rhel', 'redhat']:
-            self.skip('Hwinfo not supported on RHEL')
+            self.cancel('Hwinfo not supported on RHEL')
         sm = SoftwareManager()
         if not sm.check_installed("hwinfo") and not sm.install("hwinfo"):
             self.error("Fail to install hwinfo required for this test.")

--- a/generic/openblas.py
+++ b/generic/openblas.py
@@ -39,7 +39,7 @@ class Openblas(Test):
             packages.append("gcc-gfortran")
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip(' %s is needed for the test to be run' % package)
+                self.cancel(' %s is needed for the test to be run' % package)
         url = "https://github.com/xianyi/OpenBLAS/archive/develop.zip"
         tarball = self.fetch_asset("OpenBLAS-develop.zip", locations=[url],
                                    expire='7d')

--- a/generic/ras.py
+++ b/generic/ras.py
@@ -43,7 +43,7 @@ class RASTools(Test):
     def setUp(self):
         architecture = os.uname()[4]
         if "ppc" not in architecture:
-            self.skip("supported only on Power platform")
+            self.cancel("supported only on Power platform")
         sm = SoftwareManager()
         for package in ("ppc64-diag", "powerpc-utils", "lsvpd", "ipmitool"):
             if not sm.check_installed(package) and not sm.install(package):

--- a/generic/ras_extended.py
+++ b/generic/ras_extended.py
@@ -40,12 +40,12 @@ class RASTools(Test):
 
     def setUp(self):
         if "ppc" not in os.uname()[4]:
-            self.skip("supported only on Power platform")
+            self.cancel("supported only on Power platform")
         sm = SoftwareManager()
         for package in ("ppc64-diag", "powerpc-utils", "lsvpd", "sysfsutils"):
             if not sm.check_installed(package) and not sm.install(package):
-                self.skip("Fail to install %s required for this"
-                          " test." % package)
+                self.cancel("Fail to install %s required for this"
+                            " test." % package)
 
     @skipIf(IS_POWER_NV or IS_KVM_GUEST, "This test is not supported on KVM guest or PowerNV platform")
     def test1_uesensor(self):
@@ -61,8 +61,9 @@ class RASTools(Test):
     def test1_serv_config(self):
         self.log.info("===============Executing serv_config tool test===="
                       "===========")
-        list = ['-l', '-b', '-s', '-r', '-m', '-d', '--remote-maint', '--surveillance',
-                '--reboot-policy', '--remote-pon', '-d --force']
+        list = [
+            '-l', '-b', '-s', '-r', '-m', '-d', '--remote-maint', '--surveillance',
+            '--reboot-policy', '--remote-pon', '-d --force']
         for list_item in list:
             cmd = "serv_config %s" % list_item
             self.run_cmd(cmd)
@@ -73,7 +74,8 @@ class RASTools(Test):
     def test1_rtas_event_decode(self):
         self.log.info("===============Executing rtas_event_decode tool test===="
                       "===========")
-        self.run_cmd("rtas_event_decode -w 500 -dv -n 2302 < %s" % os.path.join(self.datadir, 'rtas'))
+        self.run_cmd("rtas_event_decode -w 500 -dv -n 2302 < %s" %
+                     os.path.join(self.datadir, 'rtas'))
         if self.is_fail >= 1:
             self.fail("%s command(s) failed in rtas_event_decode tool "
                       "verification" % self.is_fail)
@@ -147,7 +149,8 @@ class RASTools(Test):
     def test1_bootlist(self):
         self.log.info("===============Executing bootlist tool test===="
                       "===========")
-        list = ['--help', '-m normal -r', '-m normal -o', '-m service -o', '-m both -o']
+        list = ['--help', '-m normal -r',
+                '-m normal -o', '-m service -o', '-m both -o']
         for list_item in list:
             cmd = "bootlist %s" % list_item
             self.run_cmd(cmd)
@@ -157,8 +160,10 @@ class RASTools(Test):
                                           "tail -1 | cut -d' ' -f1",
                                           shell=True).strip("12345")
         file_path = os.path.join(self.srcdir, 'file')
-        process.run("echo %s > %s" % (disk_name, file_path), ignore_status=True, sudo=True, shell=True)
-        process.run("echo %s >> %s" % (interface, file_path), ignore_status=True, sudo=True, shell=True)
+        process.run("echo %s > %s" %
+                    (disk_name, file_path), ignore_status=True, sudo=True, shell=True)
+        process.run("echo %s >> %s" %
+                    (interface, file_path), ignore_status=True, sudo=True, shell=True)
         self.run_cmd("bootlist -r -m both -f %s" % file_path)
         if self.is_fail >= 1:
             self.fail("%s command(s) failed in bootlist tool "
@@ -188,7 +193,8 @@ class RASTools(Test):
         self.log.info("===============Executing lsvpd tool test============="
                       "==")
         self.run_cmd("lsvpd")
-        list = ['--debug', '--version', '--mark', '--serial=STR', '--type=STR', '--list=raid']
+        list = ['--debug', '--version', '--mark',
+                '--serial=STR', '--type=STR', '--list=raid']
         for list_item in list:
             cmd = "lsvpd %s" % list_item
             self.run_cmd(cmd)

--- a/generic/servicelog.py
+++ b/generic/servicelog.py
@@ -27,7 +27,8 @@ from avocado.utils.software_manager import SoftwareManager
 class servicelog(Test):
 
     is_fail = 0
-    events_path = os.path.join(os.path.dirname(__file__), "servicelog.py.data", "rtas_events")
+    events_path = os.path.join(
+        os.path.dirname(__file__), "servicelog.py.data", "rtas_events")
 
     def run_cmd(self, cmd):
         if process.system(cmd, ignore_status=True, sudo=True, shell=True):
@@ -40,14 +41,14 @@ class servicelog(Test):
 
     def setUp(self):
         if "ppc" not in os.uname()[4]:
-            self.skip("supported only on Power platform")
+            self.cancel("supported only on Power platform")
         if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
-            self.skip("servicelog: is not supported on the PowerNV platform")
+            self.cancel("servicelog: is not supported on the PowerNV platform")
         smm = SoftwareManager()
         for package in ("servicelog", "ppc64-diag"):
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip("Fail to install %s required for this"
-                          " test." % package)
+                self.cancel("Fail to install %s required for this"
+                            " test." % package)
 
     def test_servicelog(self):
         """
@@ -55,17 +56,20 @@ class servicelog(Test):
         """
         self.log.info("1 - Cleaning servicelog...")
         self.run_cmd("servicelog_manage --truncate notify --force")
-        rtas_events = ["v6_fru_replacement", "v6_memory_info", "v6_power_error",
-                       "v6_power_error2", "v6_fw_predictive_error", "v3_fan_failure",
-                       "v6_dump_notification", "v6_platform_error2", "v6_eeh_info",
-                       "v6_cpu_guard", "v6_platform_info", "v6_surv_error"]
+        rtas_events = [
+            "v6_fru_replacement", "v6_memory_info", "v6_power_error",
+            "v6_power_error2", "v6_fw_predictive_error", "v3_fan_failure",
+            "v6_dump_notification", "v6_platform_error2", "v6_eeh_info",
+            "v6_cpu_guard", "v6_platform_info", "v6_surv_error"]
         for event in rtas_events:
             self.log.info("Starting test scenario for %s" % event)
             self.log.info("2 - Injecting event %s" % event)
             self.run_cmd("rtas_errd -d -f %s/%s" % (self.events_path, event))
-            self.log.info("3 - Checking if service log does return ppc64_rtas events")
+            self.log.info(
+                "3 - Checking if service log does return ppc64_rtas events")
             self.run_cmd("servicelog --type=ppc64_rtas")
-            self.log.info("4 - Checking if the event was dumped to /var/log/platform")
+            self.log.info(
+                "4 - Checking if the event was dumped to /var/log/platform")
             self.run_cmd("cat /var/log/platform")
         service_log_cmds = ["--help", "--version", "--query='id=1'", "--id=1",
                             "--query='severity>=$WARNING AND closed=0'", "--serviceable=yes",
@@ -98,7 +102,8 @@ class servicelog(Test):
                      "--repair_action=all --serviceable=all" % notify_script)
         self.log.info("===========3 - Injecting serviceable event ==="
                       "======")
-        self.run_cmd("/usr/sbin/rtas_errd -d -f %s/%s" % (self.events_path, event))
+        self.run_cmd("/usr/sbin/rtas_errd -d -f %s/%s" %
+                     (self.events_path, event))
         self.log.info("========4 - Checking registered notification tools =="
                       "======")
         self.run_cmd("servicelog_notify --list")
@@ -153,7 +158,8 @@ class servicelog(Test):
         self.run_cmd("rm -f /var/spool/mail/root")
         self.log.info("===========1 - Injecting serviceable event ==="
                       "======")
-        self.run_cmd("/usr/sbin/rtas_errd -d -f %s/%s" % (self.events_path, event))
+        self.run_cmd("/usr/sbin/rtas_errd -d -f %s/%s" %
+                     (self.events_path, event))
         self.log.info("===========2 - Checking if the event shows up"
                       " on servicelog_manage =========")
         self.run_cmd("servicelog --dump")
@@ -195,7 +201,8 @@ class servicelog(Test):
         self.run_cmd("rm -f /var/spool/mail/root")
         self.log.info("===========1 - Injecting event ==="
                       "======")
-        self.run_cmd("/usr/sbin/rtas_errd -d -f %s/%s" % (self.events_path, event))
+        self.run_cmd("/usr/sbin/rtas_errd -d -f %s/%s" %
+                     (self.events_path, event))
         self.log.info("===========2 - Checking servicelog before the "
                       "repair action =========")
         self.run_cmd("servicelog --type=ppc64_rtas -v")

--- a/generic/sosreport.py
+++ b/generic/sosreport.py
@@ -52,9 +52,9 @@ class sosreport_test(Test):
         elif dist.name in ['rhel', 'redhat']:
             sos_pkg = 'sos'
         else:
-            self.skip("sosreport is not supported on this distro ")
+            self.cancel("sosreport is not supported on this distro ")
         if sos_pkg and not sm.check_installed(sos_pkg) and not sm.install(sos_pkg):
-            self.skip("Package %s is missing and could not be installed" % sos_pkg)
+            self.cancel("Package %s is missing and could not be installed" % sos_pkg)
 
     def test(self):
         self.log.info(

--- a/io/disk/Avago_storage_adapter/avago3008.py
+++ b/io/disk/Avago_storage_adapter/avago3008.py
@@ -47,11 +47,11 @@ class Avago3008(Test):
         self.size = int(self.params.get('size', default='max'))
         self.tool_location = self.params.get('tool_location')
         if not self.disk:
-            self.skip("Please provide disks to run the tests")
+            self.cancel("Please provide disks to run the tests")
         self.number_of_disk = len(self.disk)
         if (not os.path.isfile(self.tool_location) or not
            os.access(self.tool_location, os.X_OK)):
-            self.skip()
+            self.cancel()
 
         self.dict_raid = {'raid0': [2, None, None], 'raid1': [2, 2, None],
                           'raid1e': [3, None, None],
@@ -59,7 +59,7 @@ class Avago3008(Test):
 
         self.value = self.dict_raid[self.raidlevel]
         if self.number_of_disk < self.value[0]:
-            self.skip("please give enough drives to perform the test")
+            self.cancel("please give enough drives to perform the test")
 
         if self.value[1] is not None:
             self.disk = self.disk[0:self.value[1]]

--- a/io/disk/Avago_storage_adapter/avago9361_vd.py
+++ b/io/disk/Avago_storage_adapter/avago9361_vd.py
@@ -31,8 +31,8 @@ class Avago9361(Test):
     """
     This class contains functions for VD operations
     """
-    def setUp(self):
 
+    def setUp(self):
         """
         All basic set up is done here
         """
@@ -47,11 +47,11 @@ class Avago9361(Test):
             "/", ":")
         self.add_disk = str(self.params.get('add_disk')).split(" ")
         if not self.hotspare:
-            self.skip("Hotspare test needs a drive to create/test hotspare")
+            self.cancel("Hotspare test needs a drive to create/test hotspare")
         if not self.on_off:
-            self.skip("Online/Offline test needs a drive to operate on")
+            self.cancel("Online/Offline test needs a drive to operate on")
         if not self.disk:
-            self.skip("Please provide disk to perform VD operations")
+            self.cancel("Please provide disk to perform VD operations")
         self.dict_raid = {'r0': [1, None], 'r1': [2, 'Multiple2'],
                           'r5': [3, None], 'r6': [3, None],
                           'r00': [4, 'Multiple2'], 'r10': [4, 'Multiple2'],
@@ -59,8 +59,8 @@ class Avago9361(Test):
         self.value = self.dict_raid[self.raid_level]
 
         if len(self.disk) < self.value[0]:
-            self.skip("Please give enough number of drives to create %s"
-                      % self.raid_level)
+            self.cancel("Please give enough number of drives to create %s"
+                        % self.raid_level)
         if self.value[1] is not None:
             multiple = int(self.value[1].split("Multiple")[-1])
             self.disk = self.disk[:len(self.disk) -
@@ -73,11 +73,11 @@ class Avago9361(Test):
         if self.raid_level == 'r0':
             for test in ['cc', 'offline', 'rebuild', 'ghs_dhs']:
                 if test in str(self.name):
-                    self.skip("Test not applicable for Raid0")
+                    self.cancel("Test not applicable for Raid0")
         if 'migrate' in str(self.name):
             self.raid_disk = self.disk.pop()
             if self.raid_level != 'r0':
-                self.skip("Script runs for raid0")
+                self.cancel("Script runs for raid0")
         self.write_policy = ['WT', 'WB', 'AWB']
         self.read_policy = ['nora', 'ra']
         self.io_policy = ['direct', 'cached']
@@ -85,7 +85,6 @@ class Avago9361(Test):
         self.state = ['start', 'stop', 'start', 'pause', 'resume']
 
     def test_createall(self):
-
         """
         Function to create different raid level
         """
@@ -97,7 +96,6 @@ class Avago9361(Test):
                         self.vd_delete()
 
     def test_maxvd(self):
-
         """
         Function to create max VD
         """
@@ -117,7 +115,6 @@ class Avago9361(Test):
             self.vd_delete()
 
     def test_init(self):
-
         """
         Test case to start Fast and Full init on VD
         """
@@ -126,7 +123,6 @@ class Avago9361(Test):
         self.vd_delete()
 
     def test_cc(self):
-
         """
         Function to do consistency operations on VD
         """
@@ -136,7 +132,6 @@ class Avago9361(Test):
         self.vd_delete()
 
     def test_jbod(self):
-
         """
         Function to format a drive to JBOD
         """
@@ -152,7 +147,6 @@ class Avago9361(Test):
         self.check_pass(cmd, "Failed to set JBOD drives to good")
 
     def test_online_offline(self):
-
         """
         Test to run drive Online/Offline
         """
@@ -164,7 +158,6 @@ class Avago9361(Test):
         self.vd_delete()
 
     def test_ghs_dhs(self):
-
         """
         Test to create Global hot spare and Dedicated hot spare
         """
@@ -184,7 +177,6 @@ class Avago9361(Test):
         self.vd_delete()
 
     def copyback_state(self, state):
-
         """
         Helper function to run copyback test
         """
@@ -199,7 +191,6 @@ class Avago9361(Test):
         self.check_pass(cmd, "Failed to %s copyback" % state)
 
     def copyback_operation(self):
-
         """
         Function to run copyback operations
         """
@@ -211,7 +202,6 @@ class Avago9361(Test):
         self.sleep_function(cmd)
 
     def test_rebuild(self):
-
         """
         Function to handle rebuild scenario
         """
@@ -221,7 +211,6 @@ class Avago9361(Test):
         self.vd_delete()
 
     def test_patrolread(self):
-
         """
         Function to handle PR operations
         """
@@ -230,7 +219,6 @@ class Avago9361(Test):
         self.vd_delete()
 
     def test_migrate(self):
-
         """
         Test case to execute Raid Migration
         """
@@ -246,7 +234,6 @@ class Avago9361(Test):
         self.vd_delete()
 
     def rebuild(self, perform, disk=None):
-
         """
         Helper function of all types of rebuild operations
         """
@@ -264,7 +251,6 @@ class Avago9361(Test):
             self.sleep_function(cmd)
 
     def sleep_function(self, cmd):
-
         """
         Helper function for scrit to wait, till the background operation is
         complete
@@ -273,7 +259,6 @@ class Avago9361(Test):
             time.sleep(30)
 
     def rebuild_state(self, state):
-
         """
         Helper function for all CC operations
         """
@@ -283,7 +268,6 @@ class Avago9361(Test):
         time.sleep(10)
 
     def set_online_offline(self, state):
-
         """
         Helper function to set drives online and offline
         """
@@ -292,7 +276,6 @@ class Avago9361(Test):
         self.check_pass(cmd, "Failed to set drive to %s state" % state)
 
     def jbod_show(self):
-
         """
         Helper function to show JBOD details
         """
@@ -300,7 +283,6 @@ class Avago9361(Test):
         self.check_pass(cmd, "Failed to show the JBOD status")
 
     def vd_details(self):
-
         """
         Function to display the VD details
         """
@@ -308,7 +290,6 @@ class Avago9361(Test):
         self.check_pass(cmd, "Failed to display VD configuration")
 
     def vd_delete(self):
-
         """
         Function to delete the VD
         """
@@ -316,7 +297,6 @@ class Avago9361(Test):
         self.check_pass(cmd, "Failed to delete VD")
 
     def vd_create(self, write, read, iopolicy, stripe):
-
         """
         Function to create a VD
         """
@@ -336,7 +316,6 @@ class Avago9361(Test):
         self.vd_details()
 
     def check_pass(self, cmd, errmsg):
-
         """
         Helper function to check, if the cmd is passed or failed
         """
@@ -344,7 +323,6 @@ class Avago9361(Test):
             self.fail(errmsg)
 
     def showprogress(self, cmd):
-
         """
         Helper function to see progress of a given/specified operation
         """
@@ -357,7 +335,6 @@ class Avago9361(Test):
                     return True
 
     def cc_operations(self):
-
         """
         Helper function CC operations
         """
@@ -368,7 +345,6 @@ class Avago9361(Test):
         self.sleep_function(cmd)
 
     def cc_state(self, state):
-
         """
         Helper function for all CC operations
         """
@@ -381,7 +357,6 @@ class Avago9361(Test):
         time.sleep(10)
 
     def pr_operations(self):
-
         """
         Helper function for PR operations
         """
@@ -391,7 +366,6 @@ class Avago9361(Test):
             self.check_pass(cmd, "Failed to show the PR progress")
 
     def pr_state(self, state):
-
         """
         Helper function for all PR operatoins
         """
@@ -400,7 +374,6 @@ class Avago9361(Test):
         time.sleep(10)
 
     def full_init(self):
-
         """
         Helper function to start Fast/Full init
         """
@@ -411,7 +384,6 @@ class Avago9361(Test):
         self.sleep_function(cmd)
 
     def change_vdpolicy(self, write, read, iopolicy):
-
         """
         Helper function to change the VD policy
         """

--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -41,7 +41,7 @@ class Arcconftest(Test):
         """
         smm = SoftwareManager()
         if not smm.check_installed("lsscsi") and not smm.install("lsscsi"):
-            self.skip("Unable to install lsscsi")
+            self.cancel("Unable to install lsscsi")
         self.crtl_no = self.params.get('crtl_no')
         self.pci_id = self.params.get('pci_id', default="").split(",")
         self.http_path = self.params.get('http_path')
@@ -64,9 +64,9 @@ class Arcconftest(Test):
         if self.crtl_no is '' or self.pci_id is '' or self.tool_name \
            is '' or self.http_path is '' or self.firmware_path\
            is '' or self.firmware_name is '':
-            self.skip(" please ensure yaml parameters are not empty")
+            self.cancel(" please ensure yaml parameters are not empty")
         elif self.comp(self.pci_id, pci_id_formatted) == 1:
-            self.skip(" Test skipped!!, PMC controller not available")
+            self.cancel(" Test skipped!!, PMC controller not available")
 
         http_repo1 = "%s%s" % (self.firmware_path, self.firmware_name)
         self.repo1 = self.fetch_asset(http_repo1, expire='10d')
@@ -86,7 +86,7 @@ class Arcconftest(Test):
                 self.repo = self.fetch_asset(http_repo, expire='10d')
                 cmd = "rpm -ivh %s" % self.repo
             if process.system(cmd, ignore_status=True, shell=True) != 0:
-                self.skip("Unable to install arcconf")
+                self.cancel("Unable to install arcconf")
 
     def test(self):
         """

--- a/io/disk/arcconf/arcconf_drive_oper.py
+++ b/io/disk/arcconf/arcconf_drive_oper.py
@@ -41,7 +41,7 @@ class Arcconftest(Test):
         """
         smm = SoftwareManager()
         if not smm.check_installed("lsscsi") and not smm.install("lsscsi"):
-            self.skip("Unable to install lsscsi")
+            self.cancel("Unable to install lsscsi")
         self.crtl_no = self.params.get('crtl_no')
         self.channel_no = self.params.get('channel_no')
         self.disk_no = self.params.get('disk_no', default="").split(",")
@@ -67,10 +67,10 @@ class Arcconftest(Test):
         if self.crtl_no is '' or self.channel_no is '' or self.disk_no is \
            '' or self.pci_id is '' or len(self.disk_no) <= 1 or \
            self.tool_name is '' or self.http_path is '':
-            self.skip(" please ensure yaml parameters are not empty or \
+            self.cancel(" please ensure yaml parameters are not empty or \
                        the total device should be more than 1")
         elif self.comp(self.pci_id, pci_id_formatted) == 1:
-            self.skip(" Test skipped!!, PMC controller not available")
+            self.cancel(" Test skipped!!, PMC controller not available")
 
         detected_distro = distro.detect()
         if not smm.check_installed("Arcconf"):
@@ -83,7 +83,7 @@ class Arcconftest(Test):
                 self.repo = self.fetch_asset(http_repo, expire='10d')
                 cmd = "rpm -ivh %s" % self.repo
             if process.system(cmd, ignore_status=True, shell=True) == 0:
-                self.skip("Unable to install arcconf")
+                self.cancel("Unable to install arcconf")
 
         cmd = "lsscsi  | grep LogicalDrv | awk \'{print $7}\'"
         self.os_drive = self.cmdop_list(cmd)
@@ -93,7 +93,7 @@ class Arcconftest(Test):
             cmd = "df -h /boot | grep %s" % self.os_drive
             if process.system(cmd, timeout=300, ignore_status=True,
                               shell=True) == 0:
-                self.skip("Test Skipped!! OS disk requested for removal")
+                self.cancel("Test Skipped!! OS disk requested for removal")
 
             self.log.info("Deleting the default logical drive %s" %
                           (self.logicaldrive))

--- a/io/disk/arcconf/arcconf_migration.py
+++ b/io/disk/arcconf/arcconf_migration.py
@@ -42,7 +42,7 @@ class Arcconftest(Test):
         """
         smm = SoftwareManager()
         if not smm.check_installed("lsscsi") and not smm.install("lsscsi"):
-            self.skip("Unable to install lsscsi")
+            self.cancel("Unable to install lsscsi")
         self.crtl_no = self.params.get('crtl_no')
         self.channel_no = self.params.get('channel_no')
         self.disk_no = self.params.get('disk_no', default="").split(",")
@@ -76,14 +76,14 @@ class Arcconftest(Test):
            '' or self.initial_raid is '' or self.migrate_raid is '' or \
            self.disk_initial is '' or self.disk_migrated is '' or \
            len(self.initial_raid) > 1 or self.migration_sleep is '':
-            self.skip(" please ensure yaml parameters are not empty or \
+            self.cancel(" please ensure yaml parameters are not empty or \
                        the total device should be more than 1")
         elif self.comp(self.pci_id, pci_id_formatted) == 1:
-            self.skip(" Test skipped!!, PMC controller not available")
+            self.cancel(" Test skipped!!, PMC controller not available")
 
         if len(self.disk_no) < int(self.disk_initial) or \
            len(self.disk_no) < int(self.disk_migrated):
-            self.skip("Cannot Migrate, please check the prerequisite")
+            self.cancel("Cannot Migrate, please check the prerequisite")
 
         detected_distro = distro.detect()
         if not smm.check_installed("Arcconf"):
@@ -96,7 +96,7 @@ class Arcconftest(Test):
                 self.repo = self.fetch_asset(http_repo, expire='10d')
                 cmd = "rpm -ivh %s" % self.repo
             if process.system(cmd, ignore_status=True, shell=True) == 0:
-                self.skip("Unable to install arcconf")
+                self.cancel("Unable to install arcconf")
 
         self.os_drive = self.cmdop_list("OS")
 
@@ -238,7 +238,7 @@ class Arcconftest(Test):
             self.check_pass(cmd, "Failed to cleanup Logical drive")
         else:
             if cond == 0:
-                self.skip("Test Skipped!! OS disk requested for removal")
+                self.cancel("Test Skipped!! OS disk requested for removal")
 
 
 if __name__ == "__main__":

--- a/io/disk/arcconf/arcconf_raid_oper.py
+++ b/io/disk/arcconf/arcconf_raid_oper.py
@@ -44,7 +44,7 @@ class Arcconftest(Test):
         """
         smm = SoftwareManager()
         if not smm.check_installed("lsscsi") and not smm.install("lsscsi"):
-            self.skip("Unable to install lsscsi")
+            self.cancel("Unable to install lsscsi")
         self.crtl_no = self.params.get('crtl_no')
         self.channel_no = self.params.get('channel_no')
         self.disk_no = self.params.get('disk_no', default="").split(",")
@@ -71,10 +71,10 @@ class Arcconftest(Test):
            '' or self.pci_id is '' or len(self.disk_no) <= 1 or \
            self.fs_type is '' or self.mount_point is '' or self.tool_name \
            is '' or self.http_path is '':
-            self.skip(" Test skipped!!, please ensure yaml parameters are \
+            self.cancel(" Test skipped!!, please ensure yaml parameters are \
             entered or disk count is more than 1")
         elif self.comp(self.pci_id, pci_id_formatted) == 1:
-            self.skip(" Test skipped!!, PMC controller not available")
+            self.cancel(" Test skipped!!, PMC controller not available")
 
         detected_distro = distro.detect()
         if not smm.check_installed("Arcconf"):
@@ -87,7 +87,7 @@ class Arcconftest(Test):
                 self.repo = self.fetch_asset(http_repo, expire='10d')
                 cmd = "rpm -ivh %s" % self.repo
             if process.run(cmd, shell=True) == 0:
-                self.skip("Unable to install arcconf")
+                self.cancel("Unable to install arcconf")
 
         cmd = "lsscsi  | grep LogicalDrv | awk \'{print $7}\'"
         self.os_drive = self.cmdop_list(cmd)
@@ -97,7 +97,7 @@ class Arcconftest(Test):
             cmd = "df -h /boot | grep %s" % self.os_drive
             if process.system(cmd, timeout=300, ignore_status=True,
                               shell=True) == 0:
-                self.skip("Test Skipped!! OS disk requested for removal")
+                self.cancel("Test Skipped!! OS disk requested for removal")
 
             self.log.info("Deleting the default logical drive %s" %
                           (self.logicaldrive))

--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -53,7 +53,7 @@ class Bonnie(Test):
             if distro.detect().name == 'Ubuntu':
                 if not smm.check_installed("btrfs-tools") and not \
                         smm.install("btrfs-tools"):
-                    self.skip('btrfs-tools is needed for the test to be run')
+                    self.cancel('btrfs-tools is needed for the test to be run')
 
         self.disk = self.params.get('disk', default=None)
         self.scratch_dir = self.params.get('dir', default=self.srcdir)

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -58,7 +58,7 @@ class Disktest(Test):
         """
         softm = SoftwareManager()
         if not softm.check_installed("gcc") and not softm.install("gcc"):
-            self.skip('Gcc is needed for the test to be run')
+            self.cancel('Gcc is needed for the test to be run')
         # Log of all the disktest processes
         self.disk_log = os.path.abspath(os.path.join(self.outputdir,
                                                      "log.txt"))
@@ -87,8 +87,8 @@ class Disktest(Test):
         if self.chunk_mb == 0:
             self.chunk_mb = 1
         if memory_mb > self.chunk_mb:
-            self.skip("Chunk size has to be greater or equal to RAM size. "
-                      "(%s > %s)" % (self.chunk_mb, memory_mb))
+            self.cancel("Chunk size has to be greater or equal to RAM size. "
+                        "(%s > %s)" % (self.chunk_mb, memory_mb))
 
         gigabytes = self.params.get('gigabytes', default=None)
         if gigabytes is None:
@@ -99,8 +99,8 @@ class Disktest(Test):
 
         self.no_chunks = 1024 * gigabytes / self.chunk_mb
         if self.no_chunks == 0:
-            self.skip("Free disk space is lower than chunk size (%s, %s)"
-                      % (1024 * gigabytes, self.chunk_mb))
+            self.cancel("Free disk space is lower than chunk size (%s, %s)"
+                        % (1024 * gigabytes, self.chunk_mb))
 
         self.log.info("Test will use %s chunks %sMB each in %sMB RAM using %s "
                       "GB of disk space on %s disks (%s).", self.no_chunks,

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -62,7 +62,7 @@ class FioTest(Test):
             if distro.detect().name == 'Ubuntu':
                 if not smm.check_installed("btrfs-tools") and not \
                         smm.install("btrfs-tools"):
-                    self.skip('btrfs-tools is needed for the test to be run')
+                    self.cancel('btrfs-tools is needed for the test to be run')
 
         if self.disk is not None:
             self.part_obj = Partition(self.disk, mountpoint=self.dir)

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -59,7 +59,7 @@ class fs_mark(Test):
             if distro.detect().name == 'Ubuntu':
                 if not smm.check_installed("btrfs-tools") and not \
                         smm.install("btrfs-tools"):
-                    self.skip('btrfs-tools is needed for the test to be run')
+                    self.cancel('btrfs-tools is needed for the test to be run')
 
     def test(self):
         """

--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -43,16 +43,16 @@ class HtxTest(Test):
         Build 'HTX'.
         """
         if 'ppc64' not in process.system_output('uname -a', shell=True):
-            self.skip("Platform does not supports")
+            self.cancel("Platform does not supports")
 
         if distro.detect().name != 'Ubuntu':
-            self.skip("Distro does not support")
+            self.cancel("Distro does not support")
 
         self.mdt_file = self.params.get('mdt_file', default='mdt.hd')
         self.time_limit = int(self.params.get('time_limit', default=2)) * 3600
         self.block_devices = self.params.get('disk', default=None)
         if self.block_devices is None:
-            self.skip("Needs the block devices to run the HTX")
+            self.cancel("Needs the block devices to run the HTX")
         self.block_device = []
         for disk in self.block_devices.split():
             self.block_device.append(disk.rsplit("/")[-1])
@@ -63,7 +63,7 @@ class HtxTest(Test):
         smm = SoftwareManager()
         for pkg in packages:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("Can not install %s" % pkg)
+                self.cancel("Can not install %s" % pkg)
 
         url = "https://github.com/open-power/HTX/archive/master.zip"
         tarball = self.fetch_asset("htx.zip", locations=[url], expire='7d')
@@ -77,7 +77,7 @@ class HtxTest(Test):
         process.run('dpkg --purge htxubuntu')
         process.run('dpkg -i htxubuntu.deb')
         if not os.path.exists("/usr/lpp/htx/mdt/%s" % self.mdt_file):
-            self.skip("MDT file %s not found" % self.mdt_file)
+            self.cancel("MDT file %s not found" % self.mdt_file)
         self.smt = self.params.get('smt_change', default=False)
         if self.smt:
             self.max_smt_value = 8

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -61,7 +61,7 @@ class Lvsetup(Test):
             else:
                 pkg = 'btrfs-progs'
         if pkg and not smm.check_installed(pkg) and not smm.install(pkg):
-            self.skip("Package %s is missing and could not be installed" % pkg)
+            self.cancel("Package %s is missing and could not be installed" % pkg)
         lv_snapshot_name = self.params.get(
             'lv_snapshot_name', default='avocado_sn')
         self.lv_snapshot_size = self.params.get(
@@ -74,13 +74,13 @@ class Lvsetup(Test):
             'ramdisk_sparse_filename', default='virtual_hdd')
 
         if lv_utils.vg_check(vg_name):
-            self.skip('Volume group %s already exists' % vg_name)
+            self.cancel('Volume group %s already exists' % vg_name)
         self.vg_name = vg_name
         if lv_utils.lv_check(vg_name, lv_name):
-            self.skip('Logical Volume %s already exists' % lv_name)
+            self.cancel('Logical Volume %s already exists' % lv_name)
         self.lv_name = lv_name
         if lv_utils.lv_check(vg_name, lv_snapshot_name):
-            self.skip('Snapshot %s already exists' % lv_snapshot_name)
+            self.cancel('Snapshot %s already exists' % lv_snapshot_name)
         self.mount_loc = self.srcdir
         self.lv_snapshot_name = lv_snapshot_name
 

--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -55,7 +55,7 @@ class MultipathTest(Test):
 
         smm = SoftwareManager()
         if not smm.check_installed(pkg_name) and not smm.install(pkg_name):
-            self.skip("Can not install %s" % pkg_name)
+            self.cancel("Can not install %s" % pkg_name)
 
         # Create service object
         self.mpath_svc = service.SpecificServiceManager(svc_name)
@@ -64,7 +64,7 @@ class MultipathTest(Test):
         # Check if multipath devices are present in system
         self.wwids = multipath.get_multipath_wwids()
         if self.wwids == ['']:
-            self.skip("No Multipath Devices")
+            self.cancel("No Multipath Devices")
 
         # Take a backup of current config file
         self.mpath_file = "/etc/multipath.conf"

--- a/io/disk/smartctl.py
+++ b/io/disk/smartctl.py
@@ -46,16 +46,16 @@ class SmartctlTest(Test):
         if not smm.check_installed("smartctl"):
             self.log.info("smartctl should be installed prior to the test")
             if smm.install("smartmontools") is False:
-                self.skip("Unable to install smartctl")
+                self.cancel("Unable to install smartctl")
         self.option = self.params.get('option')
         self.disks = self.params.get('disk')
         if self.disks is '' or self.option is '':
-            self.skip(" Test skipped!!, please ensure Block device and \
+            self.cancel(" Test skipped!!, please ensure Block device and \
             options are specified in yaml file")
         cmd = "df -h /boot | grep %s" % (self.disks)
         if process.system(cmd, timeout=300, ignore_status=True,
                           shell=True) == 0:
-            self.skip(" Skipping it's OS disk")
+            self.cancel(" Skipping it's OS disk")
 
     def test(self):
         """

--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -48,7 +48,7 @@ class SoftwareRaid(Test):
         if not smm.check_installed("mdadm"):
             print "Mdadm must be installed before continuing the test"
             if SoftwareManager().install("mdadm") is False:
-                self.skip("Unable to install mdadm")
+                self.cancel("Unable to install mdadm")
         cmd = "mdadm -V"
         self.check_pass(cmd, "Unable to get mdadm version")
         self.disk = self.params.get('disk', default='').strip(" ")

--- a/io/disk/ssd/blkdiscard.py
+++ b/io/disk/ssd/blkdiscard.py
@@ -38,11 +38,11 @@ class Blkdiscard(Test):
         """
         smm = SoftwareManager()
         if not smm.check_installed("util-linux"):
-            self.skip("blkdiscard is needed for the test to be run")
+            self.cancel("blkdiscard is needed for the test to be run")
         self.disk = self.params.get('disk', default='/dev/nvme0n1')
         cmd = 'ls %s' % self.disk
         if process.system(cmd, ignore_status=True) is not 0:
-            self.skip("%s does not exist" % self.disk)
+            self.cancel("%s does not exist" % self.disk)
         cmd = "blkdiscard -V"
         process.run(cmd)
 

--- a/io/disk/ssd/ezfiotest.py
+++ b/io/disk/ssd/ezfiotest.py
@@ -47,7 +47,7 @@ class EzfioTest(Test):
         self.disk = self.params.get('disk', default='/dev/nvme0n1')
         cmd = 'ls %s' % self.disk
         if process.system(cmd, ignore_status=True) is not 0:
-            self.skip("%s does not exist" % self.disk)
+            self.cancel("%s does not exist" % self.disk)
         fio_path = os.path.join(self.teststmpdir, 'fio')
         fio_link = 'https://github.com/axboe/fio.git'
         git.get_repo(fio_link, destination_dir=fio_path)

--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -43,11 +43,11 @@ class NVMeTest(Test):
         self.device = self.params.get('device', default='/dev/nvme0')
         cmd = 'ls %s' % self.device
         if process.system(cmd, ignore_status=True) is not 0:
-            self.skip("%s does not exist" % self.device)
+            self.cancel("%s does not exist" % self.device)
         smm = SoftwareManager()
         if not smm.check_installed("nvme-cli") and not \
                 smm.install("nvme-cli"):
-            self.skip('nvme-cli is needed for the test to be run')
+            self.cancel('nvme-cli is needed for the test to be run')
         self.id_ns = self.create_namespace()
         self.log.info(self.id_ns)
         cmd = "nvme id-ns %s | grep 'in use' | awk '{print $5}' | \
@@ -58,7 +58,7 @@ class NVMeTest(Test):
         self.lba = process.system_output(cmd, shell=True).strip('\n')
         self.firmware_url = self.params.get('firmware_url', default='')
         if 'firmware_upgrade' in str(self.name) and not self.firmware_url:
-            self.skip("firmware url not gien")
+            self.cancel("firmware url not gien")
 
     def get_firmware_version(self):
         """

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -51,7 +51,7 @@ class Tiobench(Test):
                 packages.extend(['btrfs-tools'])
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip("%s package required for this test." % package)
+                self.cancel("%s package required for this test." % package)
         locations = ["https://github.com/mkuoppal/tiobench/archive/master.zip"]
         tarball = self.fetch_asset("tiobench.zip", locations=locations)
         archive.extract(tarball, self.srcdir)

--- a/io/driver/driver_bind_test.py
+++ b/io/driver/driver_bind_test.py
@@ -44,7 +44,7 @@ class DriverBindTest(Test):
         self.slot = self.params.get('pci_device', default='0001:01:00.0')
         self.driver = pci.get_driver(self.slot)
         if not self.driver:
-            self.skip("%s does not exist" % self.slot)
+            self.cancel("%s does not exist" % self.slot)
 
     def test(self):
         """

--- a/io/genwqe/genwqetest.py
+++ b/io/genwqe/genwqetest.py
@@ -45,11 +45,11 @@ class GenWQETest(Test):
         url = "http://corpus.canterbury.ac.nz/resources/cantrbry.tar.gz"
         self.url = self.params.get('test_tar_url', default=url)
         if not os.path.isdir("/sys/class/genwqe/genwqe%s_card/" % self.card):
-            self.skip("Device %s does not exist" % self.card)
+            self.cancel("Device %s does not exist" % self.card)
         smm = SoftwareManager()
         for pkg in ['genwqe-tools', 'genwqe-zlib']:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip('%s is needed for the test to be run' % pkg)
+                self.cancel('%s is needed for the test to be run' % pkg)
         self.test_tar = download.get_file(self.url, "cantrbry.tar.gz")
         self.files_used = [self.test_tar]
         self.dirs_used = []

--- a/io/net/Network_config.py
+++ b/io/net/Network_config.py
@@ -38,11 +38,11 @@ class NetworkconfigTest(Test):
         sm = SoftwareManager()
         for pkg in ["ethtool", "net-tools"]:
             if not sm.check_installed(pkg) and not sm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
 
     def test_networkconfig(self):
         '''

--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -54,21 +54,21 @@ class Bonding(Test):
             depends.extend(["openssh", "iputils"])
         for pkg in depends:
             if not sm.check_installed(pkg) and not sm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.user = self.params.get("user_name", default="root")
         self.host_interfaces = self.params.get("host_interfaces",
                                                default="").split(",")
         if not self.host_interfaces:
-            self.skip("user should specify host interfaces")
+            self.cancel("user should specify host interfaces")
         self.peer_interfaces = self.params.get("peer_interfaces",
                                                default="").split(",")
         for self.host_interface in self.host_interfaces:
             if self.host_interface not in interfaces:
-                self.skip("interface is not available")
+                self.cancel("interface is not available")
         self.peer_first_ipinterface = self.params.get("peer_ip", default="")
         if not self.peer_interfaces or self.peer_first_ipinterface == "":
-            self.skip("peer machine should available")
+            self.cancel("peer machine should available")
         msg = "ip addr show  | grep %s | grep -oE '[^ ]+$'"\
               % self.peer_first_ipinterface
         cmd = "ssh %s@%s %s" % (self.user, self.peer_first_ipinterface, msg)
@@ -80,7 +80,7 @@ class Bonding(Test):
         self.bond_status = "cat /proc/net/bonding/%s" % self.bond_name
         self.mode = self.params.get("bonding_mode", default="")
         if self.mode == "":
-            self.skip("test skipped because mode not specified")
+            self.cancel("test skipped because mode not specified")
         self.host_ips = []
         self.peer_ips = [self.peer_first_ipinterface]
         for val in self.host_interfaces:

--- a/io/net/infiniband/ib_bw_perf.py
+++ b/io/net/infiniband/ib_bw_perf.py
@@ -51,15 +51,15 @@ class Bandwidth_Perf(Test):
             pkgs.append('openssh-clients')
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.flag = self.params.get("ext_flag", default="0")
         self.IF = self.params.get("interface", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
         if self.IF not in interfaces:
-            self.skip("%s interface is not available" % self.IF)
+            self.cancel("%s interface is not available" % self.IF)
         if self.peer_ip == "":
-            self.skip("%s peer machine is not available" % self.peer_ip)
+            self.cancel("%s peer machine is not available" % self.peer_ip)
         self.CA = self.params.get("CA_NAME", default="mlx4_0")
         self.PORT = self.params.get("PORT_NUM", default="1")
         self.PEER_CA = self.params.get("PEERCA", default="mlx4_0")
@@ -67,7 +67,7 @@ class Bandwidth_Perf(Test):
         self.to = self.params.get("timeout", default="600")
         self.tool_name = self.params.get("tool")
         if self.tool_name == "":
-            self.skip("should specify tool name")
+            self.cancel("should specify tool name")
         self.log.info("test with %s" % (self.tool_name))
         self.test_op = self.params.get("test_opt", default="").split(",")
         self.ext_test_op = self.params.get("ext_opt", default="").split(",")
@@ -84,10 +84,10 @@ class Bandwidth_Perf(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.peer_ip, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
     def bandwidthperf_exec(self, arg1, arg2, arg3):
         '''

--- a/io/net/infiniband/ib_latency_perf.py
+++ b/io/net/infiniband/ib_latency_perf.py
@@ -49,15 +49,15 @@ class Latency_Perf(Test):
             pkgs.append('openssh-clients')
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.flag = self.params.get("ext_flag", default="0")
         self.IF = self.params.get("interface", default="")
         self.PEER_IP = self.params.get("peer_ip", default="")
         if self.IF not in interfaces:
-            self.skip("%s interface is not available" % self.IF)
+            self.cancel("%s interface is not available" % self.IF)
         if self.PEER_IP == "":
-            self.skip("%s peer machine is not available" % self.PEER_IP)
+            self.cancel("%s peer machine is not available" % self.PEER_IP)
         self.CA = self.params.get("CA_NAME", default="mlx4_0")
         self.PORT = self.params.get("PORT_NUM", default="1")
         self.PEER_CA = self.params.get("PEERCA", default="mlx4_0")
@@ -65,7 +65,7 @@ class Latency_Perf(Test):
         self.to = self.params.get("timeout", default="600")
         self.tool_name = self.params.get("tool", default="")
         if self.tool_name == "":
-            self.skip("should specify tool name")
+            self.cancel("should specify tool name")
         self.log.info("test with %s" % (self.tool_name))
         self.test_op = self.params.get("test_opt", default="").split(",")
         self.ext_test_op = self.params.get("ext_opt", default="").split(",")
@@ -81,10 +81,10 @@ class Latency_Perf(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.PEER_IP, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
     def latencyperf_exec(self, arg1, arg2, arg3):
         '''

--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -43,9 +43,9 @@ class pingpong(Test):
         self.IF = self.params.get("interface", default="")
         self.PEER_IP = self.params.get("peer_ip", default="")
         if self.IF not in interfaces:
-            self.skip("%s interface is not available" % self.IF)
+            self.cancel("%s interface is not available" % self.IF)
         if self.PEER_IP == "":
-            self.skip("%s peer machine is not available" % self.PEER_IP)
+            self.cancel("%s peer machine is not available" % self.PEER_IP)
         self.CA = self.params.get("CA_NAME", default="mlx4_0")
         self.GID = int(self.params.get("GID_NUM", default="0"))
         self.PORT = int(self.params.get("PORT_NUM", default="1"))
@@ -73,17 +73,17 @@ class pingpong(Test):
             pkgs.extend(['libibverbs', 'openssh-clients'])
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" %
                           (cmd, self.PEER_IP, cmd),
                           ignore_status=True,
                           shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         if process.system("ibstat", shell=True, ignore_status=True) != 0:
-            self.skip("infiniband adaptors not available")
+            self.cancel("infiniband adaptors not available")
 
     def pingpong_exec(self, arg1, arg2, arg3):
         '''

--- a/io/net/infiniband/ip_over_ib.py
+++ b/io/net/infiniband/ip_over_ib.py
@@ -50,14 +50,14 @@ class ip_over_ib(Test):
             pkgs.append('openssh-clients')
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.IF = self.params.get("interface", default="")
         self.PEER_IP = self.params.get("peer_ip", default="")
         if self.IF not in interfaces:
-            self.skip("%s interface is not available" % self.IF)
+            self.cancel("%s interface is not available" % self.IF)
         if self.PEER_IP == "":
-            self.skip("%s peer machine is not available" % self.PEER_IP)
+            self.cancel("%s peer machine is not available" % self.PEER_IP)
         self.to = self.params.get("timeout", default="600")
         self.IPERF_RUN = self.params.get("IPERF_RUN", default="0")
         self.NETSERVER_RUN = self.params.get("NETSERVER_RUN", default="0")
@@ -75,10 +75,10 @@ class ip_over_ib(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.PEER_IP, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
         tarball = self.fetch_asset('ftp://ftp.netperf.org/netperf/'
                                    'netperf-2.7.0.tar.bz2', expire='7d')
@@ -87,7 +87,7 @@ class ip_over_ib(Test):
         self.neperf = os.path.join(self.netperf, version)
         tmp = "scp -r %s root@%s:" % (self.neperf, self.PEER_IP)
         if process.system(tmp, shell=True, ignore_status=True) != 0:
-            self.skip("unable to copy the netperf into peer machine")
+            self.cancel("unable to copy the netperf into peer machine")
         tmp = "cd /root/netperf-2.7.0;./configure ppc64le;make"
         cmd = "ssh %s \"%s\"" % (self.PEER_IP, tmp)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
@@ -105,7 +105,7 @@ class ip_over_ib(Test):
         self.ipe = os.path.join(self.iper, 'iperf-master')
         tmp = "scp -r %s root@%s:" % (self.ipe, self.PEER_IP)
         if process.system(tmp, shell=True, ignore_status=True) != 0:
-            self.skip("unable to copy the iperf into peer machine")
+            self.cancel("unable to copy the iperf into peer machine")
         tmp = "cd /root/iperf-master;./configure;make"
         cmd = "ssh %s \"%s\"" % (self.PEER_IP, tmp)
         if process.system(cmd, shell=True, ignore_status=True) != 0:

--- a/io/net/infiniband/mckey.py
+++ b/io/net/infiniband/mckey.py
@@ -41,13 +41,13 @@ class Mckey(Test):
         self.ext = self.params.get("ext_option", default="None")
         self.flag = self.params.get("ext_flag", default="0")
         if self.basic == "None" and self.ext == "None":
-            self.skip("No option given")
+            self.cancel("No option given")
         if self.flag == "1" and self.ext != "None":
             self.option = self.ext
         else:
             self.option = self.basic
         if process.system("ibstat", shell=True, ignore_status=True) != 0:
-            self.skip("MOFED is not installed. Skipping")
+            self.cancel("MOFED is not installed. Skipping")
         pkgs = []
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
@@ -59,14 +59,14 @@ class Mckey(Test):
         smm = SoftwareManager()
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("Not able to install %s" % pkg)
+                self.cancel("Not able to install %s" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         if self.peer_ip == "":
-            self.skip("%s peer machine is not available" % self.peer_ip)
+            self.cancel("%s peer machine is not available" % self.peer_ip)
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
         self.ip_val = self.local_ip.split(".")[-1]
@@ -87,10 +87,10 @@ class Mckey(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.peer_ip, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
     def test(self):
         """

--- a/io/net/infiniband/mofed_install_test.py
+++ b/io/net/infiniband/mofed_install_test.py
@@ -38,7 +38,7 @@ class MOFEDInstallTest(Test):
         """
         self.iso_location = self.params.get('iso_location', default='')
         if self.iso_location is '':
-            self.skip("No ISO location given")
+            self.cancel("No ISO location given")
         self.option = self.params.get('option', default='')
         self.uninstall_flag = self.params.get('uninstall', default=True)
         self.iso = self.fetch_asset(self.iso_location, expire='10d')

--- a/io/net/infiniband/ping6.py
+++ b/io/net/infiniband/ping6.py
@@ -41,13 +41,13 @@ class Ping6(Test):
         self.ext = self.params.get("ext_option", default="None")
         self.flag = self.params.get("ext_flag", default="0")
         if self.basic == "None" and self.ext == "None":
-            self.skip("No option given")
+            self.cancel("No option given")
         if self.flag == "1" and self.ext != "None":
             self.option = self.ext
         else:
             self.option = self.basic
         if process.system("ibstat", shell=True, ignore_status=True) != 0:
-            self.skip("MOFED is not installed. Skipping")
+            self.cancel("MOFED is not installed. Skipping")
         pkgs = []
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
@@ -59,16 +59,16 @@ class Ping6(Test):
         smm = SoftwareManager()
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("Not able to install %s" % pkg)
+                self.cancel("Not able to install %s" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface", default="")
         self.peer_iface = self.params.get("peer_interface", default="")
         self.ipv6_peer = self.params.get("peer_ipv6", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         if self.peer_ip == "":
-            self.skip("%s peer machine is not available" % self.peer_ip)
+            self.cancel("%s peer machine is not available" % self.peer_ip)
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
         if 10 in netifaces.ifaddresses(self.iface):
@@ -95,10 +95,10 @@ class Ping6(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.peer_ip, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
     def test(self):
         """

--- a/io/net/infiniband/rping.py
+++ b/io/net/infiniband/rping.py
@@ -41,13 +41,13 @@ class Rping(Test):
         self.ext = self.params.get("ext_option", default="None")
         self.flag = self.params.get("ext_flag", default="0")
         if self.basic == "None" and self.ext == "None":
-            self.skip("No option given")
+            self.cancel("No option given")
         if self.flag == "1" and self.ext != "None":
             self.option = self.ext
         else:
             self.option = self.basic
         if process.system("ibstat", shell=True, ignore_status=True) != 0:
-            self.skip("MOFED is not installed. Skipping")
+            self.cancel("MOFED is not installed. Skipping")
         pkgs = []
         detected_distro = distro.detect()
         smm = SoftwareManager()
@@ -59,15 +59,15 @@ class Rping(Test):
             pkgs.extend(["openssh-clients", "iputils"])
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("Not able to install %s" % pkg)
+                self.cancel("Not able to install %s" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
         self.ipv6_peer = self.params.get("peer_ipv6", default="")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         if self.peer_ip == "":
-            self.skip("%s peer machine is not available" % self.peer_ip)
+            self.cancel("%s peer machine is not available" % self.peer_ip)
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
         self.option = self.option.replace("peer_ipv6", self.ipv6_peer)
@@ -87,10 +87,10 @@ class Rping(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.peer_ip, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
     def test(self):
         """

--- a/io/net/infiniband/ucmatose.py
+++ b/io/net/infiniband/ucmatose.py
@@ -41,13 +41,13 @@ class Ucmatose(Test):
         self.ext = self.params.get("ext_option", default="None")
         self.flag = self.params.get("ext_flag", default="0")
         if self.basic == "None" and self.ext == "None":
-            self.skip("No option given")
+            self.cancel("No option given")
         if self.flag == "1" and self.ext != "None":
             self.option = self.ext
         else:
             self.option = self.basic
         if process.system("ibstat", shell=True, ignore_status=True) != 0:
-            self.skip("MOFED is not installed. Skipping")
+            self.cancel("MOFED is not installed. Skipping")
         detected_distro = distro.detect()
         pkgs = []
         smm = SoftwareManager()
@@ -59,15 +59,15 @@ class Ucmatose(Test):
             pkgs.extend(["openssh-clients", "iputils"])
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("Not able to install %s" % pkg)
+                self.cancel("Not able to install %s" % pkg)
         interfaces = netifaces.interfaces()
         self.flag = self.params.get("ext_flag", default="0")
         self.iface = self.params.get("interface", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         if self.peer_ip == "":
-            self.skip("%s peer machine is not available" % self.peer_ip)
+            self.cancel("%s peer machine is not available" % self.peer_ip)
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
 
@@ -83,10 +83,10 @@ class Ucmatose(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.peer_ip, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
     def test(self):
         """

--- a/io/net/infiniband/udaddy.py
+++ b/io/net/infiniband/udaddy.py
@@ -41,13 +41,13 @@ class Udady(Test):
         self.ext = self.params.get("ext_option", default="None")
         self.flag = self.params.get("ext_flag", default="0")
         if self.basic == "None" and self.ext == "None":
-            self.skip("No option given")
+            self.cancel("No option given")
         if self.flag == "1" and self.ext != "None":
             self.option = self.ext
         else:
             self.option = self.basic
         if process.system("ibstat", shell=True, ignore_status=True) != 0:
-            self.skip("MOFED is not installed. Skipping")
+            self.cancel("MOFED is not installed. Skipping")
         detected_distro = distro.detect()
         pkgs = []
         smm = SoftwareManager()
@@ -59,14 +59,14 @@ class Udady(Test):
             pkgs.extend(["openssh-clients", "iputils"])
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("Not able to install %s" % pkg)
+                self.cancel("Not able to install %s" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         if self.peer_ip == "":
-            self.skip("%s peer machine is not available" % self.peer_ip)
+            self.cancel("%s peer machine is not available" % self.peer_ip)
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
 
@@ -82,10 +82,10 @@ class Udady(Test):
         elif detected_distro.name == "centos":
             cmd = "service iptables stop"
         else:
-            self.skip("Distro not supported")
+            self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" % (cmd, self.peer_ip, cmd),
                           ignore_status=True, shell=True) != 0:
-            self.skip("Unable to disable firewall")
+            self.cancel("Unable to disable firewall")
 
     def test(self):
         """

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -47,25 +47,25 @@ class ReceiveMulticastTest(Test):
             pkgs.extend(["openssh-clients", "iputils"])
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         self.peer = self.params.get("peer_ip", default="")
         if self.peer == "":
-            self.skip("peer ip should specify in input")
+            self.cancel("peer ip should specify in input")
         self.user = self.params.get("user_name", default="root")
         msg = "ip addr show  | grep %s | grep -oE '[^ ]+$'" % self.peer
         cmd = "ssh %s@%s \"%s\"" % (self.user, self.peer, msg)
         self.peerif = process.system_output(cmd, shell=True).strip()
         if self.peerif == "":
-            self.skip("unable to get peer interface")
+            self.cancel("unable to get peer interface")
         cmd = "ip -f inet -o addr show %s | awk '{print $4}' | cut -d / -f1"\
               % self.iface
         self.local_ip = process.system_output(cmd, shell=True).strip()
         if self.local_ip == "":
-            self.skip("unable to get local ip")
+            self.cancel("unable to get local ip")
 
     def test_multicast(self):
         '''

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -34,20 +34,20 @@ class MultiportStress(Test):
         self.host_interfaces = self.params.get("host_interfaces",
                                                default="").split(",")
         if not self.host_interfaces:
-            self.skip("user should specify host interfaces")
+            self.cancel("user should specify host interfaces")
         smm = SoftwareManager()
         if distro.detect().name == 'Ubuntu':
             pkg = 'iputils-ping'
         else:
             pkg = 'iputils'
         if not smm.check_installed(pkg) and not smm.install(pkg):
-            self.skip("Package %s is needed to test" % pkg)
+            self.cancel("Package %s is needed to test" % pkg)
         self.peer_ips = self.params.get("peer_ips",
                                         default="").split(",")
         interfaces = netifaces.interfaces()
         for self.host_interface in self.host_interfaces:
             if self.host_interface not in interfaces:
-                self.skip("interface is not available")
+                self.cancel("interface is not available")
         self.count = self.params.get("count", default="1000")
 
     def test_multiport_stress(self):

--- a/io/net/net_data.py
+++ b/io/net/net_data.py
@@ -50,11 +50,11 @@ class NetDataTest(Test):
             pkgs.extend(["openssh-clients", "iputils"])
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         interface = self.params.get("interface")
         if interface not in interfaces:
-            self.skip("%s interface is not available" % interface)
+            self.cancel("%s interface is not available" % interface)
         mtu_list = self.params.get("size_val", default=1500)
         self.mtu_list = mtu_list.split()
         self.interface = interface

--- a/io/net/net_tools.py
+++ b/io/net/net_tools.py
@@ -112,10 +112,10 @@ class Ifconfig(Test):
 
     def setUp(self):
         if process.system("ping -c 5 -w 5 localhost", ignore_status=True):
-            self.skip("Unable to ping localhost")
+            self.cancel("Unable to ping localhost")
         self.lo_up = True
         if "lo:1" in process.system_output("ifconfig", env={"LANG": "C"}):
-            self.skip("alias for an loopback interface is configured")
+            self.cancel("alias for an loopback interface is configured")
         self.alias = None
         install_dependencies()
         self.ipv6 = False
@@ -187,7 +187,7 @@ class Arp(Test):
         interface_out = process.system_output("ip route show default",
                                               env={"LANG": "C"})
         if "default via" not in interface_out:
-            self.skip("No active interface with deafult gateway configured")
+            self.cancel("No active interface with deafult gateway configured")
         install_dependencies()
         search_obj = re.search(r"^default via\s+(\S+)\s+dev\s+(\w+)",
                                interface_out)
@@ -314,11 +314,11 @@ class Iptunnel(Test):
         self.tunnel = None
         ret = process.system_output("ps -aef", env={"LANG": "C"})
         if 'dhclient' in ret:
-            self.skip("Test not supported on systems running dhclient")
+            self.cancel("Test not supported on systems running dhclient")
         install_dependencies()
         pre = process.system_output("iptunnel show")
         if "sit1" in pre:
-            self.skip("'sit1' already configured in iptunnel: %s" % pre)
+            self.cancel("'sit1' already configured in iptunnel: %s" % pre)
 
     @avocado.fail_on(process.CmdError)
     def test_loopback_sit(self):

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -53,14 +53,14 @@ class Netperf(Test):
             pkgs.append('openssh-clients')
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         if self.peer_ip == "":
-            self.skip("%s peer machine is not available" % self.peer_ip)
+            self.cancel("%s peer machine is not available" % self.peer_ip)
         self.peer_user = self.params.get("peer_user_name", default="root")
         self.timeout = self.params.get("timeout", default="600")
         self.netperf_run = self.params.get("NETSERVER_RUN", default="0")
@@ -75,7 +75,7 @@ class Netperf(Test):
         cmd = "scp -r %s %s@%s:/tmp/" % (self.neperf, self.peer_user,
                                          self.peer_ip)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
-            self.skip("unable to copy the netperf into peer machine")
+            self.cancel("unable to copy the netperf into peer machine")
         tmp = "cd /tmp/%s;./configure ppc64le;make" % self.version
         cmd = "ssh %s@%s \"%s\"" % (self.peer_user, self.peer_ip, tmp)
         if process.system(cmd, shell=True, ignore_status=True) != 0:

--- a/io/net/pktgen.py
+++ b/io/net/pktgen.py
@@ -99,13 +99,13 @@ class Pktgen(Test):
         interfaces = process.system_output(
             "ip -o link show | awk -F': ' '{print $2}'", shell=True)
         if self.eth not in interfaces:
-            self.skip("%s is not available" % self.eth)
+            self.cancel("%s is not available" % self.eth)
 
     def ping_test(self):
         ping_response = process.system("ping -c 1 " + self.dst_ip, shell=True)
         self.log.info("Ping response value is %d" % ping_response)
         if ping_response != 0:
-            self.skip("Host not reachable")
+            self.cancel("Host not reachable")
 
 
 if __name__ == "__main__":

--- a/io/net/scp_ssh.py
+++ b/io/net/scp_ssh.py
@@ -52,14 +52,14 @@ class ScpTest(Test):
             pkgs.extend(["openssh-clients", "iputils"])
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface")
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
         self.peer = self.params.get("peer_ip", default="")
         if self.peer == "":
-            self.skip("peer ip should specify in input")
+            self.cancel("peer ip should specify in input")
         self.user = self.params.get("user_name", default="root")
 
     def test_ping(self):

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -39,12 +39,12 @@ class TcpdumpTest(Test):
         # Check if interface exists in the system
         interfaces = netifaces.interfaces()
         if self.iface not in interfaces:
-            self.skip("%s interface is not available" % self.iface)
+            self.cancel("%s interface is not available" % self.iface)
 
         # Install needed packages
         smm = SoftwareManager()
         if not smm.check_installed("tcpdump") and not smm.install("tcpdump"):
-            self.skip("Can not install tcpdump")
+            self.cancel("Can not install tcpdump")
 
     def test(self):
         """

--- a/io/pci/PowerVMEEH.py
+++ b/io/pci/PowerVMEEH.py
@@ -58,7 +58,7 @@ class PowerVMEEH(Test):
         output = genio.read_file("/sys/kernel/debug/powerpc/eeh_enable")\
             .strip()
         if output != '0x1':
-            self.skip("EEH is not enabled, please enable via FSP")
+            self.cancel("EEH is not enabled, please enable via FSP")
             sys.exit(1)
         self.max_freeze = int(self.params.get('max_freeze', default='1'))
         cmd = "echo %d > /sys/kernel/debug/powerpc/eeh_max_freezes"\

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -42,7 +42,7 @@ class PCIHotPlugTest(Test):
         """
         cmd = "uname -p"
         if 'ppc' not in process.system_output(cmd, ignore_status=True):
-            self.skip("Processor is not ppc64")
+            self.cancel("Processor is not ppc64")
         if cpu._list_matches(cpu._get_cpu_info(), 'pSeries'):
             for mdl in ['rpaphp', 'rpadlpar_io']:
                 if not linux_modules.module_is_loaded(mdl):
@@ -53,7 +53,7 @@ class PCIHotPlugTest(Test):
         self.return_code = 0
         self.device = self.params.get('pci_device', default=' ')
         if not os.path.isdir('/sys/bus/pci/devices/%s' % self.device):
-            self.skip("PCI device given does not exist")
+            self.cancel("PCI device given does not exist")
         devspec = genio.read_file("/sys/bus/pci/devices/%s/devspec"
                                   % self.device)
         self.slot = genio.read_file("/proc/device-tree/%s/ibm,loc-code"
@@ -61,9 +61,9 @@ class PCIHotPlugTest(Test):
         self.slot = re.match(r'((\w+)[\.])+(\w+)-P(\d+)-C(\d+)|Slot(\d+)',
                              self.slot).group()
         if not os.path.isdir('/sys/bus/pci/slots/%s' % self.slot):
-            self.skip("%s Slot not available" % self.slot)
+            self.cancel("%s Slot not available" % self.slot)
         if not os.path.exists('/sys/bus/pci/slots/%s/power' % self.slot):
-            self.skip("%s Slot does not support hotplug" % self.slot)
+            self.cancel("%s Slot does not support hotplug" % self.slot)
 
     def test(self):
         """

--- a/io/pci/pci_info_lsvpd.py
+++ b/io/pci/pci_info_lsvpd.py
@@ -37,7 +37,7 @@ class PciLsvpdInfo(Test):
         smm = SoftwareManager()
         for pkg in ["lsvpd"]:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip("%s package is need to test" % pkg)
+                self.cancel("%s package is need to test" % pkg)
         if process.system("vpdupdate", ignore_status=True, shell=True):
             self.fail("VPD Update fails")
 

--- a/memory/dma_memtest.py
+++ b/memory/dma_memtest.py
@@ -81,9 +81,9 @@ class DmaMemtest(Test):
         # Verify if space is available in disk
         disk_free_mb = (disk.freespace(self.tmpdir) / 1024) / 1024
         if (disk_free_mb < est_size * self.sim_cps):
-            self.skip("Space not available to extract the %s linux tars\n"
-                      "Mount and Use other partitions in dir_to_extract arg "
-                      "to run the test" % self.sim_cps)
+            self.cancel("Space not available to extract the %s linux tars\n"
+                        "Mount and Use other partitions in dir_to_extract arg "
+                        "to run the test" % self.sim_cps)
 
     @staticmethod
     def get_sim_cps(est_size):

--- a/memory/memcached.py
+++ b/memory/memcached.py
@@ -49,7 +49,7 @@ class Memcached(Test):
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
         if detected_distro.name not in ['Ubuntu', 'rhel', 'redhat']:
-            self.skip('Test Not applicable')
+            self.cancel('Test Not applicable')
 
         if detected_distro.name == "Ubuntu":
             deps = ['memcached', 'libmemcached-tools']

--- a/memory/memtester.py
+++ b/memory/memtester.py
@@ -42,7 +42,7 @@ class Memtester(Test):
 
         for pkg in ['gcc', 'make']:
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.skip('%s is needed for the test to be run' % pkg)
+                self.cancel('%s is needed for the test to be run' % pkg)
         tarball = self.fetch_asset('memtester.zip', locations=[
                                    'https://github.com/jnavila/'
                                    'memtester/archive/master.zip'],

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -61,7 +61,7 @@ class Thp_Swapping(Test):
             tmpfs_size = mem_free
 
         if swap <= 0:
-            self.skip("Swap is not enabled in the system")
+            self.cancel("Swap is not enabled in the system")
 
         if not os.path.ismount(self.mem_path):
             if not os.path.isdir(self.mem_path):

--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -42,7 +42,7 @@ class test_eliminate_domain_suffix(Test):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         if 'ppc' not in process.system_output("uname -p", ignore_status=True):
-            self.skip("Processor is not ppc64")
+            self.cancel("Processor is not ppc64")
         deps = ['gcc', 'make']
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['linux-tools-common', 'linux-tools-%s'
@@ -50,11 +50,11 @@ class test_eliminate_domain_suffix(Test):
         elif detected_distro.name in ['redhat', 'SuSE', 'fedora', 'centos']:
             deps.extend(['perf'])
         else:
-            self.skip("Install the package for perf supported by %s"
-                      % detected_distro.name)
+            self.cancel("Install the package for perf supported by %s"
+                        % detected_distro.name)
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip('%s is needed for the test to be run' % package)
+                self.cancel('%s is needed for the test to be run' % package)
         self.nfail = 0
         self.perf_args = "perf stat -v -C 0 -e"
         self.perf_stat = "%s hv_24x7/HPM_0THRD_NON_IDLE_CCYC" % self.perf_args

--- a/perf/perf_events_test.py
+++ b/perf/perf_events_test.py
@@ -48,11 +48,11 @@ class Perf_subsystem(Test):
         elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'redhat']:
             deps.extend(['perf'])
         else:
-            self.skip("Install the package for perf supported by %s"
-                      % detected_distro.name)
+            self.cancel("Install the package for perf supported by %s"
+                        % detected_distro.name)
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip('%s is needed for the test to be run' % package)
+                self.cancel('%s is needed for the test to be run' % package)
 
     def test(self):
         '''

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -46,11 +46,11 @@ class Perftool(Test):
         elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos', 'redhat']:
             deps.extend(['perf'])
         else:
-            self.skip("Install the package for perf supported\
+            self.cancel("Install the package for perf supported\
                       by %s" % detected_distro.name)
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip('%s is needed for the test to be run' % package)
+                self.cancel('%s is needed for the test to be run' % package)
 
         locations = ["https://github.com/rfmvh/perftool-testsuite/archive/"
                      "master.zip"]

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -61,7 +61,7 @@ class GCC(Test):
 
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip(
+                self.cancel(
                     "Failed to install %s required for this test." % package)
         tarball = self.fetch_asset('gcc.zip', locations=[
                                    'https://github.com/gcc-mirror/gcc/archive'

--- a/toolchain/libvecpf.py
+++ b/toolchain/libvecpf.py
@@ -38,7 +38,7 @@ class Libvecpf(Test):
         http://github.com/Libvecpf/libvecpf.git
         """
         if not distro.detect().name.lower() == 'ubuntu':
-            self.skip('Upsupported OS %s' % distro.detect().name.lower())
+            self.cancel('Upsupported OS %s' % distro.detect().name.lower())
 
         smm = SoftwareManager()
         for package in ['gcc', 'make']:

--- a/toolchain/supportconfig.py
+++ b/toolchain/supportconfig.py
@@ -41,11 +41,11 @@ class Supportconfig(Test):
         sm = SoftwareManager()
 
         if "SuSE" not in distro.detect().name:
-            self.skip("supportconfig is supported on the SuSE Distro only.")
+            self.cancel("supportconfig is supported on the SuSE Distro only.")
 
         if not sm.check_installed(
                 "supportutils") and not sm.install("supportutils"):
-            self.skip("Failed to install supportutils required for this test.")
+            self.cancel("Failed to install supportutils required for this test.")
 
     def test_supportconfig_options(self):
         """

--- a/toolchain/systemtap.py
+++ b/toolchain/systemtap.py
@@ -33,13 +33,14 @@ class Systemtap(Test):
     """
     This test runs upstream systemtap tests
     """
+
     def setUp(self):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         # TODO: Add debs for Ubuntu.
         if detected_distro.name == "Ubuntu":
-            self.skip("Skip the test  for ubuntu as debs needs to be"
-                      "added in packages")
+            self.cancel("Skip the test  for ubuntu as debs needs to be"
+                        "added in packages")
         packages = ['make', 'gcc', 'systemtap', 'systemtap-runtime',
                     'elfutils', 'kernel-devel', 'dejagnu']
         # FIXME: "redhat" as the distro name for RHEL is deprecated
@@ -55,7 +56,7 @@ class Systemtap(Test):
                              'libelf-devel'])
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip(' %s is needed for the test to be run' % package)
+                self.cancel(' %s is needed for the test to be run' % package)
         git.get_repo('git://sourceware.org/git/systemtap.git',
                      destination_dir=self.srcdir)
         os.chdir(self.srcdir)
@@ -71,8 +72,8 @@ class Systemtap(Test):
                                        " }'", ignore_status=True, sudo=True,
                                        shell=True)
         if script_result != 0:
-            self.skip("simple systemtap test failed,"
-                      "kernel debuginfo package may be missing")
+            self.cancel("simple systemtap test failed,"
+                        "kernel debuginfo package may be missing")
 
     def test(self):
         make_option = self.params.get('make_option', default='installcheck')

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -46,7 +46,7 @@ class Valgrind(Test):
             deps.extend(['gcc-c++'])
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
-                self.skip('%s is needed for the test to be run' % package)
+                self.cancel('%s is needed for the test to be run' % package)
         tarball = self.fetch_asset(
             "http://valgrind.org/downloads/valgrind-3.12.0.tar.bz2")
         archive.extract(tarball, self.srcdir)


### PR DESCRIPTION
As of Avocado version 52.0,a new type of tests status CANCEL
is enabled, so use self.cancel to set the test status instead
of self.skip which is deprecated.

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>