### PR TITLE
Add background traffic to tcpdump

### DIFF
--- a/io/net/tcpdump.py.data/tcpdump.yaml
+++ b/io/net/tcpdump.py.data/tcpdump.yaml
@@ -1,4 +1,5 @@
 interface: net0
+peer_ip:
 count: 100
 # interface packet drop accepted in percentage (eg 10 for 10%)
 drop_accepted: 10


### PR DESCRIPTION
tcpdump would wait for some network traffic to be in place, else
it waits forever.
Fixed that by generating a background traffic on the interface.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>