### PR TITLE
Improvements for HTX on NIC Interface Stress test.

### DIFF
--- a/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+++ b/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
@@ -1,7 +1,7 @@
 mdt_file: 'net.mdt'
 host_ip: x.xx.xxx.xx
 peer_ip: x.xx.xxx.xy
-peer_test_ip: xxx.x.x.xx
+peer_password: "*******"
 peer_user: "root"
 host_interfaces: "enp1s0f0,enp1s0f1"
 peer_interfaces: "enp3s0f0,enp3s0f1"


### PR DESCRIPTION
HTX Changes the test interface ips before starting the
test, due to which the commands to be executed in peer
will no more functional.
So this patch has below improvements.

1. Falling back to password based ssh to the public IP
which is not going to be effected by HTX.
2. Imprved pingum test work flow. If N/W interfaces are
in different topology N/W ping test takes some time.
So running the pingum test in a loop for 10 times until
it passes.
3. As HTX changing test interface ips, we need to restore
back to original ips. So in tearDown handling this.

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>