### PR TITLE
Removed the namespace tests from nvmetest

### DIFF
--- a/io/disk/ssd/nvmetest.py.data/README.txt
+++ b/io/disk/ssd/nvmetest.py.data/README.txt
@@ -1,6 +1,7 @@
 NVM-Express user space tooling for Linux, which handles NVMe devices.
 
 This Suite creates namespace, and performs the following tests:
+* firmware upgrade
 * format namespace
 * read
 * write
@@ -11,7 +12,10 @@ This Suite creates namespace, and performs the following tests:
 * dsm
 * reset
 * subsystem reset
+* reset_sysfs
+
 This test needs to be run as root.
 Inputs Needed (in multiplexer file):
 ------------------------------------
-Devices -       NVMe devices
+Device      -       NVMe device
+Namespace   -       Namespace in the NVMe device

--- a/io/disk/ssd/nvmetest.py.data/nvmetest.yaml
+++ b/io/disk/ssd/nvmetest.py.data/nvmetest.yaml
@@ -1,4 +1,5 @@
 Devices: !mux
     device1:
         device: /dev/nvme0
+        namespace: 1
         firmware_url:


### PR DESCRIPTION
Namespace related tests were not completely implemented in nvmetest
as multiple namespaces were not supported on older controllers.
Also, a newer selftest for nvme-cli is added which does namespace
tests.
So, removing them from nvmetest.
Also, a small pylint fix is included.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>