### PR TITLE
fix: change the distro and warn key words

### DIFF
--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -47,7 +47,7 @@ class test_eliminate_domain_suffix(Test):
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['linux-tools-common', 'linux-tools-%s'
                          % platform.uname()[2]])
-        elif detected_distro.name in ['redhat', 'SuSE', 'fedora', 'centos']:
+        elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos']:
             deps.extend(['perf'])
         else:
             self.cancel("Install the package for perf supported by %s"

--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -68,8 +68,8 @@ class test_generic_events(Test):
             raw_code = event_code.split('=', 2)[1].rstrip()
             if raw_code != val:
                 nfail += 1
-                self.warn('FAIL : Expected value is %s but got'
-                          '%s' % (val, raw_code))
+                self.log.warn('FAIL : Expected value is %s but got'
+                              '%s' % (val, raw_code))
             self.log.info('FILE in %s is %s' % (dir, file))
             self.log.info('PASS : Expected value: %s and got'
                           '%s' % (val, raw_code))


### PR DESCRIPTION
perf_24x7_hardware_counters : changed 'redhat' to 'rhel'
perf_genericevents: self.warn to self.log.warn

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>