### PR TITLE
Improvements for fc port bounce testcase.

### DIFF
--- a/io/net/port_bounce.py.data/port_bounce.yaml
+++ b/io/net/port_bounce.py.data/port_bounce.yaml
@@ -4,6 +4,7 @@ switch_name: "x.xx.xx.xxx"
 userid: "admin"
 password: "**********"
 port_ids: "10,11"
+pci_bus_addrs: "0000:03:00.1,0000:03:00.0"
 sbt: 5
 lbt: 255
 count: 2


### PR DESCRIPTION
Currently testcase just verifies port enable/disable
status only in fc switch after portbounce.

This patch adds the facility to verify the port toggle
status in Host also. By checking in below sysfs path

cat /sys/class/fc_host/host1/port_state
Online

Signed-off-by: Pridhiviraj Paidipeddi <ppaidipe@linux.vnet.ibm.com>