### PR TITLE
Fix lscfg command with proper option

### DIFF
--- a/generic/ras_extended.py
+++ b/generic/ras_extended.py
@@ -217,7 +217,11 @@ class RASTools(Test):
         self.log.info("===============Executing lscfg tool test============="
                       "==")
         self.run_cmd("lscfg")
-        list = ['--debug', '--version', '-p', '-lcpu']
+        list = ['--debug', '--version', '-p']
+        device = process.system_output('lscfg', shell=True).splitlines()[-1]
+        if device.startswith("+"):
+            list.append("-l%s" % device.split(" ")[1])
+
         for list_item in list:
             cmd = "lscfg %s" % list_item
             self.run_cmd(cmd)


### PR DESCRIPTION
lscfg command failed with a non-generic option. This patch fixes the option to be generic across machines.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>