### PR TITLE
Add with-nvmf to mofed install options

### DIFF
--- a/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
+++ b/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
@@ -46,4 +46,6 @@ Options: !mux
         option: -c docs/conf/ofed-basic.conf -n docs/conf/ofed_net.conf-example
     add-kernel-support:
         option: --add-kernel-support --skip-repo --force --kmp
+    add-kernel-support_with-nvmf:
+        option: --skip-distro-check --add-kernel-support --skip-repo --with-nvmf
         uninstall: False


### PR DESCRIPTION
Add with-nvmf to mofed install options.
This option tries to install mofed with nvme over fabrics support,
if the mofed version has support for it.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>