### PR TITLE
Adding FIO_perf test scenarios for KVM CI, adding 6 test cases: 6 yaml files and 6 job files. Multiple yaml are need because profilers need to be run for each test case individually.

### DIFF
--- a/io/disk/fiotest.py.data/fio-rand-RW.job
+++ b/io/disk/fiotest.py.data/fio-rand-RW.job
@@ -1,0 +1,12 @@
+[global]
+name=fio-rand-RW
+filename=fio-rand-RW
+rw=randrw
+rwmixread=60
+rwmixwrite=40
+bs=4K
+direct=0
+numjobs=1
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-rand-read.job
+++ b/io/disk/fiotest.py.data/fio-rand-read.job
@@ -1,0 +1,10 @@
+[global]
+name=fio-rand-read
+filename=fio-rand-read
+rw=randread
+bs=4K
+direct=0
+numjobs=1
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-rand-write.job
+++ b/io/disk/fiotest.py.data/fio-rand-write.job
@@ -1,0 +1,10 @@
+[global]
+name=fio-rand-write
+filename=fio-rand-write
+rw=randwrite
+bs=4K
+direct=0
+numjobs=1
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-seq-RW.job
+++ b/io/disk/fiotest.py.data/fio-seq-RW.job
@@ -1,0 +1,12 @@
+[global]
+name=fio-seq-RW
+filename=fio-seq-RW
+rw=rw
+rwmixread=60
+rwmixwrite=40
+bs=256K
+direct=0
+numjobs=1
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-seq-read.job
+++ b/io/disk/fiotest.py.data/fio-seq-read.job
@@ -1,0 +1,10 @@
+[global]
+name=fio-seq-reads
+filename=fio-seq-reads
+rw=read
+bs=256K
+direct=0
+numjobs=1
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-seq-write.job
+++ b/io/disk/fiotest.py.data/fio-seq-write.job
@@ -1,0 +1,10 @@
+[global]
+name=fio-seq-write
+filename=fio-seq-write
+rw=write
+bs=256K
+direct=0
+numjobs=1
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio_randRW.yaml
+++ b/io/disk/fiotest.py.data/fio_randRW.yaml
@@ -1,0 +1,8 @@
+parameters:
+    disk: '/dev/sdd'
+    dir: '/mnt'
+    fio_job: 'fio-rand-RW.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_randread.yaml
+++ b/io/disk/fiotest.py.data/fio_randread.yaml
@@ -1,0 +1,8 @@
+parameters:
+    disk: '/dev/sdd'
+    dir: '/mnt'
+    fio_job: 'fio-rand-read.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_randwrite.yaml
+++ b/io/disk/fiotest.py.data/fio_randwrite.yaml
@@ -1,0 +1,8 @@
+parameters:
+    disk: '/dev/sdd'
+    dir: '/mnt'
+    fio_job: 'fio-rand-write.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seqRW.yaml
+++ b/io/disk/fiotest.py.data/fio_seqRW.yaml
@@ -1,0 +1,8 @@
+parameters:
+    disk: '/dev/sdd'
+    dir: '/mnt'
+    fio_job: 'fio-seq-RW.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seqread.yaml
+++ b/io/disk/fiotest.py.data/fio_seqread.yaml
@@ -1,0 +1,8 @@
+parameters:
+    disk: '/dev/sdd'
+    dir: '/mnt'
+    fio_job: 'fio-seq-read.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seqwrite.yaml
+++ b/io/disk/fiotest.py.data/fio_seqwrite.yaml
@@ -1,0 +1,8 @@
+parameters:
+    disk: '/dev/sdd'
+    dir: '/mnt'
+    fio_job: 'fio-seq-write.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'


### PR DESCRIPTION
Adding FIO_perf test scenarios for KVM host CI

Adding FIO_perf test scenarios for KVM CI, adding 6 test cases: 6 yaml files and 6 job files. Multiple yaml are need because profilers need to be run for each test case individually.



