### PR TITLE
Changing yaml parameter timeout to TIMEOUT

### DIFF
--- a/io/net/infiniband/ib_bw_perf.py
+++ b/io/net/infiniband/ib_bw_perf.py
@@ -65,7 +65,7 @@ class Bandwidth_Perf(Test):
         self.PORT = self.params.get("PORT_NUM", default="1")
         self.PEER_CA = self.params.get("PEERCA", default="mlx4_0")
         self.PEER_PORT = self.params.get("PEERPORT", default="1")
-        self.to = self.params.get("timeout", default="600")
+        self.to = self.params.get("TIMEOUT", default="600")
         self.tool_name = self.params.get("tool")
         if self.tool_name == "":
             self.cancel("should specify tool name")

--- a/io/net/infiniband/ib_bw_perf.py
+++ b/io/net/infiniband/ib_bw_perf.py
@@ -13,13 +13,14 @@
 #
 # Copyright: 2016 IBM
 # Author: Prudhvi Miryala<mprudhvi@linux.vnet.ibm.com>
-# Bandwidth Performance test for infiniband adaptors
-# ib_send_bw test
-# ib_write_bw test
-# ib_read_bw test
-# ib_atomic_bw test
-#
-#
+
+'''
+Bandwidth Performance test for infiniband adaptors
+ib_send_bw test
+ib_write_bw test
+ib_read_bw test
+ib_atomic_bw test
+'''
 
 
 import time
@@ -30,7 +31,7 @@ from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process, distro
 
 
-class Bandwidth_Perf(Test):
+class BandwidthPerf(Test):
     '''
     Infiniband adaptors bandwidth performance tests using four tools
     tools are ib_send_bw,ib_write_bw,ib_read_bw,ib_atomic_bw
@@ -55,21 +56,21 @@ class Bandwidth_Perf(Test):
                 self.cancel("%s package is need to test" % pkg)
         interfaces = netifaces.interfaces()
         self.flag = self.params.get("ext_flag", default="0")
-        self.IF = self.params.get("interface", default="")
+        self.iface = self.params.get("interface", default="")
         self.peer_ip = self.params.get("peer_ip", default="")
-        if self.IF not in interfaces:
-            self.cancel("%s interface is not available" % self.IF)
+        if self.iface not in interfaces:
+            self.cancel("%s interface is not available" % self.iface)
         if self.peer_ip == "":
             self.cancel("%s peer machine is not available" % self.peer_ip)
-        self.CA = self.params.get("CA_NAME", default="mlx4_0")
-        self.PORT = self.params.get("PORT_NUM", default="1")
-        self.PEER_CA = self.params.get("PEERCA", default="mlx4_0")
-        self.PEER_PORT = self.params.get("PEERPORT", default="1")
-        self.to = self.params.get("TIMEOUT", default="600")
+        self.ca_name = self.params.get("CA_NAME", default="mlx4_0")
+        self.port = self.params.get("PORT_NUM", default="1")
+        self.peer_ca = self.params.get("PEERCA", default="mlx4_0")
+        self.peer_port = self.params.get("PEERPORT", default="1")
+        self.tmo = self.params.get("TIMEOUT", default="600")
         self.tool_name = self.params.get("tool")
         if self.tool_name == "":
             self.cancel("should specify tool name")
-        self.log.info("test with %s" % (self.tool_name))
+        self.log.info("test with %s", self.tool_name)
         self.test_op = self.params.get("test_opt", default="").split(",")
         self.ext_test_op = self.params.get("ext_opt", default="").split(",")
 
@@ -97,21 +98,21 @@ class Bandwidth_Perf(Test):
         flag = 0
         logs = "> /tmp/ib_log 2>&1 &"
         cmd = "ssh %s \" timeout %s %s -d %s -i %s %s %s %s\" " \
-            % (self.peer_ip, self.to, arg1, self.PEER_CA, self.PEER_PORT,
+            % (self.peer_ip, self.tmo, arg1, self.peer_ca, self.peer_port,
                arg2, arg3, logs)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("ssh failed to remote machine\
                       or  faing data from remote machine failed")
         time.sleep(2)
-        self.log.info("client data for %s(%s)" % (arg1, arg2))
+        self.log.info("client data for %s(%s)", arg1, arg2)
         cmd = "timeout %s %s -d %s -i %s %s %s %s" \
-            % (self.to, arg1, self.CA, self.PORT, self.peer_ip,
+            % (self.tmo, arg1, self.ca_name, self.port, self.peer_ip,
                arg2, arg3)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             flag = 1
-        self.log.info("server data for %s(%s)" % (arg1, arg2))
+        self.log.info("server data for %s(%s)", arg1, arg2)
         cmd = "ssh %s \"timeout %s cat /tmp/ib_log && rm -rf /tmp/ib_log\" " %\
-              (self.peer_ip, self.to)
+              (self.peer_ip, self.tmo)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("ssh failed to remote machine\
                       or fetching data from remote machine failed")
@@ -129,7 +130,8 @@ class Bandwidth_Perf(Test):
         if self.flag == "1":
             for val in self.ext_test_op:
                 if self.bandwidthperf_exec(self.tool_name, val, "") != 0:
-                    err.append("client cmd fail: %s %s" % (self.tool_name, val))
+                    err.append("client cmd fail: %s %s" % (self.tool_name,
+                                                           val))
         else:
             self.log.info("Extended test option skipped")
         if err:

--- a/io/net/infiniband/ib_bw_perf.py.data/ib_bw_perf.yaml
+++ b/io/net/infiniband/ib_bw_perf.py.data/ib_bw_perf.yaml
@@ -20,4 +20,4 @@ parameters:
     PORT_NUM: "1"
     PEERCA: ""
     PEERPORT: "1"
-    timeout: "600"
+    TIMEOUT: "600"

--- a/io/net/infiniband/ib_latency_perf.py
+++ b/io/net/infiniband/ib_latency_perf.py
@@ -63,7 +63,7 @@ class Latency_Perf(Test):
         self.PORT = self.params.get("PORT_NUM", default="1")
         self.PEER_CA = self.params.get("PEERCA", default="mlx4_0")
         self.PEER_PORT = self.params.get("PEERPORT", default="1")
-        self.to = self.params.get("timeout", default="600")
+        self.to = self.params.get("TIMEOUT", default="600")
         self.tool_name = self.params.get("tool", default="")
         if self.tool_name == "":
             self.cancel("should specify tool name")

--- a/io/net/infiniband/ib_latency_perf.py.data/ib_latency_perf.yaml
+++ b/io/net/infiniband/ib_latency_perf.py.data/ib_latency_perf.yaml
@@ -20,4 +20,4 @@ parameters:
     PORT_NUM: "1"
     PEERCA: ""
     PEERPORT: "1"
-    timeout: "600"
+    TIMEOUT: "600"

--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -53,7 +53,7 @@ class pingpong(Test):
         self.PEER_CA = self.params.get("PEERCA", default="mlx4_0")
         self.PEER_GID = int(self.params.get("PEERGID", default="0"))
         self.PEER_PORT = int(self.params.get("PEERPORT", default="1"))
-        self.to = self.params.get("timeout", default="120")
+        self.to = self.params.get("TIMEOUT", default="120")
 
         smm = SoftwareManager()
         detected_distro = distro.detect()

--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -13,11 +13,14 @@
 #
 # Copyright: 2016 IBM
 # Author: Prudhvi Miryala<mprudhvi@linux.vnet.ibm.com>
-# ping pong test
-# ibv_ud_pingpong
-# ibv_uc_pingpong
-# ibv_rc_pingpong
-# ibv_srq_pingpong
+
+'''
+ping pong test
+ibv_ud_pingpong
+ibv_uc_pingpong
+ibv_rc_pingpong
+ibv_srq_pingpong
+'''
 
 
 import time
@@ -29,7 +32,7 @@ from avocado.utils import process
 from avocado.utils import distro
 
 
-class pingpong(Test):
+class PingPong(Test):
     '''
     ibv_ud_pingpong test
     ibv_ud_pingpong tool should be installed
@@ -41,19 +44,19 @@ class pingpong(Test):
         '''
         interfaces = netifaces.interfaces()
         self.flag = self.params.get("ext_flag", default="0")
-        self.IF = self.params.get("interface", default="")
-        self.PEER_IP = self.params.get("peer_ip", default="")
-        if self.IF not in interfaces:
-            self.cancel("%s interface is not available" % self.IF)
-        if self.PEER_IP == "":
-            self.cancel("%s peer machine is not available" % self.PEER_IP)
-        self.CA = self.params.get("CA_NAME", default="mlx4_0")
-        self.GID = int(self.params.get("GID_NUM", default="0"))
-        self.PORT = int(self.params.get("PORT_NUM", default="1"))
-        self.PEER_CA = self.params.get("PEERCA", default="mlx4_0")
-        self.PEER_GID = int(self.params.get("PEERGID", default="0"))
-        self.PEER_PORT = int(self.params.get("PEERPORT", default="1"))
-        self.to = self.params.get("TIMEOUT", default="120")
+        self.iface = self.params.get("interface", default="")
+        self.peer_ip = self.params.get("peer_ip", default="")
+        if self.iface not in interfaces:
+            self.cancel("%s interface is not available" % self.iface)
+        if self.peer_ip == "":
+            self.cancel("%s peer machine is not available" % self.peer_ip)
+        self.ca_name = self.params.get("CA_NAME", default="mlx4_0")
+        self.gid = int(self.params.get("GID_NUM", default="0"))
+        self.port = int(self.params.get("PORT_NUM", default="1"))
+        self.peer_ca = self.params.get("PEERCA", default="mlx4_0")
+        self.peer_gid = int(self.params.get("PEERGID", default="0"))
+        self.peer_port = int(self.params.get("PEERPORT", default="1"))
+        self.tmo = self.params.get("TIMEOUT", default="120")
 
         smm = SoftwareManager()
         detected_distro = distro.detect()
@@ -76,7 +79,7 @@ class pingpong(Test):
         else:
             self.cancel("Distro not supported")
         if process.system("%s && ssh %s %s" %
-                          (cmd, self.PEER_IP, cmd),
+                          (cmd, self.peer_ip, cmd),
                           ignore_status=True,
                           shell=True) != 0:
             self.cancel("Unable to disable firewall")
@@ -95,28 +98,26 @@ class pingpong(Test):
         if test == "basic":
             test = ""
         msg = " \"timeout %s %s -d %s -g %d -i %d %s %s %s\" " \
-            % (self.to, arg1, self.PEER_CA, self.PEER_GID, self.PEER_PORT,
+            % (self.tmo, arg1, self.peer_ca, self.peer_gid, self.peer_port,
                test, arg3, logs)
-        cmd = "ssh %s %s" % (self.PEER_IP, msg)
+        cmd = "ssh %s %s" % (self.peer_ip, msg)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("ssh failed to remote machine")
         time.sleep(2)
-        self.log.info("client data for %s(%s)" % (arg1, arg2))
-        self.log.info("%s -d %s -g %d %s -i %d %s %s"
-                      % (arg1, self.CA, self.GID, self.PEER_IP, self.PORT,
-                         test, arg3))
+        self.log.info("client data for %s(%s)", arg1, arg2)
+        self.log.info("%s -d %s -g %d %s -i %d %s %s", arg1, self.ca_name,
+                      self.gid, self.peer_ip, self.port, test, arg3)
         tmp = "timeout %s %s -d %s -g %d -i %d %s %s %s" \
-            % (self.to, arg1, self.CA, self.GID, self.PORT, self.PEER_IP,
+            % (self.tmo, arg1, self.ca_name, self.gid, self.port, self.peer_ip,
                test, arg3)
         if process.system(tmp, shell=True, ignore_status=True) != 0:
             self.fail("test failed")
-        self.log.info("server data for %s(%s)" % (arg1, arg2))
-        self.log.info("%s -d %s -g %d -i %d %s %s"
-                      % (arg1, self.PEER_CA, self.PEER_GID, self.PEER_PORT,
-                         test, arg3))
+        self.log.info("server data for %s(%s)", arg1, arg2)
+        self.log.info("%s -d %s -g %d -i %d %s %s", arg1, self.peer_ca,
+                      self.peer_gid, self.peer_port, test, arg3)
         msg = " \"timeout %s cat /tmp/ib_log && rm -rf /tmp/ib_log\" " \
-            % self.to
-        cmd = "ssh %s %s" % (self.PEER_IP, msg)
+            % self.tmo
+        cmd = "ssh %s %s" % (self.peer_ip, msg)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("test failed")
 
@@ -126,13 +127,13 @@ class pingpong(Test):
         ext test options are depends upon user
         '''
         tool_name = self.params.get("tool")
-        self.log.info("test with %s" % (tool_name))
-        if "ib" not in self.IF and tool_name == "ibv_ud_pingpong":
-            tmp = "grep -w -B 1 %s" % self.PEER_IP
-            cmd = " \` ifconfig | %s | head -1 | cut -f1 -d ' ' \` " % tmp
-            msg = "ssh %s \"ifconfig %s mtu 9000\"" % (self.PEER_IP, cmd)
+        self.log.info("test with %s", tool_name)
+        if "ib" not in self.iface and tool_name == "ibv_ud_pingpong":
+            tmp = "grep -w -B 1 %s" % self.peer_ip
+            cmd = " ` ifconfig | %s | head -1 | cut -f1 -d ' ' ` " % tmp
+            msg = "ssh %s \"ifconfig %s mtu 9000\"" % (self.peer_ip, cmd)
             process.system(msg, shell=True)
-            con_msg = "ifconfig %s mtu 9000" % (self.IF)
+            con_msg = "ifconfig %s mtu 9000" % (self.iface)
             process.system(con_msg, shell=True)
             time.sleep(10)
         val1 = ""
@@ -150,15 +151,13 @@ class pingpong(Test):
                 self.pingpong_exec(tool_name, val, "")
         else:
             self.log.info("Extended test option skipped")
-        '''
-        change MTU to 1500 for non-IB tests
-        '''
-        if "ib" not in self.IF and tool_name == "ibv_ud_pingpong":
-            tmp = "grep -w -B 1 %s" % self.PEER_IP
-            cmd = "\`ifconfig | %s | head -1 | cut -f1 -d' '\`" % tmp
-            msg = "ssh %s \"ifconfig %s mtu 1500\"" % (self.PEER_IP, cmd)
+        # change MTU to 1500 for non-IB tests
+        if "ib" not in self.iface and tool_name == "ibv_ud_pingpong":
+            tmp = "grep -w -B 1 %s" % self.peer_ip
+            cmd = "`ifconfig | %s | head -1 | cut -f1 -d' '`" % tmp
+            msg = "ssh %s \"ifconfig %s mtu 1500\"" % (self.peer_ip, cmd)
             process.system(msg, shell=True)
-            con_msg = "ifconfig %s mtu 1500" % (self.IF)
+            con_msg = "ifconfig %s mtu 1500" % (self.iface)
             process.system(con_msg, shell=True)
             time.sleep(10)
 

--- a/io/net/infiniband/ib_pingpong.py.data/ib_pingpong.yaml
+++ b/io/net/infiniband/ib_pingpong.py.data/ib_pingpong.yaml
@@ -25,4 +25,4 @@ parameters:
     PEERCA: "mlx4_0"
     PEERGID: "0"
     PEERPORT: "1"
-    timeout: "120"
+    TIMEOUT: "120"

--- a/io/net/infiniband/ip_over_ib.py
+++ b/io/net/infiniband/ip_over_ib.py
@@ -59,7 +59,7 @@ class ip_over_ib(Test):
             self.cancel("%s interface is not available" % self.IF)
         if self.PEER_IP == "":
             self.cancel("%s peer machine is not available" % self.PEER_IP)
-        self.to = self.params.get("timeout", default="600")
+        self.to = self.params.get("TIMEOUT", default="600")
         self.IPERF_RUN = self.params.get("IPERF_RUN", default="0")
         self.NETSERVER_RUN = self.params.get("NETSERVER_RUN", default="0")
         self.iper = os.path.join(self.teststmpdir, 'iperf')

--- a/io/net/infiniband/ip_over_ib.py.data/ip_over_ib.yaml
+++ b/io/net/infiniband/ip_over_ib.py.data/ip_over_ib.yaml
@@ -6,6 +6,6 @@ Test: !mux
 parameters:
     interface: "ib0"
     peer_ip: "13.13.13.15"
-    timeout: "600"
+    TIMEOUT: "600"
     NETSERVER_RUN: 0
     IPERF_RUN: 0

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -63,7 +63,7 @@ class Netperf(Test):
         if self.peer_ip == "":
             self.cancel("%s peer machine is not available" % self.peer_ip)
         self.peer_user = self.params.get("peer_user_name", default="root")
-        self.timeout = self.params.get("timeout", default="600")
+        self.timeout = self.params.get("TIMEOUT", default="600")
         self.netperf_run = str(self.params.get("NETSERVER_RUN", default=0))
         self.netperf = os.path.join(self.teststmpdir, 'netperf')
         netperf_download = self.params.get("netperf_download", default="https:"

--- a/io/net/netperf_test.py.data/netperf_test.yaml
+++ b/io/net/netperf_test.py.data/netperf_test.yaml
@@ -1,7 +1,7 @@
 interface: ""
 peer_ip: ""
 peer_user_name: "root"
-timeout: "600"
+TIMEOUT: "600"
 NETSERVER_RUN: 0
 EXPECTED_THROUGHPUT: 90
 duration: 600


### PR DESCRIPTION
* Avocado treats yaml parameter 'timeout' as test timeout.
So, if we want a yaml parameter timeout to mean something else, we
can use it in any other form / case, here we use upper case: TIMEOUT

* PEP8 and Pylint fixes