### PR TITLE
Fixed numactl typo

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -32,7 +32,7 @@ class Numactl(Test):
 
     def setUp(self):
         '''
-        Build Stutter Test
+        Build Numactl Test
         Source:
         https://github.com/numactl/numactl
         '''


### PR DESCRIPTION
Fix typo in numctl test

Signed-off-by: Harish <harish@linux.vnet.ibm.com>