### PR TITLE
Avago3008 - Added Setup, Cleanup, ClearConfig

### DIFF
--- a/io/disk/Avago_storage_adapter/avago3008.py.data/Readme
+++ b/io/disk/Avago_storage_adapter/avago3008.py.data/Readme
@@ -10,3 +10,6 @@ Size: Size of the raid array you want to create, default it will be max
 tool_location: Please give the tool location, i.e., location of the tool in
 the system. e.g., If the tool is downloaded in /root, then plz mention
 /root/sas3ircu.
+clear_config: If clearing raid is to be done before executing the tests, this needs to be set to True
+setup_raid: If just raid setup needs to be done, this needs to be set to True
+cleanup_raid: If just raid cleanup needs to be done, this needs to be set to True

--- a/io/disk/Avago_storage_adapter/avago3008.py.data/avago3008_cleanupraid.yaml
+++ b/io/disk/Avago_storage_adapter/avago3008.py.data/avago3008_cleanupraid.yaml
@@ -1,16 +1,11 @@
 cenario:
     controller:
-    disk_bay: 
-    spare: ""
+    disk_bay:
+    spare:
     size: 10000
     tool_location: /root/sas3ircu
     clear_config: False
+    cleanup_raid: True
 raidlevel: !mux
     raid1:
         raidlevel: raid1
-    raid1E:
-        raidlevel: raid1e
-    raid0:
-        raidlevel: raid0
-    raid10:
-        raidlevel: raid10

--- a/io/disk/Avago_storage_adapter/avago3008.py.data/avago3008_setupraid.yaml
+++ b/io/disk/Avago_storage_adapter/avago3008.py.data/avago3008_setupraid.yaml
@@ -1,16 +1,11 @@
 cenario:
     controller:
-    disk_bay: 
-    spare: ""
+    disk_bay:
+    spare:
     size: 10000
     tool_location: /root/sas3ircu
     clear_config: False
+    setup_raid: True
 raidlevel: !mux
     raid1:
         raidlevel: raid1
-    raid1E:
-        raidlevel: raid1e
-    raid0:
-        raidlevel: raid0
-    raid10:
-        raidlevel: raid10


### PR DESCRIPTION
Added the following functionalities to avago3008 test:
* Setup: Based on yaml parameter setup_raid, test just creates raid.
* Cleanup: Based on yaml parameter cleanup_raid, test just deletes
raid.
* ClearConfig: Based on yaml parameter clear_config, test decides
whether to clear the raids in the drives or not before starting the
other tests.

Changed the yaml parameter disk to disk_bay.
Made HotSpare and Rebuild test to run only if hotspare drive is
given and clear_config is True

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>