### PR TITLE
Extend test category using tags

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -28,6 +28,8 @@ class Numactl(Test):
 
     """
     Self test case of numactl
+
+    :avocado: tags=cpu
     """
 
     def setUp(self):

--- a/cpu/numatop.py
+++ b/cpu/numatop.py
@@ -29,6 +29,8 @@ class Numatop(Test):
     """
     Test case of numatop functionality
     Test runs mgen application to check numatop snapshot registers it
+
+    :avocado: tags=cpu,privileged
     """
 
     def setUp(self):


### PR DESCRIPTION
Added tags for new test cases on cpu category

[praveen@dhcp-9-109-222-39 avocado-misc-tests]$ avocado list   --filter-by-tags=cpu,privileged cpu/
INSTRUMENTED cpu/numatop.py:Numatop.test
[praveen@dhcp-9-109-222-39 avocado-misc-tests]$ avocado list   --filter-by-tags=cpu cpu/
INSTRUMENTED cpu/numactl.py:Numactl.test
INSTRUMENTED cpu/numatop.py:Numatop.test
[praveen@dhcp-9-109-222-39 avocado-misc-tests]$

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>