### PR TITLE
Fixed issue in io:disk:bonnie

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -48,11 +48,19 @@ class Bonnie(Test):
         """
         fstype = self.params.get('fs', default='ext4')
         smm = SoftwareManager()
+        deps = ['gcc', 'make']
+        if distro.detect().name == 'Ubuntu':
+            deps.extend(['g++'])
+        else:
+            deps.extend(['gcc-c++'])
         if fstype == 'btrfs':
             if distro.detect().name == 'Ubuntu':
-                if not smm.check_installed("btrfs-tools") and not \
-                        smm.install("btrfs-tools"):
-                    self.cancel('btrfs-tools is needed for the test to be run')
+                deps.extend(['btrfs-tools'])
+
+        for package in deps:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel("Fail to install/check %s, which is needed for"
+                            "Bonnie test to run" % package)
 
         self.disk = self.params.get('disk', default=None)
         self.scratch_dir = self.params.get('dir', default=self.srcdir)


### PR DESCRIPTION
configure failed due to per-requisite

2017-09-16 16:38:59,012 download         L0066 INFO | Fetching http://www.coker.com.au/bonnie++/bonnie++-1.03e.tgz -> /var/lib/avocado/data/cache/bonnie++-1.03e.tgz.ev2AJ3
2017-09-16 16:39:01,433 process          L0389 INFO | Running './configure'
2017-09-16 16:39:01,512 process          L0479 DEBUG| [stdout] checking for g++... no
2017-09-16 16:39:01,513 process          L0479 DEBUG| [stdout] checking for c++... no
2017-09-16 16:39:01,513 process          L0479 DEBUG| [stdout] checking for gpp... no
2017-09-16 16:39:01,513 process          L0479 DEBUG| [stdout] checking for aCC... no
2017-09-16 16:39:01,514 process          L0479 DEBUG| [stdout] checking for CC... no
2017-09-16 16:39:01,514 process          L0479 DEBUG| [stdout] checking for cxx... no
2017-09-16 16:39:01,515 process          L0479 DEBUG| [stdout] checking for cc++... no
2017-09-16 16:39:01,515 process          L0479 DEBUG| [stdout] checking for cl.exe... no
2017-09-16 16:39:01,515 process          L0479 DEBUG| [stdout] checking for FCC... no
2017-09-16 16:39:01,516 process          L0479 DEBUG| [stdout] checking for KCC... no
2017-09-16 16:39:01,516 process          L0479 DEBUG| [stdout] checking for RCC... no
2017-09-16 16:39:01,516 process          L0479 DEBUG| [stdout] checking for xlC_r... no
2017-09-16 16:39:01,517 process          L0479 DEBUG| [stdout] checking for xlC... no
2017-09-16 16:39:01,527 process          L0479 DEBUG| [stdout] checking for C++ compiler default output file name...
2017-09-16 16:39:01,529 process          L0479 DEBUG| [stderr] configure: error: C++ compiler cannot create executables
2017-09-16 16:39:01,529 process          L0479 DEBUG| [stderr] See `config.log' for more details.
2017-09-16 16:39:01,549 process          L0499 INFO | Command './configure' finished with 77 after 0.114249944687s
2017-09-16 16:39:01,550 stacktrace       L0039 ERROR|
2017-09-16 16:39:01,550 stacktrace       L0042 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado/core/test.py:583
2017-09-16 16:39:01,551 stacktrace       L0045 ERROR| Traceback (most recent call last):
2017-09-16 16:39:01,551 stacktrace       L0045 ERROR|   File "/var/tmp/avocado/avocado-misc-tests/io/disk/bonnie.py", line 70, in setUp
2017-09-16 16:39:01,551 stacktrace       L0045 ERROR|     process.run('./configure')
2017-09-16 16:39:01,551 stacktrace       L0045 ERROR|   File "/usr/lib/python2.7/site-packages/avocado/utils/process.py", line 1117, in run
2017-09-16 16:39:01,551 stacktrace       L0045 ERROR|     raise CmdError(cmd, sp.result)
2017-09-16 16:39:01,551 stacktrace       L0045 ERROR| CmdError: Command './configure' failed (rc=77)
2017-09-16 16:39:01,551 stacktrace       L0046 ERROR|
2017-09-16 16:39:01,552 test             L0751 ERROR| ERROR 1-/var/tmp/avocado/avocado-misc-tests/io/disk/bonnie.py:Bonnie.test -> TestSetupFail: Command './configure' failed (rc=77)
2017-09-16 16:39:01,552 test             L0740 INFO |

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Reported-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>