### PR TITLE
Removed multipath flush from teardown

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -140,7 +140,6 @@ class MultipathTest(Test):
 
         # Need to wait for some time to make sure multipaths are loaded.
         time.sleep(5)
-        process.run('multipath -F')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Multipath test was flushing all the paths in teardown.
This will cause all multipath devices to stop, which is not
expected. The system state should be retained after the test

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>