### PR TITLE
Changed srcdir to teststmpdir

### DIFF
--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -54,9 +54,9 @@ class Dbench(Test):
         data_dir = os.path.abspath(self.datadir)
         tarball = self.fetch_asset(
             'http://samba.org/ftp/tridge/dbench/dbench-3.04.tar.gz')
-        archive.extract(tarball, self.srcdir)
+        archive.extract(tarball, self.teststmpdir)
         cb_version = os.path.basename(tarball.split('.tar.')[0])
-        self.sourcedir = os.path.join(self.srcdir, cb_version)
+        self.sourcedir = os.path.join(self.teststmpdir, cb_version)
         os.chdir(self.sourcedir)
         patch = self.params.get('patch', default='dbench_startup.patch')
         process.run('patch -p1 < %s' % data_dir + '/' + patch, shell=True)

--- a/io/disk/ioping.py
+++ b/io/disk/ioping.py
@@ -55,9 +55,9 @@ class Ioping(Test):
                                    'google-code-archive-downloads/v2/'
                                    'code.google.com/ioping/'
                                    'ioping-0.8.tar.gz', expire='0d')
-        archive.extract(tarball, self.srcdir)
+        archive.extract(tarball, self.teststmpdir)
         version = os.path.basename(tarball.split('.tar.')[0])
-        self.sourcedir = os.path.join(self.srcdir, version)
+        self.sourcedir = os.path.join(self.teststmpdir, version)
 
         build.make(self.sourcedir)
 

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -422,9 +422,9 @@ class IOZone(Test):
                 self.cancel("%s is needed for the test to be run" % package)
         tarball = self.fetch_asset(
             'http://www.iozone.org/src/current/iozone3_434.tar')
-        archive.extract(tarball, self.srcdir)
+        archive.extract(tarball, self.teststmpdir)
         version = os.path.basename(tarball.split('.tar')[0])
-        self.sourcedir = os.path.join(self.srcdir, version)
+        self.sourcedir = os.path.join(self.teststmpdir, version)
 
         make_dir = os.path.join(self.sourcedir, 'src', 'current')
         os.chdir(make_dir)

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -55,8 +55,8 @@ class Tiobench(Test):
                 self.cancel("%s package required for this test." % package)
         locations = ["https://github.com/mkuoppal/tiobench/archive/master.zip"]
         tarball = self.fetch_asset("tiobench.zip", locations=locations)
-        archive.extract(tarball, self.srcdir)
-        os.chdir(os.path.join(self.srcdir, "tiobench-master"))
+        archive.extract(tarball, self.teststmpdir)
+        os.chdir(os.path.join(self.teststmpdir, "tiobench-master"))
         build.make(".")
 
     def test(self):


### PR DESCRIPTION
teststmpdir is same for all of a test's variants. Thus, it is
better to use it as target to build our packages so that we save
time in re-compiling.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>