### PR TITLE
Fixed test analysis of ltp failures

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -77,7 +77,8 @@ class ltp(Test):
         split_lines = (line.split(None, 3)
                        for line in result.stdout.splitlines())
         failed_tests = [items[0] for items in split_lines
-                        if len(items) == 4 and items[2] in fail_statuses]
+                        if len(items) == 4 and
+                        items[2].strip(":") in fail_statuses]
 
         if failed_tests:
             self.fail("LTP tests failed: %s" % ", ".join(failed_tests))


### PR DESCRIPTION
Few tests had test status being split with ":" like "TFAIL:" and script did not catch in the failure list generated. This patch fixes this issue.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>