### PR TITLE
Ras test fix

### DIFF
--- a/generic/ras.py
+++ b/generic/ras.py
@@ -255,6 +255,16 @@ class RASTools(Test):
             self.fail("%s command(s) failed in rtas_errd and rtas_dump tools "
                       "verification" % self.is_fail)
 
+    @skipIf(IS_POWER_NV, "This test is not supported on PowerNV platform")
+    def test13_rtas_event_decode(self):
+        self.log.info("===============Executing rtas_event_decode tool test===="
+                      "===========")
+        self.run_cmd("rtas_event_decode -w 500 -dv -n 2302 < %s" %
+                     os.path.join(self.datadir, 'rtas'))
+        if self.is_fail >= 1:
+            self.fail("%s command(s) failed in rtas_event_decode tool "
+                      "verification" % self.is_fail)
+
 
 if __name__ == "__main__":
     main()

--- a/generic/ras.py
+++ b/generic/ras.py
@@ -18,7 +18,7 @@ import os
 from shutil import copyfile
 from avocado import Test
 from avocado import main
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado import skipIf
 from avocado.utils.software_manager import SoftwareManager
 
@@ -41,8 +41,7 @@ class RASTools(Test):
         return
 
     def setUp(self):
-        architecture = os.uname()[4]
-        if "ppc" not in architecture:
+        if "ppc" not in distro.detect().arch:
             self.cancel("supported only on Power platform")
         sm = SoftwareManager()
         for package in ("ppc64-diag", "powerpc-utils", "lsvpd", "ipmitool"):

--- a/generic/ras_extended.py
+++ b/generic/ras_extended.py
@@ -71,16 +71,6 @@ class RASTools(Test):
             self.fail("%s command(s) failed in serv_config tool "
                       "verification" % self.is_fail)
 
-    @skipIf(IS_POWER_NV, "This test is not supported on PowerNV platform")
-    def test1_rtas_event_decode(self):
-        self.log.info("===============Executing rtas_event_decode tool test===="
-                      "===========")
-        self.run_cmd("rtas_event_decode -w 500 -dv -n 2302 < %s" %
-                     os.path.join(self.datadir, 'rtas'))
-        if self.is_fail >= 1:
-            self.fail("%s command(s) failed in rtas_event_decode tool "
-                      "verification" % self.is_fail)
-
     @skipIf(IS_POWER_NV or IS_KVM_GUEST, "This test is not supported on KVM guest or PowerNV platform")
     def test1_ls_vscsi(self):
         self.log.info("===============Executing ls-vscsi tool test===="

--- a/generic/ras_extended.py
+++ b/generic/ras_extended.py
@@ -18,7 +18,7 @@ import os
 from shutil import copyfile
 from avocado import Test
 from avocado import main
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado import skipIf
 from avocado.utils.software_manager import SoftwareManager
 
@@ -39,7 +39,7 @@ class RASTools(Test):
         return
 
     def setUp(self):
-        if "ppc" not in os.uname()[4]:
+        if "ppc" not in distro.detect().arch:
             self.cancel("supported only on Power platform")
         sm = SoftwareManager()
         for package in ("ppc64-diag", "powerpc-utils", "lsvpd", "sysfsutils"):


### PR DESCRIPTION
Use avocado library function for processor check and Move ras_extended test to ras test.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>