### PR TITLE
numactl-devel package was not getting installed

### DIFF
--- a/perf/rt_tests.py
+++ b/perf/rt_tests.py
@@ -46,7 +46,7 @@ class rt_tests(Test):
         if detected_distro.name == "Ubuntu":
             deps.append("build-essential")
             deps.append("libnuma-dev")
-        elif detected_distro.name == "redhat":
+        elif detected_distro.name in ['centos', 'fedora', 'rhel', 'redhat']:
             deps.append("numactl-devel")
         for package in deps:
             if not sm.check_installed(package) and not sm.install(package):


### PR DESCRIPTION
because distro name it was checking for redhat
now made changes to check centos,fedora, rhel and redhat

Signed-off-by: chidanand <chidanand.harlapur@in.ibm.com>