### PR TITLE
Use new meminfo object

### DIFF
--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -44,11 +44,11 @@ class Thp_Swapping(Test):
         '''
 
         self.swap_free = []
-        mem_free = memory.read_from_meminfo("MemFree") / 1024
-        mem = memory.read_from_meminfo("MemTotal") / 1024
-        swap = memory.read_from_meminfo("SwapTotal") / 1024
-        self.hugepage_size = memory.read_from_meminfo("Hugepagesize") / 1024
-        self.swap_free.append(memory.read_from_meminfo("SwapFree") / 1024)
+        mem_free = memory.meminfo.MemFree.mb
+        mem = memory.meminfo.MemTotal.mb
+        swap = memory.meminfo.SwapTotal.mb
+        self.hugepage_size = memory.meminfo.Hugepagesize.mb
+        self.swap_free.append(memory.meminfo.SwapFree.mb)
         self.mem_path = os.path.join(data_dir.get_tmp_dir(), 'thp_space')
         self.dd_timeout = 900
 
@@ -90,7 +90,7 @@ class Thp_Swapping(Test):
                               verbose=False, ignore_status=True, shell=True)):
                 self.fail('Swap command Failed %s' % swap_cmd)
 
-        self.swap_free.append(memory.read_from_meminfo("SwapFree") / 1024)
+        self.swap_free.append(memory.meminfo.SwapFree.mb)
 
         # Checks Swap is used or not
         if self.swap_free[1] - self.swap_free[0] >= 0:


### PR DESCRIPTION
Avocado memory library has now a meminfo object. Let's take advantage of it.

Signed-off-by: Amador Pahim <apahim@redhat.com>