### PR TITLE
Fix thp_swap test

### DIFF
--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -53,7 +53,7 @@ class Thp_Swapping(Test):
         self.dd_timeout = 900
 
         # If swap is enough fill all memory with dd
-        if self.swap_free > (mem - mem_free):
+        if self.swap_free[0] > (mem - mem_free):
             self.count = (mem / self.hugepage_size) / 2
             tmpfs_size = mem
         else:


### PR DESCRIPTION
Patch fixes a wrong comparison between a list and int in thp_swap test case. Replace with actual value to be compared.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>