### PR TITLE
adding support for multiple fio jobs for KVM perf CI

### DIFF
--- a/io/disk/fiotest.py.data/fio-rand-RW.job
+++ b/io/disk/fiotest.py.data/fio-rand-RW.job
@@ -1,0 +1,18 @@
+; fio-rand-RW.job for fiotest
+
+[global]
+name=fio-rand-RW
+filename=fio-rand-RW
+rw=randrw
+rwmixread=60
+rwmixwrite=40
+bs=4K
+direct=0
+numjobs=4
+time_based=1
+runtime=900
+
+[file1]
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-rand-read.job
+++ b/io/disk/fiotest.py.data/fio-rand-read.job
@@ -1,0 +1,16 @@
+; fio-rand-read.job for fiotest
+
+[global]
+name=fio-rand-read
+filename=fio-rand-read
+rw=randread
+bs=4K
+direct=0
+numjobs=1
+time_based=1
+runtime=900
+
+[file1]
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-rand-write.job
+++ b/io/disk/fiotest.py.data/fio-rand-write.job
@@ -1,0 +1,16 @@
+; fio-rand-write.job for fiotest
+
+[global]
+name=fio-rand-write
+filename=fio-rand-write
+rw=randwrite
+bs=4K
+direct=0
+numjobs=4
+time_based=1
+runtime=900
+
+[file1]
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-seq-RW.job
+++ b/io/disk/fiotest.py.data/fio-seq-RW.job
@@ -1,0 +1,18 @@
+; fio-seq-RW.job for fiotest
+
+[global]
+name=fio-seq-RW
+filename=fio-seq-RW
+rw=rw
+rwmixread=60
+rwmixwrite=40
+bs=256K
+direct=0
+numjobs=4
+time_based=1
+runtime=900
+
+[file1]
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-seq-read.job
+++ b/io/disk/fiotest.py.data/fio-seq-read.job
@@ -1,0 +1,14 @@
+[global]
+name=fio-seq-reads
+filename=fio-seq-reads
+rw=read
+bs=256K
+direct=0
+numjobs=1
+time_based=1
+runtime=900
+
+[file1]
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio-seq-write.job
+++ b/io/disk/fiotest.py.data/fio-seq-write.job
@@ -1,0 +1,16 @@
+; fio-seq-write.job for fiotest
+
+[global]
+name=fio-seq-write
+filename=fio-seq-write
+rw=write
+bs=256K
+direct=0
+numjobs=1
+time_based=1
+runtime=900
+
+[file1]
+size=10G
+ioengine=libaio
+iodepth=16

--- a/io/disk/fiotest.py.data/fio_rand_RW.yaml
+++ b/io/disk/fiotest.py.data/fio_rand_RW.yaml
@@ -1,0 +1,8 @@
+fio_randRW.yaml:
+parameters:
+    dir: '/mnt'
+    fio_job: 'fio-rand-RW.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_rand_read.yaml
+++ b/io/disk/fiotest.py.data/fio_rand_read.yaml
@@ -1,0 +1,8 @@
+fio_randread.yaml:
+parameters:
+    dir: '/mnt'
+    fio_job: 'fio-rand-read.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_rand_write.yaml
+++ b/io/disk/fiotest.py.data/fio_rand_write.yaml
@@ -1,0 +1,8 @@
+fio_randwrite.yaml:
+parameters:
+    dir: '/mnt'
+    fio_job: 'fio-rand-write.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seq_RW.yaml
+++ b/io/disk/fiotest.py.data/fio_seq_RW.yaml
@@ -1,0 +1,8 @@
+fio_seqRW.yaml:
+parameters:
+    dir: '/mnt'
+    fio_job: 'fio-seq-RW.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seq_read.yaml
+++ b/io/disk/fiotest.py.data/fio_seq_read.yaml
@@ -1,0 +1,9 @@
+parameters:
+    dir: '/mnt'
+    fio_job: !mux
+       fio-seq-read:
+         fio_job: 'fio-seq-read.job'
+       fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seq_write.yaml
+++ b/io/disk/fiotest.py.data/fio_seq_write.yaml
@@ -1,0 +1,8 @@
+fio_seqwrite.yaml:
+parameters:
+    dir: '/mnt'
+    fio_job: 'fio-seq-write.job'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'


### PR DESCRIPTION
multiple yaml files are needed because the requirement is to have profilers run individually for each test

Signed-off-by: Venu <venutiwa@in.ibm.com>

With reference to https://github.com/avocado-framework-tests/avocado-misc-tests/pull/644: as per the comment on this PR, adding the changes in single commit.