### PR TITLE
Script to add Uperf which is a network benchmark tool to measure

### DIFF
--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2017 IBM
+# Author: Harsha Thygaraaja <harshkid@linux.vnet.ibm.com>
+
+"""
+Unified Performance Tool or uperf for short, is a network
+performance measurement tool that supports execution of
+workload profiles
+"""
+
+import os
+import time
+import netifaces
+from avocado import main
+from avocado import Test
+from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import distro
+from avocado.utils import build
+from avocado.utils import archive
+from avocado.utils import process
+from avocado.utils.genio import read_file
+
+
+class Uperf(Test):
+    """
+    Uperf Test
+    """
+
+    def setUp(self):
+        """
+        To check and install dependencies for the test
+        """
+        smm = SoftwareManager()
+        detected_distro = distro.detect()
+        pkgs = ["gcc", "autoconf", "perl", "m4", "git-core"]
+        if detected_distro.name == "Ubuntu":
+            pkgs.extend(["libsctp1", "libsctp-dev", "lksctp-tools"])
+        else:
+            pkgs.extend(["lksctp-tools", "lksctp-tools-devel"])
+        for pkg in pkgs:
+            if not smm.check_installed(pkg) and not smm.install(pkg):
+                self.cancel("%s package is need to test" % pkg)
+        interfaces = netifaces.interfaces()
+        self.iface = self.params.get("interface", default="")
+        self.peer_ip = self.params.get("peer_ip", default="")
+        if self.iface not in interfaces:
+            self.cancel("%s interface is not available" % self.iface)
+        if self.peer_ip == "":
+            self.cancel("%s peer machine is not available" % self.peer_ip)
+        self.peer_user = self.params.get("peer_user_name", default="root")
+        uperf_download = self.params.get("uperf_download", default="https:"
+                                         "//github.com/uperf/uperf/"
+                                         "archive/master.zip")
+        tarball = self.fetch_asset(uperf_download, expire='7d')
+        archive.extract(tarball, self.teststmpdir)
+        self.uperf_dir = os.path.join(self.teststmpdir, "uperf-master")
+        cmd = "scp -r %s %s@%s:/tmp" % (self.uperf_dir, self.peer_user,
+                                        self.peer_ip)
+        if process.system(cmd, shell=True, ignore_status=True) != 0:
+            self.cancel("unable to copy the uperf into peer machine")
+        tmp = "cd /tmp/uperf-master;./configure ppc64le;make"
+        cmd = "ssh %s@%s \"%s\"" % (self.peer_user, self.peer_ip, tmp)
+        if process.system(cmd, ignore_status=True, shell=True, sudo=True):
+            self.cancel("Unable to compile Uperf into peer machine")
+        os.chdir(self.uperf_dir)
+        process.system('./configure ppc64le', shell=True)
+        build.make(self.uperf_dir)
+        self.uperf = os.path.join(self.uperf_dir, 'doc')
+        self.expected_tp = self.params.get("EXPECTED_THROUGHPUT", default="85")
+        self.uperf_run = str(self.params.get("UPERF_SERVER_RUN", default=0))
+
+    def test(self):
+        """
+        Test run is a One way throughput test. In this test, we have one host
+        transmitting (or receiving) data from a client. This transmit large
+        messages using multiple threads or processes.
+        """
+        if self.uperf_run == '1':
+            tmp = "cd /tmp/uperf-master/src;./uperf -s"
+            cmd = "ssh %s@%s \"%s\"" % (self.peer_user, self.peer_ip, tmp)
+            obj = process.SubProcess(cmd, verbose=False, shell=True)
+            obj.start()
+        speed = int(read_file("/sys/class/net/%s/speed" % self.iface))
+        self.expected_tp = int(self.expected_tp) * speed / 100
+        os.chdir(self.uperf)
+        time.sleep(1)
+        cmd = "h=%s proto=tcp uperf -m throughput.xml -a" % self.peer_ip
+        result = process.run(cmd, shell=True, ignore_status=True)
+        if result.exit_status != 0:
+            self.fail("FAIL: Uperf Run failed")
+        for line in result.stdout.splitlines():
+            if self.peer_ip in line:
+                tmp = int(line.split()[3].split('.')[0])
+                # Converting the throughput calculated in Gb to Mb
+                tput = tmp * 1000
+                if tput < self.expected_tp:
+                    self.fail("FAIL: Throughput Actual - %d, Expected - %d"
+                              % (tput, self.expected_tp))
+        if 'WARNING' in result.stdout:
+            self.log.warn('Test completed with warning')
+
+    def tearDown(self):
+        """
+        Killing Uperf process in peer machine
+        """
+        msg = "pkill uperf; rm -rf /tmp/uperf-master"
+        cmd = "ssh %s@%s \"%s\"" % (self.peer_user, self.peer_ip, msg)
+        if process.system(cmd, shell=True, ignore_status=True) != 0:
+            self.fail("Either the ssh to peer machine machine\
+                       failed or uperf process was not killed")
+
+
+if __name__ == "__main__":
+    main()

--- a/io/net/uperf_test.py.data/README.txt
+++ b/io/net/uperf_test.py.data/README.txt
@@ -1,0 +1,26 @@
+Description:
+------------------------
+Unified Performance Tool or uperf for short, is a network
+performance measurement tool that supports execution of
+workload profiles
+
+Inputs Needed To Run Tests:
+-----------------------------
+interface		- interface on which test run
+peer_ip			- IP of the Peer interface to be tested
+peer_user_name		- Username in Peer system to be used
+UPERF_SERVER_RUN	- Whether to run netserver in peer or not (1 to run, 0 to not run)
+EXPECTED_THROUGHPUT	- Expected Throughput as a percentage (1-100)
+
+Requirements:
+-----------------------
+1. Generate sshkey for your test partner to run the test uninterrupted.
+2. Install netifaces using pip. command: pip install netifaces
+3. Install dependant packages for uperf tools to be compiled in the
+Peer machine. 
+For Rhel and Sles distros: lksctp-tools, lksctp-tools-devel
+For Ubuntu: libsctp1, libsctp-dev, lksctp-tools
+
+
+
+

--- a/io/net/uperf_test.py.data/uperf_test.yaml
+++ b/io/net/uperf_test.py.data/uperf_test.yaml
@@ -1,0 +1,5 @@
+interface: ""
+peer_ip: ""
+peer_user_name: "root"
+EXPECTED_THROUGHPUT : 80
+UPERF_SERVER_RUN : 1


### PR DESCRIPTION
Network performance

This script will calculate the performance of the network IO adapter
in GB

Signed-off-by: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>