### PR TITLE
Use dd for loop device creation on ext3 root fs and change default disk device

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -101,7 +101,7 @@ class Xfstests(Test):
 
         if self.dev_type == 'loop':
             base_disk = self.params.get('disk', default=None)
-            loop_size = self.params.get('loop_size', default='9GiB')
+            loop_size = self.params.get('loop_size', default='7GiB')
             if not base_disk:
                 # Using root for file creation by default
                 if disk.freespace('/') / 1073741824 > 15:


### PR DESCRIPTION
xfstests checks for 15GB of availabe space but default sizes are more than that and hence test fails to create loop devices. So default sizes are reduced.
As fallocate is not supported on ext3 root file system, it is replaced with dd command for loop device creation for ext3 fs.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>