### PR TITLE
Restoring blacklisted multipaths

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -125,6 +125,7 @@ class MultipathTest(Test):
                 multipath.form_conf_mpath_file(blacklist=cmd)
                 if disk in multipath.get_paths(path_dic["wwid"]):
                     msg += "Blacklist of %s fails\n" % disk
+            multipath.form_conf_mpath_file()
 
         # Print errors
         if msg:


### PR DESCRIPTION
After blacklisting multipaths via conf file, they were not restored.
This would cause them to be blacklisted for operations after that.
Fixed it by restoring it immediately after blacklisting.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>