### PR TITLE
Support ext4 root filesystem

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -46,7 +46,8 @@ class Xfstests(Test):
         Source: git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
         """
         self.use_dd = False
-        if process.system_output("df -T / | awk 'END {print $2}'", shell=True) == 'ext3':
+        root_fs = process.system_output("df -T / | awk 'END {print $2}'", shell=True)
+        if root_fs in ['ext3', 'ext4']:
             self.use_dd = True
         sm = SoftwareManager()
 


### PR DESCRIPTION
fallocate fails on ext4 root filesystem, this patch handles it

Signed-off-by: Harish <harish@linux.vnet.ibm.com>