### PR TITLE
Fixed checking for ERROR in dmesg

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -82,14 +82,13 @@ class cpustresstest(Test):
 
     @staticmethod
     def __error_check():
-        ERROR = None
-        logs = (process.system_output(
-            "dmesg -T --level=alert,crit,err,warn", ignore_status=True, shell=True, sudo=True)).split()
-        for log in logs:
-            for error in errorlog:
+        ERROR = []
+        logs = process.system_output("dmesg -Txl 1,2,3,4").splitlines()
+        for error in errorlog:
+            for log in logs:
                 if error in log:
-                    ERROR = 'Test resulted %s in syslogs"' % error
-        return ERROR
+                    ERROR.append(log)
+        return "\n".join(ERROR)
 
     @staticmethod
     def __isSMT():

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -122,12 +122,16 @@ class stressng(Test):
         cmd = 'stress-ng %s' % " ".join(args)
         process.run(cmd, ignore_status=True, sudo=True)
         collect_dmesg(self)
+        ERROR = []
         pattern = ['WARNING: CPU:', 'Oops',
                    'Segfault', 'soft lockup', 'Unable to handle']
-        logs = process.system_output('dmesg')
-        for x in pattern:
-            if any(x in y for y in logs.split()):
-                self.fail("Test failed !!!!! :  %s in dmesg" % x)
+        logs = process.system_output('dmesg').splitlines()
+        for fail_pattern in pattern:
+            for log in logs:
+                if fail_pattern in log:
+                    ERROR.append(log)
+        if ERROR:
+            self.fail("Test failed with following errors in demsg :  %s " % "\n".joing(ERROR))
 
 
 if __name__ == "__main__":

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -119,14 +119,13 @@ class memstress(Test):
 
     @staticmethod
     def __error_check():
-        ERROR = None
-        logs = (process.system_output(
-            "dmesg -T --level=alert,crit,err,warn", ignore_status=True, shell=True, sudo=True)).split()
-        for log in logs:
-            for error in errorlog:
+        ERROR = []
+        logs = process.system_output("dmesg -Txl 1,2,3,4").splitlines()
+        for error in errorlog:
+            for log in logs:
                 if error in log:
-                    ERROR = 'Test: resulted %s in syslogs"' % error
-        return ERROR
+                    ERROR.append(log)
+        return "\n".join(ERROR)
 
     @staticmethod
     def __is_auto_online():


### PR DESCRIPTION
the code was spliting the dmesg due to which multi-word match will fail. This
was a critical issue were we may mix the bugs. the same is fixed with this patch.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>