### PR TITLE
Adding cxl(CAPI) tests

### DIFF
--- a/generic/cxl.py
+++ b/generic/cxl.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2017 IBM
+# Author: sudeesh john <sudeesh@linux.vnet.ibm.com>
+
+import os
+from avocado import Test, main
+from avocado.utils import build, git, process
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Cxl(Test):
+    """
+    This tests the CAPI functionality in IBM Power machines.
+    This wrapper uses the testcases from
+    https://github.com/ibm-capi/cxl-tests.git
+    """
+
+    def setUp(self):
+        """
+        Preparing the machie for the cxl test
+        """
+        self.script = self.params.get('script', default='memcpy_afu_ctx')
+        self.args = self.params.get('args', default='')
+        lspci_out = process.system_output("lspci")
+        if "accelerators" not in lspci_out:
+            self.cancel("No capi card preset. Unable to initialte the test")
+        smngr = SoftwareManager()
+        for pkgs in ['gcc', 'make', 'automake', 'autoconf']:
+            if not smngr.check_installed(pkgs) and not smngr.install(pkgs):
+                self.cancel('%s is needed for the test to be run' % pkgs)
+        git.get_repo('https://github.com/ibm-capi/cxl-tests.git',
+                     destination_dir=self.teststmpdir)
+        os.chdir(self.teststmpdir)
+        if not os.path.isfile('memcpy_afu_ctx'):
+            build.make(".")
+
+    def test(self):
+        """
+        Runs the cxl tests.
+        """
+        cmd = "./%s  %s" % (self.script, self.args)
+        result = process.run(cmd, ignore_status=True)
+        if "Unable to open cxl device" in result.stderr:
+            self.fail("%s is failed" % cmd)
+        elif "failed" in result.stdout:
+            self.fail("%s is failed" % cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/generic/cxl.py.data/cxl.yaml
+++ b/generic/cxl.py.data/cxl.yaml
@@ -1,0 +1,35 @@
+#Usage: memcpy_afu_ctx [options]
+#Options:
+#	-c <card_num>	Use this CAPI card (default 0).
+#	-h		Display this help text.
+#	-I <irq_count>	Define this number of interrupts (default 4).
+#	-i <irq_num>	Use this interrupt command source number (default 0).
+#	-k		Use the Stop_on_Invalid_Command and Restart logic.
+#	-l <loops>	Run this number of memcpy loops (default 1).
+#	-p <procs>	Fork this number of processes (default 1).
+#	-s <bufsize>	Copy this number of bytes (default 1024).
+#	-t		Do not memcpy. Test timebase sync instead.
+#	-e <timeout>		End timeout.
+#			Seconds to wait for the AFU to signal completion.
+# SAMPLE RUN
+# A typical run of the program would look like this:
+# ./memcpy_afu_ctx -e 10 -p 508 -l 10
+setup:
+  script: 'memcpy_afu_ctx'
+  general: !mux
+    memcpy_afu_ctx_1:
+        args: "-e 10 -p 508 -l 1"
+    memcpy_afu_ctx_2:
+        args: "-e 10 -p 508 -l 10"
+    memcpy_afu_ctx_3:
+        args: "-e 10 -p 508 -l 1000"
+    memcpy_afu_ctx_4:
+        args: "-e 10 -p 200 -l 100000"
+    memcpy_afu_ctx_5:
+        args: "-e 10 -p 100 -l 1000000"
+    memcpy_afu_ctx_6:
+        args: "-e 5 -p 508 -l 10"
+    cxl_eeh_tests.sh:
+      script: 'cxl_eeh_tests.sh'
+      args: ''
+      


### PR DESCRIPTION
This is to test CAPI cxl driver and libcxl library . Wrapper is making use of the test cases  at https://github.com/ibm-capi/cxl-tests

Signed-off-by: sudeesh john <sudeesh@linux.vnet.ibm.com>