### PR TITLE
Fixed cpu:numactl compilation issue

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado import main
-from avocado.utils import archive, build, process
+from avocado.utils import archive, build, process, distro
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -41,7 +41,17 @@ class Numactl(Test):
 
         # Check for basic utilities
         smm = SoftwareManager()
-        for package in ['gcc', 'numactl', 'autoconf', 'automake', 'make']:
+
+        detected_distro = distro.detect()
+        deps = ['gcc', 'libtool', 'autoconf', 'automake', 'make']
+        if detected_distro.name == "Ubuntu":
+            deps.extend(['libnuma-dev'])
+        elif detected_distro.name in ["centos", "rhel", "fedora"]:
+            deps.extend(['numactl-devel'])
+        else:
+            deps.extend(['libnuma-devel'])
+
+        for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel("Failed to install %s, which is needed for"
                             "the test to be run" % package)


### PR DESCRIPTION
1-fixed compilation issue as it is failing due to package missing
2- added numa package for all distribution

issue :

04:51:34 INFO | Running './autogen.sh'
04:51:40 DEBUG| [stderr] configure.ac:9: installing 'build-aux/install-sh'
04:51:40 DEBUG| [stderr] configure.ac:9: installing 'build-aux/missing'
04:51:40 DEBUG| [stderr] Makefile.am:8: error: Libtool library used but 'LIBTOOL' is undefined
04:51:40 DEBUG| [stderr] Makefile.am:8:   The usual way to define 'LIBTOOL' is to add 'LT_INIT'
04:51:40 DEBUG| [stderr] Makefile.am:8:   to 'configure.ac' and run 'aclocal' and 'autoconf' again.
04:51:40 DEBUG| [stderr] Makefile.am:8:   If 'LT_INIT' is in 'configure.ac', make sure
04:51:40 DEBUG| [stderr] Makefile.am:8:   its definition is in aclocal's search path.
04:51:40 DEBUG| [stderr] Makefile.am: installing 'build-aux/depcomp'
04:51:40 DEBUG| [stderr] parallel-tests: installing 'build-aux/test-driver'
04:51:40 DEBUG| [stderr] autoreconf: automake failed with exit status: 1
04:51:40 INFO | Command './autogen.sh' finished with 1 after 6.06579399109s

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>