### PR TITLE
Ltrace fix

### DIFF
--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -41,7 +41,7 @@ class Ltrace(Test):
         that needs to be installed, if not installed test will stop.
         """
 
-        sm = SoftwareManager()
+        smm = SoftwareManager()
         dist = distro.detect()
         dist_name = dist.name.lower()
 
@@ -66,7 +66,7 @@ class Ltrace(Test):
             self.cancel("Unsupported OS!")
 
         for package in packages:
-            if not sm.check_installed(package) and not sm.install(package):
+            if not smm.check_installed(package) and not smm.install(package):
                 self.cancel("Fail to install %s required for this test." %
                             package)
 
@@ -76,6 +76,8 @@ class Ltrace(Test):
 
         self.src_lt = os.path.join(self.srcdir, "ltrace")
         os.chdir(self.src_lt)
+        process.run('patch -p1 < %s' %
+                    os.path.join(self.datadir, 'ltrace.patch'), shell=True)
         process.run('./autogen.sh')
         process.run('./configure')
         build.make(self.src_lt)

--- a/toolchain/ltrace.py.data/ltrace.patch
+++ b/toolchain/ltrace.py.data/ltrace.patch
@@ -1,0 +1,40 @@
+--- ltrace_orig/sysdeps/linux-gnu/proc.c	2017-11-09 05:11:38.610000000 -0500
++++ ltrace/sysdeps/linux-gnu/proc.c	2017-11-09 06:00:45.140000000 -0500
+@@ -242,24 +242,27 @@ process_tasks(pid_t pid, pid_t **ret_tas
+ 	size_t alloc = 0;
+ 
+ 	while (1) {
+-		struct dirent entry;
+ 		struct dirent *result;
+-		if (readdir_r(d, &entry, &result) != 0) {
+-		fail:
+-			free(tasks);
+-			closedir(d);
+-			return -1;
+-		}
+-		if (result == NULL)
++		errno = 0;
++		result = readdir(d);
++		if (result == NULL) {
++			if (errno) {
++				free(tasks);
++				closedir(d);
++				return -1;
++			}
+ 			break;
++		}
+ 		if (result->d_type == DT_DIR && all_digits(result->d_name)) {
+ 			pid_t npid = atoi(result->d_name);
+ 			if (n >= alloc) {
+ 				alloc = alloc > 0 ? (2 * alloc) : 8;
+ 				pid_t *ntasks = realloc(tasks,
+ 							sizeof(*tasks) * alloc);
+-				if (ntasks == NULL)
+-					goto fail;
++				if (ntasks == NULL){
++					free(tasks);
++					return -1;
++				}
+ 				tasks = ntasks;
+ 			}
+ 			assert(n < alloc);


### PR DESCRIPTION
Fixed (cleanup) toolchain:ltrace 
1- removed build package dependencies from suse pacakge list
2- clean up
 a- removed redundant code for checking package dependencies
 b- change append list of package method
 c- change variable name to valid name

Fixed toolchain:ltrace compilation issue 

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
