### PR TITLE
 Add options in xfstests for user creation and deletion on SuSE

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -155,9 +155,11 @@ class Xfstests(Test):
                         for test in self.gen_exclude_tests:
                             fp.write('generic/%s\n' % test)
 
-        process.run('useradd fsgqa', sudo=True)
         if self.detected_distro.name is not 'SuSE':
             process.run('useradd 123456-fsgqa', sudo=True)
+            process.run('useradd fsgqa', sudo=True)
+        else:
+            process.run('useradd -m -U fsgqa', sudo=True)
         if not os.path.exists(self.scratch_mnt):
             os.makedirs(self.scratch_mnt)
         if not os.path.exists(self.test_mnt):
@@ -196,9 +198,12 @@ class Xfstests(Test):
             self.fail('One or more tests failed. Please check the logs.')
 
     def tearDown(self):
-        process.system('userdel fsgqa', sudo=True)
         if self.detected_distro.name is not 'SuSE':
             process.system('userdel 123456-fsgqa', sudo=True)
+            process.system('userdel fsgqa', sudo=True)
+        else:
+            process.system('userdel -r -f fsgqa', sudo=True)
+            process.system('groupdel fsgqa', sudo=True)
         # In case if any test has been interrupted
         process.system('umount %s %s' % (self.scratch_mnt, self.test_mnt),
                        sudo=True, ignore_status=True)

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -160,6 +160,7 @@ class Xfstests(Test):
             process.run('useradd fsgqa', sudo=True)
         else:
             process.run('useradd -m -U fsgqa', sudo=True)
+            process.run('groupadd sys', sudo=True)
         if not os.path.exists(self.scratch_mnt):
             os.makedirs(self.scratch_mnt)
         if not os.path.exists(self.test_mnt):
@@ -204,6 +205,7 @@ class Xfstests(Test):
         else:
             process.system('userdel -r -f fsgqa', sudo=True)
             process.system('groupdel fsgqa', sudo=True)
+            process.system('groupdel sys', sudo=True)
         # In case if any test has been interrupted
         process.system('umount %s %s' % (self.scratch_mnt, self.test_mnt),
                        sudo=True, ignore_status=True)


### PR DESCRIPTION
xfstests user specific tests fail due to lack of home dir creation on SuSE. This patch adds option to do the same.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>