### PR TITLE
code to git clone upstream sysbench

### DIFF
--- a/generic/sysbench.py.data/sysbench.yaml
+++ b/generic/sysbench.py.data/sysbench.yaml
@@ -1,5 +1,8 @@
 max-time: null
 max-request: null
+url-link: 'https://github.com/akopytov/sysbench.git'
+#Comment out branch if you want to checkout master.
+branch: '0.4'
 tests:
   types: !mux
     cpu:


### PR DESCRIPTION
Few distro does not provide sysbench as part of ISO, For those
distros git clone upstream sysbench, compile and use it.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>