### PR TITLE
Fix regex for failure in kselftest

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -51,9 +51,8 @@ class kselftest(Test):
                          'libpopt-dev', 'libcap-ng0', 'libcap-ng-dev',
                          'libnuma-dev', 'libfuse-dev'])
         elif 'SuSE' in detected_distro.name:
-            deps.extend(['popt', 'glibc', 'glibc-devel',
-                         'popt-devel', 'libcap1', 'libcap1-devel',
-                         'libcap-ng', 'libcap-ng-devel'])
+            deps.extend(['popt', 'glibc', 'glibc-devel', 'popt-devel',
+                         'libcap2', 'libcap-devel', 'libcap-ng-devel'])
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -88,7 +88,7 @@ class kselftest(Test):
                 error = True
                 self.log.info("Testcase failed. Log from build: %s" % line)
         for line in open(os.path.join(self.logdir, 'debug.log')).readlines():
-            match = re.search(r'selftests:\s+\w+\s+\[FAIL]', line)
+            match = re.search(r'selftests:(.*)\[FAIL\]', line)
             if match:
                 error = True
                 self.log.info("Testcase failed. Log from debug: %s" %


### PR DESCRIPTION
Few test failures are not getting captured due to regex mismatch. sample failure: tm-unavailable. This patch fixes it.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>