### PR TITLE
Fix: Test will check the processor chipset

### DIFF
--- a/io/pci/PowerVMEEH.py
+++ b/io/pci/PowerVMEEH.py
@@ -56,6 +56,8 @@ class PowerVMEEH(Test):
         """
         Gets the console and set-up the machine for test
         """
+        if 'ppc' not in process.system_output(cmd, ignore_status=True):
+            self.cancel("Processor is not ppc64")
         output = genio.read_file("/sys/kernel/debug/powerpc/eeh_enable")\
             .strip()
         if output != '0x1':


### PR DESCRIPTION
Test will now check the processor chipset, if its not
Power processor, test will exit.

Signed-off-by: Venkat R B <vrbagal1@linux.vnet.ibm.com>