### PR TITLE
Fix openblas syntax

### DIFF
--- a/generic/openblas.py
+++ b/generic/openblas.py
@@ -37,7 +37,7 @@ class Openblas(Test):
         if detected_distro.name == "Ubuntu":
             packages.append("gfortran")
         elif detected_distro.name == "SuSE":
-            packages.append("gcc-fortran", "libgfortran4")
+            packages.append(["gcc-fortran", "libgfortran4"])
         else:
             packages.append("gcc-gfortran")
         for package in packages:


### PR DESCRIPTION
Openblas test failed with wrong syntax on list append. Patch fixes the syntax.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>