### PR TITLE
Fixed Suse package issue in kernel:kernbench

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -93,7 +93,7 @@ class Kernbench(Test):
                          'libnuma-dev', 'libfuse-dev'])
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
-                         'popt-devel', 'libcap1', 'libcap-devel',
+                         'popt-devel', 'libcap2', 'libcap-devel',
                          'libcap-ng-devel'])
         elif detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',


### PR DESCRIPTION
test run is failing due to wrong package dependencies

[stdout] 'libcap1' not found in package names. Trying capabilities.
[stderr] No provider of 'libcap1' found.
Command '/usr/bin/zypper -n install -l libcap1' finished with 104 after 1.40578007698s

Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_framework-56.0-py2.7.egg/avocado/core/test.py:796
Traceback (most recent call last):
  File "/root/avocado-misc-tests/kernel/kernbench.py", line 105, in setUp
    self.cancel('%s is needed for the test to be run' % package)
  File "/usr/lib/python2.7/site-packages/avocado_framework-56.0-py2.7.egg/avocado/core/test.py", line 1032, in cancel
    raise exceptions.TestCancel(message)
TestCancel: libcap1 is needed for the test to be run

CANCEL 1-kernbench.py:Kernbench.test -> TestCancel: libcap1 is needed for the test to be run

Not logging /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor (file does not exist)
Not logging /proc/pci (file does not exist)

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>