### PR TITLE
Fixed issue in kernel:kernbench

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -55,8 +55,7 @@ class Kernbench(Test):
         else:
             build_string = "/usr/bin/time -o %s make -j %s vmlinux" % (
                 timefile, threads)
-        process.system(build_string, allow_output_check='None',
-                       ignore_status=True, shell=True)
+        process.system(build_string, ignore_status=True, shell=True)
         if not os.path.isfile('vmlinux'):
             self.fail("No vmlinux found, kernel build failed")
 


### PR DESCRIPTION
fixed issue in test as value of allow_output_check should not be 'None' it should be None

issue:

Command 'make oldnoconfig' finished with 0 after 4.20647501945s

Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_framework-56.0-py2.7.egg/avocado/core/test.py:819
Traceback (most recent call last):
  File "/root/avocado-misc-tests/kernel/kernbench.py", line 135, in test
    self.time_build(self.threads, timefile,"")
  File "/root/avocado-misc-tests/kernel/kernbench.py", line 59, in time_build
    ignore_status=True, shell=True)
  File "/usr/lib/python2.7/site-packages/avocado_framework-56.0-py2.7.egg/avocado/utils/process.py", line 1240, in system
    sudo=sudo, ignore_bg_processes=ignore_bg_processes)
  File "/usr/lib/python2.7/site-packages/avocado_framework-56.0-py2.7.egg/avocado/utils/process.py", line 1188, in run
    sudo=sudo, ignore_bg_processes=ignore_bg_processes)
  File "/usr/lib/python2.7/site-packages/avocado_framework-56.0-py2.7.egg/avocado/utils/process.py", line 441, in __init__
    raise ValueError(msg)
ValueError: Invalid value (None) set in allow_output_check

Local variables:
 -> system_time <type 'int'>: 0
 -> run <type 'int'>: 0
 -> self <class 'kernbench.Kernbench'>: 1-avocado-misc-tests/kernel/kernbench.py:Kernbench.test
 -> elapsed_time <type 'int'>: 0
 -> tarball <type 'str'>: /home/shruvenk/avocado-fvt-wrapper/data/cache/kernbench.zip
 -> timefile <type 'str'>: /var/tmp/avocado_B676u6/1-avocado-misc-tests_kernel_kernbench.py_Kernbench.test/src/linux-master/time_file
 -> user_time <type 'int'>: 0
DATA (filename=stdout.expected) => NOT FOUND (data sources: variant, test, file)
DATA (filename=stderr.expected) => NOT FOUND (data sources: variant, test, file)
Traceback (most recent call last):

  File "/usr/lib/python2.7/site-packages/avocado_framework-56.0-py2.7.egg/avocado/core/test.py", line 893, in _run_avocado
    raise test_exception

ValueError: Invalid value (None) set in allow_output_check

ERROR 1-avocado-misc-tests/kernel/kernbench.py:Kernbench.test -> ValueError: Invalid value (None) set in allow_output_check

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>