### PR TITLE
Remove unnecessary check for command existence

### DIFF
--- a/generic/sosreport.py
+++ b/generic/sosreport.py
@@ -42,9 +42,7 @@ class sosreport_test(Test):
         dist = distro.detect()
         sm = SoftwareManager()
         sos_pkg = ""
-        if not process.system("sosreport", ignore_status=True, sudo=True):
-            self.log.info("sosreport is installed")
-        elif dist.name == 'Ubuntu':
+        if dist.name == 'Ubuntu':
             sos_pkg = 'sosreport'
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility


### PR DESCRIPTION
This command fails on SuSE
01:51:43 INFO | Running 'sosreport'
01:51:43 ERROR|
01:51:43 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_framework-55.0-py2.7.egg/avocado/core/test.py:797
01:51:43 ERROR| Traceback (most recent call last):
01:51:43 ERROR|   File "/home/harish/avocado-fvt-wrapper/tests/avocado-misc-tests/generic/sosreport.py", line 45, in setUp
01:51:43 ERROR|     if not process.system("sosreport", ignore_status=True, sudo=True):
01:51:43 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_framework-55.0-py2.7.egg/avocado/utils/process.py", line 1165, in system
01:51:43 ERROR|     sudo=sudo, ignore_bg_processes=ignore_bg_processes)
01:51:43 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_framework-55.0-py2.7.egg/avocado/utils/process.py", line 1114, in run
01:51:43 ERROR|     cmd_result = sp.run(timeout=timeout)
01:51:43 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_framework-55.0-py2.7.egg/avocado/utils/process.py", line 638, in run
01:51:43 ERROR|     self._init_subprocess()
01:51:43 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_framework-55.0-py2.7.egg/avocado/utils/process.py", line 402, in _init_subprocess
01:51:43 ERROR|     raise details
01:51:43 ERROR| OSError: [Errno 2] No such file or directory (sosreport)
01:51:43 ERROR|

Signed-off-by: Harish <harish@linux.vnet.ibm.com>