### PR TITLE
consider link encapsulation output of ifconfig

### DIFF
--- a/generic/lshw.py
+++ b/generic/lshw.py
@@ -30,7 +30,7 @@ class Lshwrun(Test):
     machines (PowerMac G4 is known to work).
     """
     interface = process.system_output("ip route show")
-    active_interface = process.system_output("ifconfig | head -1 | cut -d':' -f1", shell=True).strip()
+    active_interface = process.system_output("ifconfig | head -1 | cut -d':' -f1", shell=True).strip().split()[0]
     fail_cmd = list()
 
     def run_cmd(self, cmd):


### PR DESCRIPTION
The call of ifconfig may contain info about the
link encapsulation in the output in addition to
the network interface. If the link encapsulation
info is not included in the output `.split()[0]` works
as well.

Reference: GH-739
Signed-off-by: kromer <florian.kromer@roboception.de>