### PR TITLE
Add patch to ltrace test

### DIFF
--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -46,7 +46,7 @@ class Ltrace(Test):
         dist_name = dist.name.lower()
 
         packages = ['gcc', 'wget', 'autoconf', 'automake',
-                    'dejagnu', 'binutils']
+                    'dejagnu', 'binutils', 'patch']
 
         if dist_name == 'suse':
             packages.extend(['libdw-devel', 'libelf-devel', 'git-core',


### PR DESCRIPTION
Test failed with patch command not available, this patch fixes it

Running 'patch -p1 < /root/avocado-fvt-wrapper/tests/avocado-misc-ests/toolchain/ltrace.py.data/ltrace.patch'
 [stderr] /bin/sh: patch: command not found
 Command 'patch -p1 < /root/avocado-fvt-wrapper/tests/avocado-misc-tests/toolchain/ltrace.py.data/ltrace.patch' finished with 127 after 0.00122499465942s

Signed-off-by: Harish <harish@linux.vnet.ibm.com>