### PR TITLE
Support to run distribution specific ltrace test

### DIFF
--- a/toolchain/ltrace.py.data/ltrace.yaml
+++ b/toolchain/ltrace.py.data/ltrace.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        url: 'git://git.debian.org/git/collab-maint/ltrace.git'
+        type: 'upstream'
+    distro:
+        type: 'distro'


### PR DESCRIPTION
Added support to run tests from distrution ltrace source

Signed-off-by: Harish <harish@linux.vnet.ibm.com>