### PR TITLE
Compressing multiple yaml into 1

### DIFF
--- a/io/disk/fiotest.py.data/fio-perf.yaml
+++ b/io/disk/fiotest.py.data/fio-perf.yaml
@@ -1,0 +1,19 @@
+parameters:
+    dir: '/mnt'
+    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
+job: !mux
+    rand-RW:
+        fio_job: 'fio-rand-RW.job'
+    fio-rand-read:
+        fio_job: 'fio-rand-read.job'
+    fio-rand-write:
+        fio_job: 'fio-rand-write.job'
+    fio-seq-RW:
+        fio_job: 'fio-seq-RW.job' 
+    fio-seq-read:
+        fio_job: 'fio-seq-read.job'
+    fio-seq-write:
+        fio_job: 'fio-seq-write.job'
+filesystem: !mux
+    ext4:
+        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_rand_RW.yaml
+++ b/io/disk/fiotest.py.data/fio_rand_RW.yaml
@@ -1,8 +1,0 @@
-fio_randRW.yaml:
-parameters:
-    dir: '/mnt'
-    fio_job: 'fio-rand-RW.job'
-    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
-filesystem: !mux
-    ext4:
-        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_rand_read.yaml
+++ b/io/disk/fiotest.py.data/fio_rand_read.yaml
@@ -1,8 +1,0 @@
-fio_randread.yaml:
-parameters:
-    dir: '/mnt'
-    fio_job: 'fio-rand-read.job'
-    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
-filesystem: !mux
-    ext4:
-        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_rand_write.yaml
+++ b/io/disk/fiotest.py.data/fio_rand_write.yaml
@@ -1,8 +1,0 @@
-fio_randwrite.yaml:
-parameters:
-    dir: '/mnt'
-    fio_job: 'fio-rand-write.job'
-    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
-filesystem: !mux
-    ext4:
-        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seq_RW.yaml
+++ b/io/disk/fiotest.py.data/fio_seq_RW.yaml
@@ -1,8 +1,0 @@
-fio_seqRW.yaml:
-parameters:
-    dir: '/mnt'
-    fio_job: 'fio-seq-RW.job'
-    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
-filesystem: !mux
-    ext4:
-        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seq_read.yaml
+++ b/io/disk/fiotest.py.data/fio_seq_read.yaml
@@ -1,9 +1,0 @@
-parameters:
-    dir: '/mnt'
-    fio_job: !mux
-       fio-seq-read:
-         fio_job: 'fio-seq-read.job'
-       fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
-filesystem: !mux
-    ext4:
-        fs: 'ext4'

--- a/io/disk/fiotest.py.data/fio_seq_write.yaml
+++ b/io/disk/fiotest.py.data/fio_seq_write.yaml
@@ -1,8 +1,0 @@
-fio_seqwrite.yaml:
-parameters:
-    dir: '/mnt'
-    fio_job: 'fio-seq-write.job'
-    fio_tool_url: 'http://brick.kernel.dk/snaps/fio-2.99.tar.gz'
-filesystem: !mux
-    ext4:
-        fs: 'ext4'


### PR DESCRIPTION
In reference to commit 3cc16493d034db3a385ab06941267337ff987ce8,
wherein since profilers and sysinfo per test was not supported,
we allowed this commit to have multiple yaml files.

Since that was fixed in avocado, we are compressing the yaml files
into single yaml.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>