### PR TITLE
Fix dma_memtest for tmp dir creation

### DIFF
--- a/memory/dma_memtest.py
+++ b/memory/dma_memtest.py
@@ -118,7 +118,8 @@ class DmaMemtest(Test):
         for j in range(self.sim_cps):
             tmp_dir = 'linux.%s' % j
             if self.parallel:
-                os.mkdir(tmp_dir)
+                if not os.path.exists(tmp_dir):
+                    os.mkdir(tmp_dir)
                 # Start parallel process
                 tar_cmd = 'tar jxf ' + self.tarball + ' -C ' + tmp_dir
                 self.log.info("Unpacking tarball to %s", tmp_dir)

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -54,7 +54,8 @@ class Thp(Test):
         self.count = free_mem / self.block_size
 
         # Mount device as per free memory size
-        os.mkdir(self.mem_path)
+        if not os.path.exists(self.mem_path):
+            os.mkdir(self.mem_path)
         self.device = Partition(device="none", mountpoint=self.mem_path)
         self.device.mount(mountpoint=self.mem_path, fstype="tmpfs",
                           args='-o size=%dM' % free_mem)

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -51,7 +51,8 @@ class Thp_Defrag(Test):
         self.mem_path = os.path.join(data_dir.get_tmp_dir(), 'thp_space')
         self.block_size = int(mmap.PAGESIZE) / 1024
         # add mount point
-        os.mkdir(self.mem_path)
+        if os.path.exists(self.mem_path):
+            os.mkdir(self.mem_path)
         self.device = Partition(device="none", mountpoint=self.mem_path)
         self.device.mount(mountpoint=self.mem_path, fstype="tmpfs")
         free_space = (disk.freespace(self.mem_path)) / 1024


### PR DESCRIPTION
Test error's out as mkdir fails as it already exists. Patch fixes it.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>