### PR TITLE
Fix: ignore the kill command status

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -116,7 +116,7 @@ class cpustresstest(Test):
     @staticmethod
     def __kill_process(pids):
         for pid in pids:
-            process.run("kill -9 %s" % pid)
+            process.run("kill -9 %s" % pid, ignore_status=True)
 
     def test(self):
         """


### PR DESCRIPTION
Some times the process gets killed while testing affinity as expected,
so kill command fails when process not found so ignore the sataus

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>