### PR TITLE
Fix memory tests for multi-level makedirs

### DIFF
--- a/memory/dma_memtest.py
+++ b/memory/dma_memtest.py
@@ -119,7 +119,7 @@ class DmaMemtest(Test):
             tmp_dir = 'linux.%s' % j
             if self.parallel:
                 if not os.path.exists(tmp_dir):
-                    os.mkdir(tmp_dir)
+                    os.makedirs(tmp_dir)
                 # Start parallel process
                 tar_cmd = 'tar jxf ' + self.tarball + ' -C ' + tmp_dir
                 self.log.info("Unpacking tarball to %s", tmp_dir)

--- a/memory/stutter.py
+++ b/memory/stutter.py
@@ -58,7 +58,8 @@ class Stutter(Test):
         self._logdir = self.params.get('logdir', default='/var/tmp/logdir')
         self._rundir = self.params.get('rundir', default='/tmp')
 
-        process.run('mkdir -p  %s' % self._logdir)
+        if not os.path.exists(self._logdir):
+            os.makedirs(self._logdir)
 
         # export env variable, used by test script
         os.environ['MEMTOTAL_BYTES'] = self._memory

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -55,7 +55,7 @@ class Thp(Test):
 
         # Mount device as per free memory size
         if not os.path.exists(self.mem_path):
-            os.mkdir(self.mem_path)
+            os.makedirs(self.mem_path)
         self.device = Partition(device="none", mountpoint=self.mem_path)
         self.device.mount(mountpoint=self.mem_path, fstype="tmpfs",
                           args='-o size=%dM' % free_mem)

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -52,7 +52,7 @@ class Thp_Defrag(Test):
         self.block_size = int(mmap.PAGESIZE) / 1024
         # add mount point
         if os.path.exists(self.mem_path):
-            os.mkdir(self.mem_path)
+            os.makedirs(self.mem_path)
         self.device = Partition(device="none", mountpoint=self.mem_path)
         self.device.mount(mountpoint=self.mem_path, fstype="tmpfs")
         free_space = (disk.freespace(self.mem_path)) / 1024


### PR DESCRIPTION
Patch replaces mkdir to makedirs to support creation of mult-level directory.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>