### PR TITLE
This patch will add a multicast route to the peer to

### DIFF
--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -79,6 +79,11 @@ class ReceiveMulticastTest(Test):
         if process.system(cmd, shell=True, verbose=True,
                           ignore_status=True) != 0:
             self.fail("unable to set all mulicast option to test interface")
+        msg = "ip route add 224.0.0.0/4 dev %s" % self.peerif
+        cmd = "ssh %s@%s \"%s\"" % (self.user, self.peer, msg)
+        if process.system(cmd, shell=True, verbose=True,
+                          ignore_status=True) != 0:
+            self.fail("Unable to add route for Peer interafce")
         msg = "ping -I %s 224.0.0.1 -c 1 | grep %s" %\
               (self.peerif, self.local_ip)
         cmd = "timeout 600 ssh %s@%s \"%s\"" % (self.user, self.peer, msg)
@@ -87,8 +92,13 @@ class ReceiveMulticastTest(Test):
 
     def tearDown(self):
         '''
-        turn off multicast option
+        delete multicast route and turn off multicast option
         '''
+        msg = "ip route del 224.0.0.0/4"
+        cmd = "ssh %s@%s \"%s\"" % (self.user, self.peer, msg)
+        if process.system(cmd, shell=True, verbose=True,
+                          ignore_status=True) != 0:
+            self.log.info("Unable to delete multicast route added for peer")
         cmd = "echo 1 > /proc/sys/net/ipv4/icmp_echo_ignore_broadcasts"
         if process.system(cmd, shell=True, verbose=True,
                           ignore_status=True) != 0:


### PR DESCRIPTION
ensure that the multicasts to the peer will go via
this route from the test interface

Signed-off-by: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>