### PR TITLE
Added memory-fork test for memory sanity test

### DIFF
--- a/memory/fork_mem.py
+++ b/memory/fork_mem.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2018 IBM
+# Author: Harish <harish@linux.vnet.ibm.com>
+#
+
+
+import os
+import shutil
+from avocado import Test
+from avocado import main
+from avocado.utils import process, build, memory
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Forkoff(Test):
+    """
+    Perform mmap and process forking to maxiumum extent
+
+    :avocado: tags=memory
+    """
+
+    def setUp(self):
+        '''
+        Use 85% of memory with/without many process forked
+        WARNING: System may go out-of-memory based on the available resource
+        '''
+        smm = SoftwareManager()
+        self.itern = int(self.params.get('iterations', default='10'))
+        self.procs = int(self.params.get('procs', default='1'))
+        self.minmem = int(self.params.get('minmem', default='10'))
+        self.fails = []
+
+        if not (self.itern and self.procs and self.minmem):
+            self.cancel(
+                'Please use a non-zero value for number'
+                ' of iterations, processes and memory to be used')
+
+        self.freemem = int((0.85 * memory.freememtotal()) / 1024)
+        # Check for basic utilities
+        for packages in ['gcc', 'make']:
+            if not smm.check_installed(packages) and not smm.install(packages):
+                self.cancel('%s is needed for the test to be run' % packages)
+
+        shutil.copyfile(os.path.join(self.datadir, 'forkoff.c'),
+                        os.path.join(self.teststmpdir, 'forkoff.c'))
+
+        shutil.copyfile(os.path.join(self.datadir, 'Makefile'),
+                        os.path.join(self.teststmpdir, 'Makefile'))
+
+        build.make(self.teststmpdir)
+
+    def run_test(self, mem, proc, itern):
+        cmd = "./forkoff %s %s %s" % (mem, proc, itern)
+        if process.system(cmd, shell=True, ignore_status=True) != 0:
+            self.fails.append(cmd)
+
+    def test(self):
+        '''
+        Execute memory fork off tests
+        1. Total memory with one process
+        2. Split memeory between given processes
+        3. Maximum process with minimum memory (10 MB) per process
+        '''
+        os.chdir(self.teststmpdir)
+
+        self.run_test(self.freemem, 1, self.itern)
+        self.run_test(self.freemem / self.procs, self.procs, self.itern)
+        self.run_test(self.minmem, self.freemem / self.minmem, self.itern)
+
+        if self.fails:
+            self.fail("The following test(s) failed: %s" % self.fails)
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/fork_mem.py.data/Makefile
+++ b/memory/fork_mem.py.data/Makefile
@@ -1,0 +1,7 @@
+all : forkoff
+
+forkoff_test : forkoff.c
+	gcc forkoff.c -o $@
+
+clean :
+	rm forkoff

--- a/memory/fork_mem.py.data/fork_mem.yaml
+++ b/memory/fork_mem.py.data/fork_mem.yaml
@@ -1,0 +1,5 @@
+setup:
+ iterations: 1
+ procs: 10
+ # in MB
+ minmem: 10

--- a/memory/fork_mem.py.data/forkoff.c
+++ b/memory/fork_mem.py.data/forkoff.c
@@ -1,0 +1,62 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE for more details.
+ * Copyright: 2018 IBM
+ *
+ * Author:       Larry Woodman <lwoodman@redhat.com>
+ * Modified By:  Harish <harish@linux.vnet.ibm.com>
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <stdio.h>
+
+main(int argc,char *argv[])
+{
+        unsigned long size, psize, procs, itterations;
+        char    *ptr;
+        char    *i;
+        int     pid, j, k, status;
+
+        if ((argc <= 1)||(argc >4)) {
+                printf("bad args, usage: forkoff <memsize MB> #children #itterations\n");
+                exit(-1);
+        }
+        size = ((long)atol(argv[1])*1024*1024);
+        psize = getpagesize();
+        procs = atol(argv[2]);
+        itterations = atol(argv[3]);
+        printf("mmaping %ld anonymous bytes\n", size);
+        ptr = (char *)mmap((void *)0, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+        if ( ptr == (char *) -1 ) {
+                printf("address = %lx\n", ptr);
+                perror("");
+        }
+        k = procs;
+        do{
+                pid = fork();
+                if (pid == -1) {
+                        printf("fork failure\n");
+                        exit(-1);
+                } else if (!pid) {
+			printf("PID %d touching %d pages\n", getpid(), size/psize);
+
+                        for (j=0; j<itterations; j++) {
+                                for (i = ptr; i < ptr + size - 1; i += psize) {
+					*i=(char)'i';
+                                }
+                        }
+			exit(0);
+		}
+	} while(--k);
+	while (procs-- && wait(&status));
+}


### PR DESCRIPTION
Test has three scenarios each of which uses 85% of the free memory by creating processes and using some part of memory per process.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>