### PR TITLE
Fix numatop compilation

### DIFF
--- a/cpu/numatop.py
+++ b/cpu/numatop.py
@@ -47,7 +47,8 @@ class Numatop(Test):
         if not detected_distro == "ubuntu":
             self.cancel("Upsupported OS %s" % detected_distro)
         smm = SoftwareManager()
-        for package in ['gcc', 'numatop', 'make', 'libnuma-dev']:
+        for package in ['gcc', 'numatop', 'make', 'libnuma-dev',
+                        'libncurses-dev']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel("Failed to install %s, which is needed for"
                             "the test to be run" % package)


### PR DESCRIPTION
numatop compile failed due to a package install failure. Patch adds the package required

Signed-off-by: Harish <harish@linux.vnet.ibm.com>