### PR TITLE
Added memory_api test to check memory syscalls

### DIFF
--- a/memory/memory_api.py
+++ b/memory/memory_api.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2018 IBM
+# Author: Harish <harish@linux.vnet.ibm.com>
+#
+# Based on code by Ranjit Manomohan <ranjitm@google.com>
+#   copyright: 2008 Google Inc.
+#   https://github.com/autotest/autotest-client-tests/tree/master/memory_api
+#
+
+
+import os
+import shutil
+from avocado import Test
+from avocado import main
+from avocado.utils import process, build, memory
+from avocado.utils.software_manager import SoftwareManager
+
+
+class MemorySyscall(Test):
+    """
+    Excercises malloc, mmap, mprotect, mremap syscalls with 90 %
+    of the machine's free memory
+    """
+
+    def copyutil(self, file_name):
+        shutil.copyfile(os.path.join(self.datadir, file_name),
+                        os.path.join(self.teststmpdir, file_name))
+
+    def setUp(self):
+        smm = SoftwareManager()
+        self.memsize = int(self.params.get(
+            'memory_size', default=(memory.freememtotal() / 1024)) * 1048576 * 0.5)
+
+        for package in ['gcc', 'make']:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+        for file_name in ['memory_api.c', 'mremap.c', 'Makefile']:
+            self.copyutil(file_name)
+
+        build.make(self.teststmpdir)
+
+    def test(self):
+        os.chdir(self.teststmpdir)
+        proc = process.SubProcess('./memory_api %s ' % self.memsize,
+                                  shell=True, allow_output_check='both')
+        proc.start()
+        while proc.poll() is None:
+            pass
+
+        if proc.poll() != 0:
+            self.fail("Unexpected application abort, check for possible issues")
+
+        self.log.info("Testing mremap with minimal memory and expand it")
+        if process.system('./mremap %s' % str(int(memory.freememtotal())), ignore_status=True):
+            self.fail('Mremap expansion failed')
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/memory_api.py.data/Makefile
+++ b/memory/memory_api.py.data/Makefile
@@ -1,0 +1,10 @@
+all : memory_api mremap
+
+memory_api : memory_api.c
+	gcc memory_api.c -o $@
+
+mremap : mremap.c
+	gcc mremap.c -o $@
+
+clean :
+	rm memory_api mremap

--- a/memory/memory_api.py.data/memory_api.c
+++ b/memory/memory_api.py.data/memory_api.c
@@ -1,0 +1,165 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE for more details.
+ * Copyright: 2017 IBM
+ * Author: Ranjit Manomohan <ranjitm@google.com>
+ * Modified by: Harish<harish@linux.vnet.ibm.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+/* This file includes a simple set of memory allocation calls that
+ * a user space program can use to allocate/free or move memory mappings.
+ * The intent of this program is to make it easier to verify if the kernel
+ * internal mappings are correct. */
+
+#define PAGE_SHIFT 12
+
+#define ROUND_PAGES(memsize) ((memsize >> (PAGE_SHIFT)) << PAGE_SHIFT)
+
+/* approximately half of memsize, page aligned */
+#define HALF_MEM(memsize) ((memsize >> (PAGE_SHIFT))<<(PAGE_SHIFT - 1))
+
+void *mremap(void *old_address, size_t old_size,
+                    size_t new_size, int flags, ... /* void *new_address */);
+
+
+int main(int argc, char *argv[]) {
+	unsigned long i, numpages, fd, pagesize, memsize;
+	char *mem;
+        pagesize = getpagesize();
+	if (argc != 2) {
+		printf("Usage: %s <memory_size>\n", argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	memsize = strtoul(argv[1], NULL, 10);
+
+	memsize = ROUND_PAGES(memsize);
+
+	/* We should be limited to < 4G so any size other than 0 is ok */
+	if (memsize == 0) {
+		printf("Invalid memsize\n");
+		exit(EXIT_FAILURE);
+	}
+
+
+	numpages = memsize / pagesize;
+
+	mlockall(MCL_FUTURE);
+
+	mem = malloc(memsize);
+
+	if (mem == (void*) -1) {
+		perror("Failed to allocate memory using malloc\n");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Successfully allocated malloc memory %lu bytes @%p\n",
+				memsize,  mem);
+
+	sleep(1);
+
+	free(mem);
+	mem =  mmap(0, memsize, PROT_READ | PROT_WRITE,
+			MAP_PRIVATE| MAP_ANONYMOUS,
+			-1, 0);
+
+	if (mem == (void*) -1) {
+		perror("Failed to allocate anon private memory using mmap\n");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Successfully allocated anon mmap memory %lu bytes @%p\n",
+				memsize,  mem);
+
+	sleep(1);
+
+	if (-1 == mprotect(mem, HALF_MEM(memsize), PROT_READ)) {
+		perror("Failed to W protect memory using mprotect\n");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Successfully write protected %lu bytes @%p\n",
+			HALF_MEM(memsize), mem);
+
+	sleep(1);
+
+	if (-1 == mprotect(mem, HALF_MEM(memsize),
+					 PROT_READ | PROT_WRITE)) {
+		perror("Failed to RW protect memory using mprotect\n");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Successfully cleared write protected %lu bytes @%p\n",
+			HALF_MEM(memsize), mem);
+	sleep(1);
+
+	/* Mark all pages with a specific pattern */
+	for (i = 0; i < numpages; i++) {
+		unsigned long *ptr = (unsigned long *)(mem + i*pagesize);
+		*ptr = i;
+	}
+
+	mem = mremap(mem , memsize,
+				memsize + HALF_MEM(memsize),
+				1 /* MREMAP_MAYMOVE */);
+
+	if (mem == MAP_FAILED) {
+		perror("Failed to remap expand anon private memory\n");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Successfully remapped %lu bytes @%p\n",
+			memsize + HALF_MEM(memsize), mem);
+
+	sleep(1);
+	/* Read all pages to check the pattern */
+	for (i = 0; i < numpages; i++) {
+		unsigned long value = *(unsigned long*)(mem + i*pagesize);
+		if (value != i) {
+			printf("remap error expected %lu got %lu\n",
+					i, value);
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	if (munmap(mem, memsize + HALF_MEM(memsize))) {
+		perror("Could not unmap and free memory\n");
+		exit(EXIT_FAILURE);
+	}
+
+
+	fd = open("/dev/zero", O_RDONLY);
+
+	mem =  mmap(0, memsize, PROT_READ | PROT_WRITE,
+			MAP_PRIVATE,
+			fd, 0);
+
+	if (mem == (void*) -1) {
+		perror("Failed to allocate file backed memory using mmap\n");
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Successfully allocated file backed mmap memory %lu bytes @%p\n",
+					 memsize, mem);
+	sleep(1);
+
+	if (munmap(mem, memsize)) {
+		perror("Could not unmap and free file backed memory\n");
+		exit(EXIT_FAILURE);
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/memory/memory_api.py.data/memory_api.yaml
+++ b/memory/memory_api.py.data/memory_api.yaml
@@ -1,0 +1,2 @@
+setup:
+ memory_size: 10 # in MB

--- a/memory/memory_api.py.data/mremap.c
+++ b/memory/memory_api.py.data/mremap.c
@@ -1,0 +1,98 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE for more details.
+ * Copyright: 2017 IBM
+ * Author: Ranjit Manomohan <ranjitm@google.com>
+ * Modified by: Harish<harish@linux.vnet.ibm.com>
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+/* This program allocates memory with multiple calls to remap. This
+ * can be used to verify if the remap api is working correctly. */
+
+#define PAGE_SHIFT 12
+
+#define ROUND_PAGES(memsize) ((memsize >> (PAGE_SHIFT)) << PAGE_SHIFT)
+
+void *mremap(void *old_address, size_t old_size,
+                    size_t new_size, int flags, ... /* void *new_address */);
+
+
+int main(int argc, char *argv[]) {
+	unsigned long memsize, pagesize, i, fd;
+	char *mem;
+
+	if (argc != 2) {
+		printf("Usage: %s <memory_size>\n", argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	memsize = strtoul(argv[1], NULL, 10);
+
+	memsize = ROUND_PAGES(memsize);
+
+	/* We should be limited to < 4G so any size other than 0 is ok */
+	if (memsize == 0) {
+		printf("Invalid memsize\n");
+		exit(EXIT_FAILURE);
+	}
+
+
+	mem =  mmap(0, memsize, PROT_READ | PROT_WRITE,
+			MAP_PRIVATE | MAP_ANONYMOUS,
+			-1, 0);
+
+	if (mem == (void*) -1) {
+		perror("Failed to allocate anon private memory using mmap\n");
+		exit(EXIT_FAILURE);
+	}
+
+	for (i = 2; i <= 16; i <<= 1) {
+		mem = mremap(mem , memsize * (i >> 1),
+					memsize * i,
+					1 /* MREMAP_MAYMOVE */);
+
+		if (mem == MAP_FAILED) {
+			perror("Failed to remap expand anon private memory\n");
+			exit(EXIT_FAILURE);
+		}
+
+		printf("Successfully remapped %lu bytes @%p\n",
+				memsize * i, mem);
+	}
+
+	if (munmap(mem, memsize * 16)) {
+		perror("Could not unmap and free memory\n");
+		exit(EXIT_FAILURE);
+	}
+
+	mem =  mmap(0, memsize, PROT_READ | PROT_WRITE,
+			MAP_PRIVATE | MAP_ANONYMOUS,
+			-1, 0);
+
+	if (mem == (void*) -1) {
+		perror("Failed to allocate anon private memory using mmap\n");
+		exit(EXIT_FAILURE);
+	}
+
+        if (munmap(mem, memsize)) {
+                perror("Could not unmap and free file backed memory\n");
+                exit(EXIT_FAILURE);
+        }
+
+
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
Patch adds memory_api tests from autotest. Modified code necessary to be architecture independent.

Source: https://github.com/autotest/autotest-client-tests/blob/master/memory_api/

Signed-off-by: Harish <harish@linux.vnet.ibm.com>