### PR TITLE
Add numa scenario in stress-ng

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -96,6 +96,8 @@ class stressng(Test):
             elif 'cpu' in self.class_type:
                 self.workers = 2 * multiprocessing.cpu_count()
                 args.append('--cpu %s --cpu-method all ' % self.workers)
+            elif 'numa' in self.class_type:
+                args.append('--numa %s' % self.workers)
             else:
                 args.append('--class %s --sequential %s ' %
                             (self.class_type, self.workers))

--- a/generic/stress-ng.py.data/stress-ng-numa.yaml
+++ b/generic/stress-ng.py.data/stress-ng-numa.yaml
@@ -1,0 +1,10 @@
+workers: 10
+ttimeout: '120'
+verify: True
+syslog: True
+metrics: True
+maximize: True
+times: True
+aggressive: True
+class: 'numa'
+stressors: null

--- a/generic/stress-ng.py.data/stress-ng.yaml
+++ b/generic/stress-ng.py.data/stress-ng.yaml
@@ -59,3 +59,7 @@ subsystem: !mux
         class: 'vm'
         stressors: null
         exclude: null
+    numa:
+        class: 'numa'
+        stressors: null
+        exclude: null


### PR DESCRIPTION
Stress-ng can be run with numa, patch adds the same

Signed-off-by: Harish <harish@linux.vnet.ibm.com>