### PR TITLE
Fixed mistake in parameter reading in PowerNVEEH

### DIFF
--- a/io/pci/PowerNVEEH.py
+++ b/io/pci/PowerNVEEH.py
@@ -65,7 +65,7 @@ class PowerNVEEH(Test):
         cmd = "echo %d > /sys/kernel/debug/powerpc/eeh_max_freezes"\
             % self.max_freeze
         process.system(cmd, ignore_status=True, shell=True)
-        self.function = str(self.params.get('function'), default='4')
+        self.function = str(self.params.get('function', default='4'))
         self.err = str(self.params.get('err'))
         self.pci_device = str(self.params.get('pci_device', default=' '))
         self.phb = self.pci_device.split(":", 1)[0]


### PR DESCRIPTION
There was a mistake introduced in PowerNVEEH test with the last
commit in self.params.get, and this commit fixes it.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>