### PR TITLE
Handling Exception when unable to mount filesystem

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -54,7 +54,7 @@ class Bonnie(Test):
             smm = SoftwareManager()
             if not smm.check_installed('bonnie++')\
                     and not smm.check_installed('bonnie++'):
-                '''Install the package from web'''
+                # Install the package from web
                 deps = ['gcc', 'make']
                 if distro.detect().name == 'Ubuntu':
                     deps.extend(['g++'])
@@ -129,7 +129,7 @@ class Bonnie(Test):
         self.log.info("Removing the filesystem created on %s", self.disk)
         delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
         if process.system(delete_fs, shell=True, ignore_status=True):
-	    self.fail("Failed to delete filesystem on %s", self.disk)
+            self.fail("Failed to delete filesystem on %s", self.disk)
 
 
 if __name__ == "__main__":

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -33,6 +33,7 @@ from avocado.utils import memory
 from avocado.utils import process
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.partition import PartitionError
 
 
 class Disktest(Test):
@@ -107,7 +108,11 @@ class Disktest(Test):
             self.log.info("creating %s fs on %s", self.fstype, self.disk)
             self.part_obj.mkfs(self.fstype)
             self.log.info("mounting %s on %s", self.disk, self.dirs)
-            self.part_obj.mount()
+            try:
+                self.part_obj.mount()
+            except PartitionError:
+                self.fail("Mounting disk %s on directory %s failed",
+                          self.disk, self.dirs)
 
     def _compile_disktest(self):
         """

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -28,6 +28,7 @@ from avocado.utils import build
 from avocado.utils import process, distro
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.partition import PartitionError
 
 
 class FioTest(Test):
@@ -72,7 +73,12 @@ class FioTest(Test):
             self.part_obj.mkfs(fstype)
             self.log.info("Mounting disk %s on directory %s",
                           self.disk, self.dir)
-            self.part_obj.mount()
+            try:
+                self.part_obj.mount()
+            except PartitionError:
+                self.fail("Mounting disk %s on directory %s failed",
+                          self.disk, self.dir)
+
 
     def test(self):
         """
@@ -94,6 +100,10 @@ class FioTest(Test):
         if self.disk is not None:
             self.log.info("Unmounting directory %s", self.dir)
             self.part_obj.unmount()
+        self.log.info("Removing the filesystem created on %s", self.disk)
+        delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
+        if process.system(delete_fs, shell=True, ignore_status=True):
+            self.fail("Failed to delete filesystem on %s", self.disk)
         if os.path.exists(self.fio_file):
             os.remove(self.fio_file)
 

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -18,6 +18,9 @@
 #   copyright 2006 Randy Dunlap <rdunlap@xenotime.net>
 #   https://github.com/autotest/autotest-client-tests/tree/master/fio
 
+"""
+FIO Test
+"""
 
 import os
 
@@ -79,6 +82,7 @@ class FioTest(Test):
                 self.fail("Mounting disk %s on directory %s failed",
                           self.disk, self.dir)
 
+        self.fio_file = 'fiotest-image'
 
     def test(self):
         """
@@ -86,7 +90,6 @@ class FioTest(Test):
         """
         self.log.info("Test will run on %s", self.dir)
         fio_job = self.params.get('fio_job', default='fio-simple.job')
-        self.fio_file = 'fiotest-image'
         cmd = '%s/fio %s %s --filename=%s' % (self.sourcedir,
                                               os.path.join(
                                                   self.datadir, fio_job),

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -30,6 +30,7 @@ from avocado.utils import build
 from avocado.utils import process, distro
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.partition import PartitionError
 
 
 class FSMark(Test):
@@ -73,7 +74,11 @@ class FSMark(Test):
             self.log.info("creating file system")
             self.part_obj.mkfs(self.fstype)
             self.log.info("Mounting disk %s on dir %s", self.disk, self.dir)
-            self.part_obj.mount()
+            try:
+                self.part_obj.mount()
+            except PartitionError:
+                self.fail("Mounting disk %s on directory %s failed",
+                          self.disk, self.dir)
 
     def test(self):
         """

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -26,6 +26,7 @@ from avocado.utils import build
 from avocado.utils import process, archive
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.partition import Partition
+from avocado.utils.partition import PartitionError
 
 
 class Ltp_Fs(Test):
@@ -55,7 +56,11 @@ class Ltp_Fs(Test):
             self.log.info("creating %s file system on %s", fstype, self.disk)
             self.part_obj.mkfs(fstype)
             self.log.info("mounting %s on %s", self.disk, self.mount_point)
-            self.part_obj.mount()
+            try:
+                self.part_obj.mount()
+            except PartitionError:
+                self.fail("Mounting disk %s on directory %s failed",
+                          self.disk, self.mount_point)
 
         url = "https://github.com/linux-test-project/ltp/"
         url += "archive/master.zip"

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -18,6 +18,10 @@
 # copyright 2006 Google, Inc.
 # https://github.com/autotest/autotest-client-tests/tree/master/ltp
 
+"""
+LTP Filesystem tests
+"""
+
 
 import os
 from avocado import Test
@@ -29,7 +33,7 @@ from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
 
 
-class Ltp_Fs(Test):
+class LtpFs(Test):
 
     '''
     Using LTP (Linux Test Project) testsuite to run Filesystem related tests
@@ -39,10 +43,10 @@ class Ltp_Fs(Test):
         '''
         To check and install dependencies for the test
         '''
-        sm = SoftwareManager()
+        smm = SoftwareManager()
         for package in ['gcc', 'make', 'automake', 'autoconf']:
-            if not sm.check_installed(package) and not sm.install(package):
-                self.error("%s is needed for the test to be run", package)
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel("%s is needed for the test to be run" % package)
         self.disk = self.params.get('disk', default=None)
         self.mount_point = self.params.get('dir', default=self.srcdir)
         self.script = self.params.get('script')

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -59,24 +59,8 @@ class Tiobench(Test):
         archive.extract(tarball, self.teststmpdir)
         os.chdir(os.path.join(self.teststmpdir, "tiobench-master"))
         build.make(".")
-
-    def test(self):
-        """
-        Test execution with necessary arguments.
-        :params dir: The directory in which to test.
-                     Defaults to ., the current directory.
-        :params blocks: The blocksize in Bytes to use. Defaults to 4096.
-        :params threads: The number of concurrent test threads.
-        :params size: The total size in MBytes of the files may use together.
-        :params num_runs: This number specifies over how many runs
-                          each test should be averaged.
-        """
         self.target = self.params.get('dir', default=self.srcdir)
         self.disk = self.params.get('disk', default=None)
-        blocks = self.params.get('blocks', default=4096)
-        threads = self.params.get('threads', default=10)
-        size = self.params.get('size', default=1024)
-        num_runs = self.params.get('numruns', default=2)
 
         if self.disk is not None:
             self.part_obj = Partition(self.disk, mountpoint=self.target)
@@ -92,7 +76,21 @@ class Tiobench(Test):
                 self.fail("Mounting disk %s on directory %s failed",
                           self.disk, self.target)
 
-        self.log.info("Test will run on %s" % self.target)
+    def test(self):
+        """
+        Test execution with necessary arguments.
+        :params blocks: The blocksize in Bytes to use. Defaults to 4096.
+        :params threads: The number of concurrent test threads.
+        :params size: The total size in MBytes of the files may use together.
+        :params num_runs: This number specifies over how many runs
+                          each test should be averaged.
+        """
+        blocks = self.params.get('blocks', default=4096)
+        threads = self.params.get('threads', default=10)
+        size = self.params.get('size', default=1024)
+        num_runs = self.params.get('numruns', default=2)
+
+        self.log.info("Test will run on %s", self.target)
         self.whiteboard = process.system_output('perl ./tiobench.pl '
                                                 '--target {} --block={} '
                                                 '--threads={} --size={} '

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -31,6 +31,7 @@ from avocado.utils import build
 from avocado.utils import process, distro
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.partition import Partition
+from avocado.utils.partition import PartitionError
 
 
 class Tiobench(Test):
@@ -85,7 +86,11 @@ class Tiobench(Test):
             self.part_obj.mkfs(self.fstype)
             self.log.info("Mounting disk %s on directory %s", self.disk,
                           self.target)
-            self.part_obj.mount()
+            try:
+                self.part_obj.mount()
+            except PartitionError:
+                self.fail("Mounting disk %s on directory %s failed",
+                          self.disk, self.target)
 
         self.log.info("Test will run on %s" % self.target)
         self.whiteboard = process.system_output('perl ./tiobench.pl '
@@ -104,6 +109,10 @@ class Tiobench(Test):
             self.log.info("Unmounting disk %s on directory %s", self.disk,
                           self.target)
             self.part_obj.unmount()
+        self.log.info("Removing the filesystem created on %s", self.disk)
+        delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
+        if process.system(delete_fs, shell=True, ignore_status=True):
+            self.fail("Failed to delete filesystem on %s", self.disk)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some linux distros do not support certain filesystems. In such
cases, mount throws an error. Since that was not handled in the
test, test ERRORs out. So, handling the exception and failing
gracefully.

Also, taking care of cleaning the filesystem on the disk, in
tearDown()

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>