### PR TITLE
Fix numa as stressor instead of class

### DIFF
--- a/generic/stress-ng.py.data/stress-ng-numa.yaml
+++ b/generic/stress-ng.py.data/stress-ng-numa.yaml
@@ -6,5 +6,4 @@ metrics: True
 maximize: True
 times: True
 aggressive: True
-class: 'numa'
-stressors: null
+stressors: 'numa'

--- a/generic/stress-ng.py.data/stress-ng.yaml
+++ b/generic/stress-ng.py.data/stress-ng.yaml
@@ -62,6 +62,5 @@ subsystem: !mux
         stressors: null
         exclude: null
     numa:
-        class: 'numa'
-        stressors: null
+        stressors: 'numa'
         exclude: null


### PR DESCRIPTION
'numa' was used wrongly as class instead of stress. Handled a minor fix if either of the stressors are None

Signed-off-by: Harish <harish@linux.vnet.ibm.com>