### PR TITLE
Fix: trinity yaml input

### DIFF
--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -77,7 +77,7 @@ class Trinity(Test):
         Trinity need to run as non root user
         '''
 
-        args = self.params.get('runarg', default=' ')
+        args = self.params.get('runargs', default=' ')
 
         process.system('su - trinity -c " %s  %s  %s"' %
                        (os.path.join(self.sourcedir, 'trinity'), args,


### PR DESCRIPTION
Trinity test failed to get yaml input due to a typo, patch fixed the typo

Signed-off-by: Harish <harish@linux.vnet.ibm.com>