### PR TITLE
Fix: Tests using run_make parameters in utils/build.py

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -83,7 +83,8 @@ class Stressng(Test):
         archive.extract(tarball, self.srcdir)
         sourcedir = os.path.join(self.srcdir, 'stress-ng-master')
         os.chdir(sourcedir)
-        result = build.run_make(sourcedir, ignore_status=True)
+        result = build.run_make(sourcedir,
+                                process_kwargs={'ignore_status': True})
         for line in str(result).splitlines():
             if 'error:' in line:
                 self.cancel(

--- a/io/disk/ssd/nvme_cli_selftests.py
+++ b/io/disk/ssd/nvme_cli_selftests.py
@@ -79,7 +79,8 @@ class NVMeCliSelfTest(Test):
         err = []
         for line in build.run_make(os.path.join(self.nvme_dir, 'tests'),
                                    extra_args='run',
-                                   ignore_status=True).stderr.splitlines():
+                                   process_kwargs={'ignore_status': True}
+                                   ).stderr.splitlines():
             if 'FAIL:' in line:
                 err.append(line.split('.')[1])
         self.fail("Some tests failed. Details below:\n%s" % "\n".join(err))

--- a/perf/libunwind.py
+++ b/perf/libunwind.py
@@ -69,7 +69,7 @@ class Libunwind(Test):
         Execute regression tests for libunwind library
         '''
         results = build.run_make(self.sourcedir, extra_args='check',
-                                 ignore_status=True).stdout
+                                 process_kwargs={'ignore_status': True}).stdout
 
         fail_list = ['FAIL', 'XFAIL', 'ERROR']
         failures = []

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -76,7 +76,8 @@ class Perftool(Test):
 
         # perf testsuite
         for line in build.run_make(self.sourcedir, extra_args='check',
-                                   ignore_status=True).stdout.splitlines():
+                                   process_kwargs={'ignore_status': True}
+                                   ).stdout.splitlines():
             if '-- [ FAIL ] --' in line:
                 self.count += 1
                 self.log.info(line)

--- a/toolchain/atlas.py
+++ b/toolchain/atlas.py
@@ -73,7 +73,7 @@ class Atlas(Test):
         '''
         make_option = self.params.get('make_option', default='check')
         ret = build.run_make(self.atlas_build_dir, extra_args=make_option,
-                             ignore_status=True)
+                             process_kwargs={'ignore_status': True})
         if ret.exit_status:
             self.fail("Make check Has been Failed !!"
                       "Please, refer the log file")

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -85,7 +85,8 @@ class GCC(Test):
         Runs the gcc `make check`
         """
         ret = build.run_make(
-            self.sourcedir, extra_args='check', ignore_status=True)
+            self.sourcedir, extra_args='check',
+            process_kwargs={'ignore_status': True})
         self.summary = ret.stdout.splitlines()
         for index, line in enumerate(self.summary):
             if "=== gcc Summary ===" in line:

--- a/toolchain/libvecpf.py
+++ b/toolchain/libvecpf.py
@@ -58,7 +58,7 @@ class Libvecpf(Test):
         Execute self test of libvecpf library
         """
         results = build.run_make(self.sourcedir, extra_args='check',
-                                 ignore_status=True).stdout
+                                 process_kwargs={'ignore_status': True}).stdout
 
         fail_list = ['FAIL', 'XFAIL', 'ERROR']
         failures = []

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -70,7 +70,8 @@ class Valgrind(Test):
         summary = ''
         flag = False
         results = build.run_make(
-            self.sourcedir, extra_args=cmd, ignore_status=True).stdout
+            self.sourcedir, extra_args=cmd,
+            process_kwargs={'ignore_status': True}).stdout
         for line in results.splitlines():
             if line.startswith('==') and line.endswith('=='):
                 flag = True


### PR DESCRIPTION
With build.run_make deprecating few optional parameters, tests are changed to adopt the deprecation

Signed-off-by: Harish <harish@linux.vnet.ibm.com>