### PR TITLE
generic/ras.py: skip test instead of canceling it

### DIFF
--- a/generic/ras.py
+++ b/generic/ras.py
@@ -19,7 +19,7 @@ from shutil import copyfile
 from avocado import Test
 from avocado import main
 from avocado.utils import process, distro
-from avocado import skipIf
+from avocado import skipIf, skipUnless
 from avocado.utils.software_manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
@@ -40,9 +40,9 @@ class RASTools(Test):
             self.is_fail += 1
         return
 
+    @skipUnless("ppc" in distro.detect().arch,
+                "supported only on Power platform")
     def setUp(self):
-        if "ppc" not in distro.detect().arch:
-            self.cancel("supported only on Power platform")
         sm = SoftwareManager()
         for package in ("ppc64-diag", "powerpc-utils", "lsvpd", "ipmitool"):
             if not sm.check_installed(package) and not sm.install(package):


### PR DESCRIPTION
It makes more sense to skip a test altogether if possible.

Signed-off-by: Cleber Rosa <crosa@redhat.com>