### PR TITLE
Fix kernel compile on Ubuntu

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -89,7 +89,8 @@ class Kernbench(Test):
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['libpopt0', 'libc6', 'libc6-dev', 'libpopt-dev',
                          'libcap-ng0', 'libcap-ng-dev', 'elfutils', 'libelf1',
-                         'libnuma-dev', 'libfuse-dev'])
+                         'libnuma-dev', 'libfuse-dev', 'libssl-dev', 'flex',
+                         'bison'])
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
                          'popt-devel', 'libcap2', 'libcap-devel',

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -50,7 +50,7 @@ class kselftest(Test):
         deps = ['gcc', 'make', 'automake', 'autoconf']
 
         if 'Ubuntu' in detected_distro.name:
-            deps.extend(['libpopt0', 'libc6', 'libc6-dev',
+            deps.extend(['libpopt0', 'libc6', 'libc6-dev', 'libcap-dev',
                          'libpopt-dev', 'libcap-ng0', 'libcap-ng-dev',
                          'libnuma-dev', 'libfuse-dev', 'elfutils', 'libelf1'])
         elif 'SuSE' in detected_distro.name:


### PR DESCRIPTION
Patch adds required packages for Ubuntu to compile kernel and compile selftests/vm tests properly

Signed-off-by: Harish <harish@linux.vnet.ibm.com>