### PR TITLE
Differentiate tests that support multiple disks

### DIFF
--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -48,7 +48,7 @@ class Lvsetup(Test):
         """
         pkg = ""
         smm = SoftwareManager()
-        self.disk = self.params.get('disk', default=None)
+        self.disk = self.params.get('disks', default=None)
         vg_name = self.params.get('vg_name', default='avocado_vg')
         lv_name = self.params.get('lv_name', default='avocado_lv')
         self.lv_size = self.params.get('lv_size', default='1G')

--- a/io/disk/lvsetup.py.data/README
+++ b/io/disk/lvsetup.py.data/README
@@ -5,7 +5,7 @@ volume and merges snapshot with the logical volume.
 
 Inputs Needed in yaml file:
 ---------------------------
-disk: Name of the disk on which volume groups, logical volumes,
+disks: Name of the disks on which volume groups, logical volumes,
       snapshots are created. Created on loop device if not specified
 vg_name: Name of the volume group.
 lv_name: Name of the logical volume.

--- a/io/disk/lvsetup.py.data/lvsetup.yaml
+++ b/io/disk/lvsetup.py.data/lvsetup.yaml
@@ -1,7 +1,7 @@
 scenario: !mux
 # btrfs needs minimum LV size of 641M
     real:
-        disk: /dev/vde
+        disks: /dev/vde
         lv_size: "641M"
 filesystem: !mux
     ext2:

--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -50,7 +50,7 @@ class SoftwareRaid(Test):
                 self.cancel("Unable to install mdadm")
         cmd = "mdadm -V"
         self.check_pass(cmd, "Unable to get mdadm version")
-        self.disk = self.params.get('disk', default='').strip(" ")
+        self.disk = self.params.get('disks', default='').strip(" ")
         self.raidlevel = str(self.params.get('raid', default='0'))
         self.sparedisk = ""
         if self.raidlevel == 'linear' or self.raidlevel == '0':

--- a/io/disk/softwareraid.py.data/softwareraid.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid.yaml
@@ -1,5 +1,5 @@
 scenario:
-    disk: /dev/sde1 /dev/sde2 /dev/sde3 /dev/sde4 /dev/sdd1
+    disks: /dev/sde1 /dev/sde2 /dev/sde3 /dev/sde4 /dev/sdd1
 raidlevel: !mux
     raidlinear:
         raid: linear


### PR DESCRIPTION
Some tests support multiple disks as input from multiplexer
file. This commit makes this explicit, and differentiates it
from other tests which accepts only one disk as input.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>