### PR TITLE
Fix: timeout for variable stressors

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -143,8 +143,8 @@ class Stressng(Test):
                     process.run("%s %s" % (cmd, stress_cmd),
                                 ignore_status=True, sudo=True)
             if self.ttimeout and self.v_stressors:
-                timeout = int(self.ttimeout) + \
-                    int(memory.memtotal() / 1024 / 1024)
+                timeout = ' --timeout %s ' % str(
+                    int(self.ttimeout) + int(memory.memtotal() / 1024 / 1024))
             if self.v_stressors:
                 for stressor in self.v_stressors.split(' '):
                     stress_cmd = ' --%s %s %s' % (stressor,


### PR DESCRIPTION
Timeout stressors have a timeout calculated for variable stressors. Patch fixes adding --timeout needed to run the variable stressors.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>