### PR TITLE
Fixed generic:sysbench test

### DIFF
--- a/generic/sysbench.py
+++ b/generic/sysbench.py
@@ -15,6 +15,7 @@
 # Author: Hariharan T.S.  <harihare@in.ibm.com>
 
 import os
+import shutil
 from avocado import Test
 from avocado import main
 from avocado.utils import process, git
@@ -64,9 +65,17 @@ class Sysbench(Test):
                 self.urllink = self.params.get(
                     'url-link', default="https://github.com/akopytov/"
                                         "sysbench.git")
+                self.fixlink = self.params.get('fixlink', default=None)
+                self.fix_dir = self.params.get('fixdir', default=None)
                 self.bch = self.params.get('branch', default='master')
                 git.get_repo(self.urllink, branch=self.bch,
                              destination_dir=self.teststmpdir)
+
+                if self.fixlink and self.fix_dir:
+                    fixpath = '%s%s' % (self.teststmpdir, self.fix_dir)
+                    shutil.rmtree(fixpath)
+                    git.get_repo(self.fixlink, branch="ppc64-port",
+                                 destination_dir=fixpath)
                 os.chdir(self.teststmpdir)
                 self.run_cmd("./autogen.sh")
                 self.run_cmd("./configure --without-mysql")

--- a/generic/sysbench.py.data/sysbench.yaml
+++ b/generic/sysbench.py.data/sysbench.yaml
@@ -1,6 +1,8 @@
 max-time: null
 max-request: null
 url-link: 'https://github.com/akopytov/sysbench.git'
+fixlink: 'https://github.com/PPC64/LuaJIT.git'
+fixdir: '/third_party/luajit/luajit/'
 #Comment out branch if you want to checkout master.
 branch: '0.4'
 tests:


### PR DESCRIPTION
as in powerpc64 bit system compilation of upstream branch is failing
so this patch address that issue as try to clone ppc64 specfic LuaJIT upstream

based on issue : https://github.com/akopytov/sysbench/issues/129

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>