### PR TITLE
Fix: Adopt meminfo with avocado library fix

### DIFF
--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -144,7 +144,7 @@ class memstress(Test):
             return False
 
     def run_stress(self):
-        mem_free = memory.meminfo.MemFree.mb / 2
+        mem_free = memory.meminfo.MemFree.m / 2
         cpu_count = int(multiprocessing.cpu_count()) / 2
         process.run("stress --cpu %s --io %s --vm %s --vm-bytes %sM --timeout %ss" %
                     (cpu_count, self.iocount, self.vmcount, mem_free, self.stresstime), ignore_status=True, sudo=True, shell=True)
@@ -215,20 +215,20 @@ class memstress(Test):
     def dlpar_mem_hotplug(self):
         if 'ppc' in platform.processor() and 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
             if "mem_dlpar=yes" in process.system_output("drmgr -C", ignore_status=True, shell=True):
-                init_mem = memory.meminfo.MemTotal.kb
+                init_mem = memory.meminfo.MemTotal.k
                 self.log.info("\nDLPAR remove memory operation\n")
                 for _ in range(len(self.blocks_hotpluggable) / 2):
                     process.run(
                         "drmgr -c mem -d 5 -w 30 -r", shell=True, ignore_status=True, sudo=True)
-                if memory.meminfo.MemTotal.kb >= init_mem:
+                if memory.meminfo.MemTotal.k >= init_mem:
                     self.log.warn("dlpar mem could not complete")
                 self.run_stress()
-                init_mem = memory.meminfo.MemTotal.kb
+                init_mem = memory.meminfo.MemTotal.k
                 self.log.info("\nDLPAR add memory operation\n")
                 for _ in range(len(self.blocks_hotpluggable) / 2):
                     process.run(
                         "drmgr -c mem -d 5 -w 30 -a", shell=True, ignore_status=True, sudo=True)
-                if init_mem < memory.meminfo.MemTotal.kb:
+                if init_mem < memory.meminfo.MemTotal.k:
                     self.log.warn("dlpar mem could not complete")
             else:
                 self.log.info('UNSUPPORTED: dlpar not configured..')

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -44,11 +44,11 @@ class Thp_Swapping(Test):
         '''
 
         self.swap_free = []
-        mem_free = memory.meminfo.MemFree.mb
-        mem = memory.meminfo.MemTotal.mb
-        swap = memory.meminfo.SwapTotal.mb
-        self.hugepage_size = memory.meminfo.Hugepagesize.mb
-        self.swap_free.append(memory.meminfo.SwapFree.mb)
+        mem_free = memory.meminfo.MemFree.m
+        mem = memory.meminfo.MemTotal.m
+        swap = memory.meminfo.SwapTotal.m
+        self.hugepage_size = memory.meminfo.Hugepagesize.m
+        self.swap_free.append(memory.meminfo.SwapFree.m)
         self.mem_path = os.path.join(data_dir.get_tmp_dir(), 'thp_space')
         self.dd_timeout = 900
 
@@ -90,7 +90,7 @@ class Thp_Swapping(Test):
                               verbose=False, ignore_status=True, shell=True)):
                 self.fail('Swap command Failed %s' % swap_cmd)
 
-        self.swap_free.append(memory.meminfo.SwapFree.mb)
+        self.swap_free.append(memory.meminfo.SwapFree.m)
 
         # Checks Swap is used or not
         if self.swap_free[1] - self.swap_free[0] >= 0:

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -43,7 +43,7 @@ class VATest(Test):
         if self.scenario_arg not in range(1, 7):
             self.cancel("Test need to skip as scenario will be 1-7")
         if self.scenario_arg in [2, 3, 4]:
-            if memory.meminfo.Hugepagesize.mb != 16:
+            if memory.meminfo.Hugepagesize.m != 16:
                 self.cancel(
                     "Test need to skip as 16MB huge need to configured")
         elif self.scenario_arg in [5, 6, 7]:


### PR DESCRIPTION
With memory.MemInfo recent changes mb, kb has changed to m,k. This patch makes the changes needed in tests.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>