### PR TITLE
Fix issue that sub-process cannot be killed

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -218,7 +218,7 @@ class cpustresstest(Test):
         self.log.info("\nCreate %s pids and set proc affinity", totalcpus)
         for proc in range(0, totalcpus):
             pid = process.SubProcess(
-                "while :; do :; done &", shell=True).start()
+                "while :; do :; done", shell=True).start()
             pids.append(pid)
             process.run("taskset -pc %s %s" %
                         (proc, pid), ignore_status=True, shell=True)


### PR DESCRIPTION
Do not put the sub-process into background,
otherwise the returned PID from threading.start()
is not the PID of the sub-process.
Later on when the test script tries to kill
the sub-process, kill fails with 'No such process'.
The sub-process will keep running when test finished.

Signed-off-by: Li Yi <liyiadam@gmail.com>