### PR TITLE
Mofed install yaml changes

### DIFF
--- a/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
+++ b/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
@@ -44,8 +44,10 @@ Options: !mux
         option: --kernel-only   --without-fw-update  -v  --enable-mlnx_tune
     ofed-conf:
         option: -c docs/conf/ofed-basic.conf -n docs/conf/ofed_net.conf-example
-    add-kernel-support:
+    add-kernel-support_with-kmp:
         option: --add-kernel-support --skip-repo --force --kmp
     add-kernel-support_with-nvmf:
         option: --skip-distro-check --add-kernel-support --skip-repo --with-nvmf
+    add-kernel-support:
+        option: --add-kernel-support --skip-repo --force
         uninstall: False

--- a/io/net/infiniband/mofed_install_test.py.data/mofed_install_test_nvmf.yaml
+++ b/io/net/infiniband/mofed_install_test.py.data/mofed_install_test_nvmf.yaml
@@ -1,0 +1,7 @@
+ISO_Location:
+    location:
+        iso_location: http://www.mellanox.com/downloads/ofed/MLNX_OFED-3.3-1.0.4.0/MLNX_OFED_LINUX-3.3-1.0.4.0-rhel7.2-ppc64le.iso
+Options: !mux
+    add-kernel-support_with-nvmf:
+        option: --skip-distro-check --add-kernel-support --skip-repo --with-nvmf
+        uninstall: False


### PR DESCRIPTION
1. Moved the method to install mofed by default to last in yaml file.
2. Created a new yaml to install mofed only for nvmf, since that is
needed for nvmf tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>