### PR TITLE
Adding metadata support to softwareraid tests

### DIFF
--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -53,6 +53,7 @@ class SoftwareRaid(Test):
         self.check_pass(cmd, "Unable to get mdadm version")
         self.disk = self.params.get('disks', default='').strip(" ")
         self.raidlevel = str(self.params.get('raid', default='0'))
+        self.metadata = str(self.params.get('metadata', default='1.2'))
         self.setup = self.params.get('setup', default=True)
         self.run_test = self.params.get('run_test', default=False)
         self.cleanup = self.params.get('cleanup', default=True)
@@ -81,8 +82,9 @@ class SoftwareRaid(Test):
         Only basic operations are run viz create and delete
         """
         cmd = "echo 'yes' | mdadm --create --verbose --assume-clean \
-            /dev/md/mdsraid --level=%s --raid-devices=%d %s" \
-            % (self.raidlevel, self.disk_count, self.disk)
+            /dev/md/mdsraid --level=%s --raid-devices=%d %s \
+            --metadata %s" \
+            % (self.raidlevel, self.disk_count, self.disk, self.metadata)
         if self.sparedisk:
             cmd += " --spare-devices=1 %s " % self.sparedisk
         cmd += " --force"

--- a/io/disk/softwareraid.py.data/Readme
+++ b/io/disk/softwareraid.py.data/Readme
@@ -6,6 +6,8 @@ Values to be passed in yaml file:
 
 * Raid levels to be created
 
+* metadata levels for raid
+
 * Setup - True if only raid needs to be created and exit
 
 * Cleanup - True if only raid needs to be deleted and exit

--- a/io/disk/softwareraid.py.data/softwareraid.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid.yaml
@@ -13,3 +13,12 @@ raidlevel: !mux
         raid: 10
     raid6:
         raid: 6
+metadata: !mux
+    superblock-0.90:
+        metadata: 0.90
+    superblock-1.0:
+        metadata: 1.0
+    superblock-1.1:
+        metadata: 1.1
+    superblock-1.2:
+        metadata: 1.2

--- a/io/disk/softwareraid.py.data/softwareraid_setup.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid_setup.yaml
@@ -2,6 +2,5 @@ disks: /dev/sde1 /dev/sde2 /dev/sde3 /dev/sde4 /dev/sdd1
 setup: True
 run_test: False
 cleanup: False
-raidlevel: !mux
-    raid1:
-        raid: 1
+raid: 1
+metadata: 1.2


### PR DESCRIPTION
Adding metadata support to softwareraid tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>