### PR TITLE
Client initiated failover for a Network virtualized device

### DIFF
--- a/io/net/virt-net/Network_virtualization_client_initialized_failover.py
+++ b/io/net/virt-net/Network_virtualization_client_initialized_failover.py
@@ -23,6 +23,17 @@ from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.process import CmdError
 
 
+class CommandFailed(Exception):
+    def __init__(self, command, output, exitcode):
+        self.command = command
+        self.output = output
+        self.exitcode = exitcode
+
+    def __str__(self):
+        return "Command '%s' exited with %d.\nOutput:\n%s" \
+               % (self.command, self.exitcode, self.output)
+
+
 class NetworkVirtualizationFailoverTest(Test):
 
     """
@@ -57,7 +68,7 @@ class NetworkVirtualizationFailoverTest(Test):
             for val in range(self.count):
                 self.log.info("Performing Client initiated\
                               failover - Attempt %s" % int(val+1))
-                process.run('echo 1 > /sys/devices/vio/%s/failover' %
+                output = process.run('echo 1 > /sys/devices/vio/%s/failover' %
                             self.device, shell=True, sudo=True)
                 # Adding  a sleep of 10 sec is necessary for failover
                 # to take effect
@@ -69,8 +80,8 @@ class NetworkVirtualizationFailoverTest(Test):
                                   shell=True, ignore_status=True):
                     self.fail("Ping test failed. Network virtualized \
                                failover had affected Network connectivity")
-        except CmdError as details:
-            self.log.debug(str(details))
+        except CommandFailed as cf:
+            self.log.debug(str(cf))
             self.fail("Client initiated Failover for Network virtualized \
                        device %s failed" % self.interface)
 

--- a/io/net/virt-net/Network_virtualization_client_initialized_failover.py
+++ b/io/net/virt-net/Network_virtualization_client_initialized_failover.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2018 IBM
+# Author: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>
+
+import time
+import netifaces
+from avocado import Test
+from avocado import main
+from avocado.utils import process
+from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.process import CmdError
+
+
+class NetworkVirtualizationFailoverTest(Test):
+
+    """
+    This test performs failover for a Network virtualized device
+    """
+
+    def setUp(self):
+        """
+        Install necessary packages and identify the network
+        virtualized device.
+        """
+        smm = SoftwareManager()
+        for pkg in ["net-tools"]:
+            if not smm.check_installed(pkg) and not smm.install(pkg):
+                self.cancel("%s package is need to test" % pkg)
+        interfaces = netifaces.interfaces()
+        self.interface = self.params.get('interface')
+        if self.interface not in interfaces:
+            self.cancel("%s interface is not available" % self.interface)
+        self.device = process.system_output("ls -l /sys/class/net/ | \
+                                             grep %s | cut -d '/' -f \
+                                             5" % self.interface,
+                                            shell=True).strip()
+        self.count = int(self.params.get('count', default="1"))
+        self.peer_ip = self.params.get('peer_ip', default=None)
+
+    def test(self):
+        '''
+        Performs failover for Network virtualized device
+        '''
+        try:
+            for val in range(self.count):
+                self.log.info("Performing Client initiated\
+                              failover - Attempt %s" % int(val+1))
+                process.run('echo 1 > /sys/devices/vio/%s/failover' %
+                            self.device, shell=True, sudo=True)
+                # Adding  a sleep of 10 sec is necessary for failover
+                # to take effect
+                time.sleep(10)
+                self.log.info("Running a ping test to check if failover \
+                                affected Network connectivity")
+                if process.system('ping -I %s %s -c 5' %
+                                  (self.interface, self.peer_ip),
+                                  shell=True, ignore_status=True):
+                    self.fail("Ping test failed. Network virtualized \
+                               failover had affected Network connectivity")
+        except CmdError as details:
+            self.log.debug(str(details))
+            self.fail("Client initiated Failover for Network virtualized \
+                       device %s failed" % self.interface)
+
+
+if __name__ == "__main__":
+    main()

--- a/io/net/virt-net/Network_virtualization_client_initialized_failover.py.data/Network_virtualization_client_initialized_failover.yaml
+++ b/io/net/virt-net/Network_virtualization_client_initialized_failover.py.data/Network_virtualization_client_initialized_failover.yaml
@@ -1,0 +1,3 @@
+interface:
+count:
+peer_ip:

--- a/io/net/virt-net/Network_virtualization_client_initialized_failover.py.data/README
+++ b/io/net/virt-net/Network_virtualization_client_initialized_failover.py.data/README
@@ -1,0 +1,11 @@
+This script will perform Client initiated failover for
+a Network virtualized device for as many times as specified by the user
+
+Before starting the test, make sure that a Backing device is added to the
+Network virtualized device under test
+
+Inputs Needed (in multiplexer file):
+------------------------------------
+interface - The Network virtualized device
+count - The number of times the unbind and bind test has to be executed
+peer_ip - IP of the Peer interface to check for Network connectivity after failover


### PR DESCRIPTION
This script performs a Client initiated failover for a
Network virtualized device. It also has the option to
run this execution any number of times based on user
input

Signed-off-by: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>