### PR TITLE
Fix self.fail after mkfs failed

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -101,8 +101,8 @@ class Bonnie(Test):
             try:
                 self.part_obj.mount()
             except PartitionError:
-                self.fail("Mounting disk %s on directory %s failed",
-                          self.disk, self.scratch_dir)
+                self.fail("Mounting disk %s on directory %s failed"
+                          % (self.disk, self.scratch_dir))
 
     def test(self):
         """

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -111,8 +111,8 @@ class Disktest(Test):
             try:
                 self.part_obj.mount()
             except PartitionError:
-                self.fail("Mounting disk %s on directory %s failed",
-                          self.disk, self.dirs)
+                self.fail("Mounting disk %s on directory %s failed"
+                          % (self.disk, self.dirs))
 
     def _compile_disktest(self):
         """

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -79,8 +79,8 @@ class FioTest(Test):
             try:
                 self.part_obj.mount()
             except PartitionError:
-                self.fail("Mounting disk %s on directory %s failed",
-                          self.disk, self.dir)
+                self.fail("Mounting disk %s on directory %s failed"
+                          % (self.disk, self.dir))
 
         self.fio_file = 'fiotest-image'
 

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -77,8 +77,8 @@ class FSMark(Test):
             try:
                 self.part_obj.mount()
             except PartitionError:
-                self.fail("Mounting disk %s on directory %s failed",
-                          self.disk, self.dir)
+                self.fail("Mounting disk %s on directory %s failed"
+                          % (self.disk, self.dir))
 
     def test(self):
         """

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -63,8 +63,8 @@ class LtpFs(Test):
             try:
                 self.part_obj.mount()
             except PartitionError:
-                self.fail("Mounting disk %s on directory %s failed",
-                          self.disk, self.mount_point)
+                self.fail("Mounting disk %s on directory %s failed"
+                          % (self.disk, self.mount_point))
 
         url = "https://github.com/linux-test-project/ltp/"
         url += "archive/master.zip"

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -73,8 +73,8 @@ class Tiobench(Test):
             try:
                 self.part_obj.mount()
             except PartitionError:
-                self.fail("Mounting disk %s on directory %s failed",
-                          self.disk, self.target)
+                self.fail("Mounting disk %s on directory %s failed"
+                          % (self.disk, self.target))
 
     def test(self):
         """


### PR DESCRIPTION
I had induced a syntax error in self.fail after mkfs.
Fixing it.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>