### PR TITLE
numactl: Execute all tests without stoppage

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -71,7 +71,7 @@ class Numactl(Test):
 
     def test(self):
 
-        if build.make(self.sourcedir, extra_args='test', ignore_status=True):
+        if build.make(self.sourcedir, extra_args='-k test', ignore_status=True):
             self.fail('test failed, Please check debug log')
 
 


### PR DESCRIPTION
Most of the tests should succeed with https://github.com/numactl/numactl/pull/22. Though, in case of
failure this patch allows to continue with other tests.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>