### PR TITLE
Test to exercise page move/bind between numa

### DIFF
--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2018 IBM
+# Author: Harish <harish@linux.vnet.ibm.com>
+#
+
+
+import os
+import shutil
+
+from avocado import Test
+from avocado import main
+from avocado.utils import process, build, memory, distro
+from avocado.utils.software_manager import SoftwareManager
+
+
+class NumaTest(Test):
+    """
+    Excercises numa_move_pages and mbind call with 20% of the machine's free
+    memory
+    """
+
+    def copyutil(self, file_name):
+        shutil.copyfile(os.path.join(self.datadir, file_name),
+                        os.path.join(self.teststmpdir, file_name))
+
+    def setUp(self):
+        smm = SoftwareManager()
+        dist = distro.detect()
+        memsize = int(memory.freememtotal() * 1024 * 0.2)
+        self.nr_pages = self.params.get(
+            'nr_pages', default=memsize / memory.get_page_size())
+        self.map_type = self.params.get('map_type', default='private')
+
+        pkgs = ['gcc', 'make']
+        if dist.name == "Ubuntu":
+            pkgs.extend(['libpthread-stubs0-dev', 'libnuma-dev'])
+        else:
+            pkgs.extend(['numactl-devel'])
+
+        for package in pkgs:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+
+        for file_name in ['util.c', 'numa_test.c', 'Makefile']:
+            self.copyutil(file_name)
+
+        build.make(self.teststmpdir)
+
+    def test(self):
+        os.chdir(self.teststmpdir)
+        self.log.info("Starting test...")
+
+        if process.system('./numa_test -m %s -n %s' % (self.map_type, self.nr_pages),
+                          shell=True, sudo=True):
+            self.fail('Please check the logs for failure')
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/numa_test.py.data/Makefile
+++ b/memory/numa_test.py.data/Makefile
@@ -1,0 +1,8 @@
+BIN=numa_test
+all: ${BIN}
+
+%: %.c util.c
+	cc -o $@ $^ -lpthread -lnuma
+
+clean:
+	rm ${BIN}

--- a/memory/numa_test.py.data/numa_test.c
+++ b/memory/numa_test.py.data/numa_test.c
@@ -1,0 +1,180 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE for more details.
+ * Copyright: 2018 IBM
+ * Author: Aneesh Kumar K.V <anesh.kumar@linux.vnet.ibm.com>
+ * Author: Harish <harish@linux.vnet.ibm.com>
+ */
+
+
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <asm/unistd.h>
+#include <numa.h>
+#include <numaif.h>
+#include <string.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#define errmsg(x, ...) fprintf(stderr, x, ##__VA_ARGS__),exit(1)
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#define PROTFLAG PROT_READ|PROT_WRITE
+
+extern int *get_numa_nodes_to_use(int max_node);
+extern unsigned long get_pfn(void *addr);
+unsigned long i;
+
+struct testcase {
+	const char *msg;
+	int id;
+};
+
+static struct testcase testcases[] = {
+	{
+		.msg = "numa_move_pages",
+		.id = 1,
+	},
+	{
+		.msg = "mbind",
+		.id = 2,
+	},
+};
+
+int test_func(unsigned long nr_nodes, int mapflag, unsigned long nr_pages, unsigned long page_size, int id, const char *msg)
+{
+	char *p;
+	int *node_list, *status, *nodes;
+	int ret, same_pfn = 0;
+	void **addrs;
+	struct bitmask *all_nodes, *old_nodes, *new_nodes;
+	unsigned long *old_pfn;
+
+	printf("\n \n Testcase %d: %s\n\n", id, msg);
+	old_pfn = (unsigned long *)malloc(sizeof(unsigned long) * nr_pages);
+	node_list = (int *)malloc(sizeof(int) * 2);
+	node_list = get_numa_nodes_to_use(nr_nodes);
+
+	all_nodes = numa_bitmask_alloc(nr_nodes);
+	numa_bitmask_setbit(all_nodes, node_list[0]);
+	numa_bitmask_setbit(all_nodes, node_list[1]);
+
+	old_nodes = numa_bitmask_alloc(nr_nodes);
+	numa_bitmask_setbit(old_nodes, node_list[0]);
+	numa_sched_setaffinity(0, old_nodes);
+
+	if ( id == 2 ){
+		new_nodes = numa_bitmask_alloc(nr_nodes);
+		numa_bitmask_setbit(new_nodes, node_list[1]);
+	}
+	else{
+		addrs  = malloc(sizeof(char *) * nr_pages + 1);
+		status = malloc(sizeof(char *) * nr_pages + 1);
+		nodes  = malloc(sizeof(char *) * nr_pages + 1);
+	}
+
+	p = mmap(NULL, nr_pages * page_size, PROTFLAG, mapflag, -1, 0);
+	if (p == MAP_FAILED){
+		errmsg("Failed mmap\n");
+		return 1;
+	}
+	/* fault in */
+	memset(p, 'a', nr_pages * page_size);
+	sleep(3);
+	numa_sched_setaffinity(0, all_nodes);
+	for (i = 0; i < nr_pages; i++) {
+		if (id == 1)
+		{
+			addrs[i] = p + i * page_size;
+			nodes[i] = node_list[1];
+			status[i] = 0;
+		}
+		old_pfn[i] = get_pfn(p + i* page_size);
+	}
+	printf("Executing %s\n", msg);
+	if (id == 1)
+		ret = numa_move_pages(0, nr_pages, addrs, nodes, status, MPOL_MF_MOVE_ALL);
+	else
+		ret = mbind(p, nr_pages * page_size, MPOL_BIND, new_nodes->maskp,
+			new_nodes->size + 1, MPOL_MF_MOVE|MPOL_MF_STRICT);
+	sleep(3);
+
+	if (ret == -1)
+	{
+		errmsg("Failed %s \n", msg);
+		return 1;
+	}
+	memset(p, 'a', nr_pages * page_size);
+
+	printf("Checking PFN's\n");
+
+	for (i = 0; i < nr_pages; i++) {
+		if(old_pfn[i]!=0){
+			if(old_pfn[i] == get_pfn(p + i* page_size)){
+				same_pfn++;
+			}
+		}
+	}
+	if(same_pfn){
+		errmsg("Number of pages with same PFN: %d\n", same_pfn);
+		return 1;
+	}
+	sleep(2);
+
+	munmap(p, nr_pages * page_size);
+	return 0;
+}
+
+
+int main(int argc, char *argv[])
+{
+	int c, i, mapflag = MAP_ANONYMOUS;
+	unsigned long nr_nodes = numa_max_node() + 1, page_size = getpagesize(), nr_pages;
+
+	while ((c = getopt(argc, argv, "vm:n:Hh")) != -1) {
+		switch(c) {
+		case 'm':
+			if (!strcmp(optarg, "private"))
+				mapflag |= MAP_PRIVATE;
+			else if (!strcmp(optarg, "shared"))
+				mapflag |= MAP_SHARED;
+			else
+				errmsg("invalid optarg for -m\n");
+			break;
+		case 'n':
+			nr_pages = strtoul(optarg, NULL, 10);
+			break;
+		case 'H':
+			errmsg("%s -m [private|shared] -n <number of pages> -s [migrate|mbind]\n", argv[0]);
+			break;
+		default:
+			errmsg("invalid option\n");
+			break;
+		}
+	}
+
+	if (nr_nodes < 2)
+		errmsg("A minimum of 2 nodes is required for this test.\n");
+
+	if (!(mapflag & (MAP_SHARED | MAP_PRIVATE)))
+		errmsg("Specify shared or private using -m flag\n");
+
+	for (i = 0; i < ARRAY_SIZE(testcases); i++) {
+		struct testcase *t = testcases + i;
+		if (test_func(nr_nodes, mapflag, nr_pages, page_size, t->id, t->msg))
+		{
+			printf("Test %s Failed", t->msg);
+			exit(1);
+		}
+		printf("Testcase %d: %s Passed\n", t->id, t->msg);
+	}
+	return 0;
+}

--- a/memory/numa_test.py.data/numa_test.yaml
+++ b/memory/numa_test.py.data/numa_test.yaml
@@ -1,0 +1,3 @@
+setup:
+ nr_pages: 10 # make sure enough memory is available
+ map_type: 'shared' # 'private' or 'shared'

--- a/memory/numa_test.py.data/util.c
+++ b/memory/numa_test.py.data/util.c
@@ -1,0 +1,87 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE for more details.
+ * Copyright: 2018 IBM
+ * Author: Aneesh Kumar K.V <anesh.kumar@linux.vnet.ibm.com>
+ * Author: Harish <harish@linux.vnet.ibm.com>
+ */
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <numa.h>
+
+#define PMAP_ENTRY_SIZE		sizeof(unsigned long)
+#define PM_PFRAME_MASK		0x007FFFFFFFFFFFFFUL
+#define PM_PRESENT		0x8000000000000000UL
+
+unsigned long get_pfn(unsigned long addr)
+{
+	int fd;
+	unsigned long pmap_entry;
+	unsigned long pmap_offset;
+	int page_size = getpagesize();
+
+	fd = open("/proc/self/pagemap", O_RDONLY);
+	if (fd == -1)
+		return 0;
+
+	pmap_offset = (addr / page_size)*PMAP_ENTRY_SIZE;
+
+	if (lseek(fd, pmap_offset, SEEK_SET) == -1) {
+		printf("%s Failed to lseek\n", __func__);
+		goto err_out;
+	}
+
+	if (read(fd, &pmap_entry, PMAP_ENTRY_SIZE) == -1) {
+		printf("%s Failed to read\n", __func__);
+		goto err_out;
+	}
+
+	if (!(pmap_entry & PM_PRESENT)) {
+		goto err_out;
+	}
+
+	close(fd);
+	return pmap_entry & PM_PFRAME_MASK;
+
+err_out:
+	close(fd);
+	return 0;
+}
+
+int *get_numa_nodes_to_use(int max_node)
+{
+	unsigned long free_node_sizes;
+	long node_size;
+	int node_iterator, *nodes_to_use, got_nodes = 0;
+
+	nodes_to_use = (int *)malloc(sizeof(int) * 2);
+	/* Get 2 Nodes which contains system memory*/
+	for(node_iterator=0; node_iterator < max_node; node_iterator++){
+		node_size = numa_node_size(node_iterator,&free_node_sizes);
+		if (node_size != -1){
+			nodes_to_use[got_nodes++] = node_iterator;
+			if(got_nodes == 2)
+				break;
+		}
+	}
+
+	/* Verify if we got 2 nodes to use */
+	if (got_nodes == 2){
+		printf("Nodes used in test %d %d \n", nodes_to_use[0], nodes_to_use[1]);
+	} else {
+		printf("memory is not found in 2 nodes\n");
+		exit(1);
+	}
+	return nodes_to_use;
+}


### PR DESCRIPTION
This patch provides tests to exercise pages being moved between numa nodes using mbind and numa_move_pages. The compares the old PFN with the new PFN.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>