### PR TITLE
Fixing options for RDMA tests

### DIFF
--- a/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
@@ -22,8 +22,6 @@ test_opt: !mux
         test_opt: -y 10G
     -z:
         test_opt: -z
-    -D_10s:
-        test_opt: -D 10s
     -l_4:
         test_opt: -l 4
     -c_RC:
@@ -42,8 +40,8 @@ test_opt: !mux
         test_opt: -R -c RC
     -R_-D_30s:
         test_opt: -R -D 30s
-    -R_-f_5s:
-        test_opt: -R -f 5s
+    -R_-f_5s_-D_11s:
+        test_opt: -R -f 5s -D 11s
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_2048:

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
@@ -8,8 +8,6 @@ PEERCA: ""
 PEERPORT: "1"
 TIMEOUT: "600"
 test_opt: !mux
-    -b:
-        test_opt: -b
     -c_RC:
         test_opt: -c RC
     -D_10s:
@@ -38,8 +36,8 @@ test_opt: !mux
         test_opt: -R -c RC
     -R_-D_30s:
         test_opt: -R -D 30s
-    -R_-f_5s:
-        test_opt: -R -f 5s
+    -R_-f_5s_-D_11s:
+        test_opt: -R -f 5s -D 11s
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_2048:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
@@ -44,8 +44,8 @@ test_opt: !mux
         test_opt: -R -c RC
     -R_-D_30s:
         test_opt: -R -D 30s
-    -R_-f_5s:
-        test_opt: -R -f 5s
+    -R_-f_5s_-D_11s:
+        test_opt: -R -f 5s -D 11s
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_2048:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
@@ -42,8 +42,8 @@ test_opt: !mux
         test_opt: -R -c RC
     -R_-D_30s:
         test_opt: -R -D 30s
-    -R_-f_5s:
-        test_opt: -R -f 5s
+    -R_-f_5s_-D_11s:
+        test_opt: -R -f 5s -D 11s
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_2048:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
@@ -34,8 +34,8 @@ test_opt: !mux
         test_opt: -R -c RC
     -R_-D_30s:
         test_opt: -R -D 30s
-    -R_-f_5s:
-        test_opt: -R -f 5s
+    -R_-f_5s_-D_11s:
+        test_opt: -R -f 5s -D 11s
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_2048:


### PR DESCRIPTION
Some RDMA tests do not support certain parameters or combinations:
1. bidirectional is supported only on bandwidth test.
So removed it from latency test.
2. Duration > 2 * Margin.
So, -f 5s should have -D 11s atlease. Fixed that.
3. -D option was repeated, removed that.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>