### PR TITLE
Test to verify mprotect with data read, write

### DIFF
--- a/memory/mprotect.py
+++ b/memory/mprotect.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2018 IBM
+# Author: Harish <harish@linux.vnet.ibm.com>
+#
+
+
+import os
+import shutil
+
+from avocado import Test
+from avocado import main
+from avocado.utils import process, build, memory
+from avocado.utils.software_manager import SoftwareManager
+
+
+class Mprotect(Test):
+    """
+    Uses mprotect call to protect 90% of the machine's free
+    memory and accesses with PROT_READ, PROT_WRITE and PROT_NONE
+    """
+
+    def copyutil(self, file_name):
+        shutil.copyfile(os.path.join(self.datadir, file_name),
+                        os.path.join(self.teststmpdir, file_name))
+
+    def setUp(self):
+        smm = SoftwareManager()
+        memsize = int(memory.freememtotal() * 1024 * 0.9)
+        self.nr_pages = self.params.get('nr_pages', default=None)
+        self.in_err = self.params.get('induce_err', default=0)
+        self.failure = self.params.get('failure', default=False)
+
+        if not self.nr_pages:
+            self.nr_pages = memsize / memory.get_page_size()
+
+        for package in ['gcc', 'make']:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+
+        for file_name in ['mprotect.c', 'Makefile']:
+            self.copyutil(file_name)
+
+        build.make(self.teststmpdir)
+
+    def test(self):
+        os.chdir(self.teststmpdir)
+        self.log.info("Starting test...")
+
+        ret = process.system('./mprotect %s %s' % (self.nr_pages, self.in_err),
+                             shell=True, ignore_status=True, sudo=True)
+        if self.failure:
+            if ret is not 255:
+                self.fail("Please check the logs for debug")
+            else:
+                self.log.info("Failed as expected")
+        else:
+            if ret is not 0:
+                self.fail("Please check the logs for debug")
+            else:
+                self.log.info("Passed as expected")
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/mprotect.py.data/Makefile
+++ b/memory/mprotect.py.data/Makefile
@@ -1,0 +1,7 @@
+all: mprotect
+
+mprotect: mprotect.c
+	cc mprotect.c -o $@
+
+clean:
+	rm mprotect

--- a/memory/mprotect.py.data/mprotect.c
+++ b/memory/mprotect.py.data/mprotect.c
@@ -1,0 +1,100 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE for more details.
+ * Copyright: 2018 IBM
+ * Author: Harish <harish@linux.vnet.ibm.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <signal.h>
+
+#define handle_error(msg) \
+   do { perror(msg); exit(EXIT_FAILURE); } while (0)
+
+static void
+handler(int sig, siginfo_t *si, void *unused)
+{
+	printf("Got SIGSEGV at address: 0x%lx\n", (long) si->si_addr);
+	exit(255);
+}
+
+int main(int argc, char **argv)
+{
+	if ((argc < 2) || (argc > 3)) {
+		printf("bad args, usage: ./mprotect <nr-pages> <induce-err>\n");
+		handle_error("Input");
+	}
+
+	unsigned long length = atol(argv[1]);
+	unsigned long ps = getpagesize(), size , i, j = 0, iters = 1;
+	char *seg;
+	int fd, proto, ret, induce = 0, k = 0 ;
+	struct sigaction sa;
+
+	if (argc == 3)
+		induce = atoi(argv[2]);
+
+	fd = open("/dev/zero", O_RDWR);
+	size = ps * length;
+
+	sa.sa_flags = SA_SIGINFO;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_sigaction = handler;
+	if (sigaction(SIGSEGV, &sa, NULL) == -1)
+		handle_error("sigaction");
+
+	if ((seg = (char *)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0)) == (void *)-1)
+	{	
+		printf("mmap failed %s", strerror(errno));
+		close(fd);
+		return 0;
+	}
+	ret = mprotect(seg, size , PROT_READ | PROT_WRITE);
+	if (ret == -1)
+               	handle_error("mprotect_out");
+	memset(seg, 2, size);
+
+	printf("\nmemset -> PASS\n");
+	printf("mprotect start addr: 0x%lx\n", (long)seg);
+	for (j = 0; j < size; j+=ps)
+	{
+		k = seg[j];
+		if(k != 2)
+			handle_error("memset");
+		ret = mprotect((void *)&seg[j], seg[j], PROT_NONE);
+		if (ret == -1)
+        		handle_error("mprotect_in");
+	}
+	printf("mprotect end addr: 0x%lx\n", (long)&seg[j-ps]);
+	printf("\nmprotect PROT_NONE per page -> PASS\n");
+	if(induce){
+		printf("Accessing last page with PROT_NONE, expecting SIGSEGV\n");
+		k = seg[j-ps];
+	}
+	ret = mprotect(seg, size , PROT_READ);
+	if (ret == -1)
+               	handle_error("mprotect_out");
+
+	printf("\nmprotect PROT_READ -> PASS\n");
+	printf("Accessing last page 0x%lx after PROT_READ\n", &seg[j-ps]);
+	k = seg[j-ps];
+	if (k != 2)
+		handle_error("wrong_val");
+	else
+		printf("\nREADING LAST PAGE -> PASS\n");
+	printf("Test passed\n");
+	return 0;
+}

--- a/memory/mprotect.py.data/mprotect.yaml
+++ b/memory/mprotect.py.data/mprotect.yaml
@@ -1,0 +1,10 @@
+setup:
+    # make sure enough memory is available
+    nr_pages: null
+    scen: !mux
+        positive:
+            induce_err: 0
+            failure: False
+        negative:
+            induce_err: 1
+            failure: True


### PR DESCRIPTION
This test verifies mrpotect most pages of the free memory by read, write and accessing protected pages accordingly

Signed-off-by: Harish <harish@linux.vnet.ibm.com>