### PR TITLE
Basic packages addition and adding hard lockup dectection

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -154,8 +154,8 @@ class Stressng(Test):
                                 ignore_status=True, sudo=True)
         collect_dmesg(self)
         ERROR = []
-        pattern = ['WARNING: CPU:', 'Oops',
-                   'Segfault', 'soft lockup', 'Unable to handle']
+        pattern = ['WARNING: CPU:', 'Oops', 'Segfault', 'soft lockup',
+                   'Unable to handle', 'Hard LOCKUP']
         logs = process.system_output('dmesg').splitlines()
         for fail_pattern in pattern:
             for log in logs:

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -62,15 +62,16 @@ class Stressng(Test):
         self.v_stressors = self.params.get('v_stressors', default=None)
         self.parallel = self.params.get('parallel', default=True)
 
+        deps = ['gcc', 'make']
         if 'Ubuntu' in detected_distro.name:
-            deps = [
+            deps.extend([
                 'libaio-dev', 'libapparmor-dev', 'libattr1-dev', 'libbsd-dev',
                 'libcap-dev', 'libgcrypt11-dev', 'libkeyutils-dev',
-                'libsctp-dev', 'zlib1g-dev']
+                'libsctp-dev', 'zlib1g-dev'])
         else:
-            deps = ['libattr-devel', 'libbsd-devel', 'libcap-devel',
-                    'libgcrypt-devel', 'keyutils-libs-devel', 'zlib-devel',
-                    'libaio-devel']
+            deps.extend(['libattr-devel', 'libbsd-devel', 'libcap-devel',
+                         'libgcrypt-devel', 'keyutils-libs-devel',
+                         'zlib-devel', 'libaio-devel'])
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.log.info(


### PR DESCRIPTION
* Add basic required packages
Stress-ng fails to compile without gcc, hence this patch adds basic packages to compile.

* Detect Hard LOCKUP after test
Appending Hard LOCKUP to the list of possible failures with stress-ng running

Signed-off-by: Harish <harish@linux.vnet.ibm.com>