### PR TITLE
Fix: Apply fallocate patch for centos

### DIFF
--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -112,7 +112,7 @@ class libhugetlbfs(Test):
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
-        if detected_distro.name in ["rhel", "fedora", "redhat"]:
+        if detected_distro.name in ["rhel", "fedora", "redhat", "centos"]:
             falloc_patch = 'patch -p1 < %s ' % (
                 os.path.join(data_dir, 'falloc.patch'))
             process.run(falloc_patch, shell=True)


### PR DESCRIPTION
This patch fixes fallocate headers for centos while building libhugetlbfs.
Fixes: #866

Signed-off-by: Harish <harish@linux.vnet.ibm.com>