### PR TITLE
Fix: vatest with proper pre-requisite

### DIFF
--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -39,7 +39,7 @@ class VATest(Test):
         # Check for basic utilities
         smm = SoftwareManager()
         self.scenario_arg = int(self.params.get('scenario_arg', default=1))
-        dic = {2: 1024, 3: 1024, 4: 131072, 5: 1, 6: 1, 7: 2}
+        dic = {2: 65536, 3: 65536, 4: 131072, 5: 1, 6: 1, 7: 2}
         if self.scenario_arg not in range(1, 7):
             self.cancel("Test need to skip as scenario will be 1-7")
         if self.scenario_arg in [2, 3, 4]:
@@ -47,7 +47,7 @@ class VATest(Test):
                 self.cancel(
                     "Test need to skip as 16MB huge need to configured")
         elif self.scenario_arg in [5, 6, 7]:
-            if memory.meminfo.Hugepagesize.gb != 16:
+            if memory.meminfo.Hugepagesize.g != 16:
                 self.cancel(
                     "Test need to skip as 16GB huge need to configured")
         if self.scenario_arg != 1:

--- a/memory/vatest.py.data/va_test.c
+++ b/memory/vatest.py.data/va_test.c
@@ -129,7 +129,8 @@ void alloc_64k_full()
 {
 
 	printf("Allocating 64k pages < 128TB \n");
-	mmap_chunks_lower(8191, 0);
+        /* Note: Allocating a 16GB chunk less due to heap space required for other mappings */
+	mmap_chunks_lower(8190, 0);
 	
 	printf("Allocating 64k pages > 128TB \n");
 	mmap_chunks_higher(24575, 0);		
@@ -298,13 +299,13 @@ int main(int argc, char *argv[])
                 break;
         case 2 :
 		printf("\nScenario 2 : Get hugepage VA Below 128Tb mark \n\n");
-		printf("1024 16M hugepages must be configured \n");
+		printf("65536 16M hugepages must be configured \n");
 		printf("Else Test Fails\n\n");
 		alloc_16m_below_hint();
                 break;
         case 3 :
 		printf("\nScenario 3 : Get hugepage VA Above 128Tb mark \n\n");
-		printf("1024 16M hugepages must be configured \n");
+		printf("65536 16M hugepages must be configured \n");
 		printf("Else Test Fails\n\n");
 		alloc_16m_above_hint();
                 break;


### PR DESCRIPTION
Few scenarios had failures in allocation due to wrong pre-requisite. This patch fixes the setup.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>