### PR TITLE
Fix: Failure detection in vatest

### DIFF
--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -74,7 +74,7 @@ class VATest(Test):
         result = process.run('./va_test -s %s' %
                              self.scenario_arg, shell=True, ignore_status=True)
         for line in result.stdout.splitlines():
-            if 'Problem' in line:
+            if 'failed' in line:
                 self.fail("test failed, Please check debug log for failed"
                           "test cases")
 

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -55,7 +55,7 @@ class VATest(Test):
 
         for packages in ['gcc', 'make']:
             if not smm.check_installed(packages) and not smm.install(packages):
-                self.cancle('%s is needed for the test to be run' % packages)
+                self.cancel('%s is needed for the test to be run' % packages)
 
         shutil.copyfile(os.path.join(self.datadir, 'va_test.c'),
                         os.path.join(self.teststmpdir, 'va_test.c'))

--- a/memory/vatest.py.data/va_test.c
+++ b/memory/vatest.py.data/va_test.c
@@ -91,7 +91,7 @@ int mmap_chunks_lower(unsigned long no_of_chunks, unsigned long hugetlb_arg)
         		}
 		}
         	if (validate_addr(ptr, 0)){
-			printf("\n Address in > 128Tb !!! So Problem \n");
+			printf("\n Address failed, in > 128Tb !!! So Problem \n");
 			exit(-1);
 		}
 
@@ -117,7 +117,7 @@ int mmap_chunks_higher(unsigned long no_of_chunks, unsigned long hugetlb_arg)
         	}
 
         	if (validate_addr(hptr, 1)){
-			printf("\n Address is not in > 128Tb iterator = %d\n", i);
+			printf("\n Address failed, not in > 128Tb iterator = %d\n", i);
 			exit(-1);
 		}
 	}


### PR DESCRIPTION
Failure is suppressed as False positive in some cases where keyword is not found. Patch solves this issue.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>