### PR TITLE
fix: add unicode param when file is read as string

### DIFF
--- a/io/net/scp_ssh.py
+++ b/io/net/scp_ssh.py
@@ -115,11 +115,11 @@ class ScpTest(Test):
         '''
         self.log.info('removing data')
         cmd = "rm /tmp/tempfile"
-        if process.system(cmd, shell=True, ignore_status=True) != 0:
+        if process.system(cmd, shell=True, ignore_status=True, encoding="utf-8") != 0:
             self.log.info("unable to remove data from client")
         msg = "rm /tmp/tempfile"
         cmd = "ssh %s@%s \"%s\"" % (self.user, self.peer, msg)
-        if process.system(cmd, shell=True, ignore_status=True) != 0:
+        if process.system(cmd, shell=True, ignore_status=True, encoding="utf-8") != 0:
             self.log.info("unable to remove data from peer")
 
 


### PR DESCRIPTION
The /tmp/tmpfile is read as string and not converted to unicode on python2.7
so test is failing with this error:

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 18: ordinal

fixed to decode from str to unicode(UTF-8)

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>