### PR TITLE
 Fix: eatmemory test patch apply and use maximum possible memory

### DIFF
--- a/memory/eatmemory.py
+++ b/memory/eatmemory.py
@@ -48,7 +48,7 @@ class eatmemory(Test):
         os.chdir(self.sourcedir)
         process.run(getch_patch, shell=True)
         build.make(self.sourcedir)
-        mem = self.params.get('memory_to_test', default=memory.memtotal())
+        mem = self.params.get('memory_to_test', default=int(0.95 * memory.meminfo.MemFree.k))
         self.mem_to_eat = self._mem_to_mbytes(mem)
         if self.mem_to_eat is None:
             self.error("Memory '%s' not valid." % mem)

--- a/memory/eatmemory.py
+++ b/memory/eatmemory.py
@@ -45,6 +45,7 @@ class eatmemory(Test):
         # patch for getch remove
         getch_patch = 'patch -p1 < %s' % (os.path.join(
              self.datadir, 'eatmem_getch.patch'))
+        os.chdir(self.sourcedir)
         process.run(getch_patch, shell=True)
         build.make(self.sourcedir)
         mem = self.params.get('memory_to_test', default=memory.memtotal())

--- a/memory/eatmemory.py.data/eatmem_getch.patch
+++ b/memory/eatmemory.py.data/eatmem_getch.patch
@@ -1,12 +1,25 @@
---- ./a/eatmemory.c	2017-11-17 14:07:02.121268394 +0530
-+++ ./b/eatmemory.c	2017-11-17 14:06:54.912292114 +0530
-@@ -87,8 +87,7 @@ int main(int argc, char *argv[]){
+diff --git a/eatmemory.c b/eatmemory.c
+index e5891fa..8b1e345 100644
+--- a/eatmemory.c
++++ b/eatmemory.c
+@@ -86,16 +86,10 @@ int main(int argc, char *argv[]){
+             }
              printf("Eating %ld bytes in chunks of %d...\n",size,chunk);
              if(eat(size,chunk)){
-                 if(isatty(fileno(stdin))) {
+-                if(isatty(fileno(stdin))) {
 -                    printf("Done, press any key to free the memory\n");
 -                    getchar();
-+                    printf("Done\n");
-                 } else {
-                     printf("Done, kill this process to free the memory\n");
-                     while(true) {
+-                } else {
+-                    printf("Done, kill this process to free the memory\n");
+-                    while(true) {
+-                        sleep(1);
+-                    }
+-                }
+-            }else{
++                printf("Done\n");
++                exit(0);
++            }
++            else{
+                 printf("ERROR: Could not allocate the memory");
+             }
+         }


### PR DESCRIPTION
1) Fix: eat memory test patch apply
Existing patch does not apply properly. That too, is applied in the wrong location and does not serve the purpose of exiting from the application. This patch fixes it.

2) Use only maximum possible memory
Patch allows to use only maximum possible memory of the system as using total memory gets the process killed

Signed-off-by: Harish <harish@linux.vnet.ibm.com>