### PR TITLE
Add page poisoning test with KSM

### DIFF
--- a/memory/ksm_poison.py
+++ b/memory/ksm_poison.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2018 IBM
+# Author: Harish <harish@linux.vnet.ibm.com>
+#
+
+
+import os
+import shutil
+
+from avocado import Test
+from avocado import main
+from avocado.utils import process, build, memory
+from avocado.utils.software_manager import SoftwareManager
+
+
+class KsmPoison(Test):
+    """
+    Exercise Kernel Samepage Merging (KSM) through madvise call to share
+    machine's free mapped memory and accesses the pages through memset
+    """
+
+    def copyutil(self, file_name):
+        shutil.copyfile(os.path.join(self.datadir, file_name),
+                        os.path.join(self.teststmpdir, file_name))
+
+    def setUp(self):
+        smm = SoftwareManager()
+        memsize = int(memory.meminfo.MemFree.b * 0.1)
+        self.nr_pages = self.params.get('nr_pages', default=None)
+        self.offline = self.params.get('offline', default='s')
+        self.touch = self.params.get('touch', default=True)
+
+        if not self.nr_pages:
+            self.nr_pages = int(memsize / memory.get_page_size())
+
+        for package in ['gcc', 'make']:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+
+        for file_name in ['ksm_poison.c', 'Makefile']:
+            self.copyutil(file_name)
+
+        build.make(self.teststmpdir)
+
+    def test(self):
+        os.chdir(self.teststmpdir)
+        cmd = './ksm_poison -n %s' % str(self.nr_pages / 2)
+        if self.touch:
+            cmd = '%s -t' % cmd
+        if self.offline:
+            cmd = '%s -%s' % (cmd, self.offline)
+        ksm = process.SubProcess(cmd, shell=True, sudo=True)
+        ksm.start()
+        ksm.wait()
+
+        if ksm.result.exit_status:
+            self.fail("Please check the logs for debug")
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/ksm_poison.py.data/Makefile
+++ b/memory/ksm_poison.py.data/Makefile
@@ -1,0 +1,7 @@
+all: ksm_poison
+
+ksm_poison: ksm_poison.c
+	cc ksm_poison.c -o $@
+
+clean:
+	rm ksm_poison

--- a/memory/ksm_poison.py.data/ksm_poison.c
+++ b/memory/ksm_poison.py.data/ksm_poison.c
@@ -1,0 +1,93 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <linux/mman.h>
+
+void *mmap_memory(unsigned long size)
+{
+        void *mmap_pointer;
+        mmap_pointer = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if ((!mmap_pointer) && (mmap_pointer != MAP_FAILED)) {
+                perror("mmap");
+                exit(-1);
+        }
+        return mmap_pointer;
+}
+
+void set_mergeable(void *addr, unsigned long size)
+{
+	if (madvise(addr, size, MADV_MERGEABLE) == -1){
+		perror("madvise mergeable\n");
+	}
+}
+
+void clear_mergeable(void *addr, unsigned long size)
+{
+	if (madvise(addr, size, MADV_UNMERGEABLE) == -1){
+		perror("madvise unmergeable\n");
+	}
+}
+	
+
+int main(int argc, char *argv[])
+{
+	int c;
+	int touch = 0;
+	int nr_pages = 0;
+	int hardoffline = 0;
+	int softoffline = 0;
+	unsigned long size;
+	unsigned long pagesize = getpagesize();
+	void *map1;
+	void *map2;
+	if (argc < 2){
+		printf("Usage : <./poison> -n <nr_pages> -t -h[hardoffline or -s for softofflining]\n");
+		exit(-1);
+	}
+	while((c = getopt(argc, argv,"n:t:hs")) != -1){
+        	switch(c) {
+		case 'n' :
+                	nr_pages = atoi(optarg);
+			break;
+		case 't' :
+			touch = 1;
+			break;
+		case 'h' :
+			hardoffline = 1;
+			break;
+		case 's' :
+			softoffline = 1;
+			break;
+        	}
+	}
+	size = nr_pages * pagesize;
+	map1 = mmap_memory(size);
+	printf("Mapped at %p\n", map1);
+	map2 = mmap_memory(size);
+	printf("Mapped at %p\n", map2);
+	printf("Set MADV_MERGEABLE flag for the mapped memory\n");
+	set_mergeable(map1, size);
+	set_mergeable(map2, size);
+	memset(map1, 'x', size);
+	memset(map2, 'x', size);
+	printf("Poison the Pages\n");
+	if(hardoffline || softoffline){
+		if((madvise(map1, size, hardoffline ? MADV_HWPOISON : MADV_SOFT_OFFLINE )) == -1){
+		perror("madvise poison\n");
+		exit(-1);
+		}
+	}
+	if(touch){
+		printf("Write into Affected Pages\n");
+		memset(map1, 'x', size);
+	}
+	printf("Clear MADV_MERGEABLE flag for the mapped memory\n");
+	clear_mergeable(map1, size);
+	clear_mergeable(map2, size);
+	printf("Test passed !!!\n");
+	return 0;
+}

--- a/memory/ksm_poison.py.data/ksm_poison.yaml
+++ b/memory/ksm_poison.py.data/ksm_poison.yaml
@@ -1,0 +1,15 @@
+setup:
+    # make sure enough memory is available
+    nr_pages: null
+    offline: !mux
+        soft:
+            offline: 's'
+        # Please be wary of the fact that hard offline would
+        # make memory unusable. uncomment the following to use
+        # hard:
+        #     offline: 'h'
+    page_touch: !mux
+        touch:
+            touch: True
+        no_touch:
+            touch: False


### PR DESCRIPTION
Patch adds test to verify soft/hard offline with kernel samepage merging. As pages are offlined, only 10% of free memory is being used in the test

Signed-off-by: Harish <harish@linux.vnet.ibm.com>