### PR TITLE
Fix: Handle numa_test

### DIFF
--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -49,8 +49,10 @@ class NumaTest(Test):
         pkgs = ['gcc', 'make']
         if dist.name == "Ubuntu":
             pkgs.extend(['libpthread-stubs0-dev', 'libnuma-dev'])
-        else:
+        elif dist.name in ["centos", "rhel", "fedora"]:
             pkgs.extend(['numactl-devel'])
+        else:
+            pkgs.extend(['libnuma-devel'])
 
         for package in pkgs:
             if not smm.check_installed(package) and not smm.install(package):

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -63,7 +63,7 @@ class NumaTest(Test):
         self.log.info("Starting test...")
 
         if process.system('./numa_test -m %s -n %s' % (self.map_type, self.nr_pages),
-                          shell=True, sudo=True):
+                          shell=True, sudo=True, ignore_status=True):
             self.fail('Please check the logs for failure')
 
 

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -43,6 +43,9 @@ class NumaTest(Test):
             'nr_pages', default=memsize / memory.get_page_size())
         self.map_type = self.params.get('map_type', default='private')
 
+        if len(memory.numa_nodes()) < 2:
+            self.cancel('Test requires two numa nodes to run')
+
         pkgs = ['gcc', 'make']
         if dist.name == "Ubuntu":
             pkgs.extend(['libpthread-stubs0-dev', 'libnuma-dev'])


### PR DESCRIPTION
1) Fix: numa_test ERROR's not handled
Patch prevents numa_test from error as process.system is handled

2) Handle pre-requisite for numatest
Patch skips numa_test from running on single numa node machines

3) Fix: Packages for numa_test
The existing packages were not handled properly for sles. Hence, fixed in this patch

Signed-off-by: Harish <harish@linux.vnet.ibm.com>