### PR TITLE
Fix: service_check test

### DIFF
--- a/generic/service_check.py
+++ b/generic/service_check.py
@@ -35,6 +35,11 @@ class service_check(Test):
         config_file = self.datadir + '/services.cfg'
         parser.read(config_file)
         services_list = parser.get(detected_distro.name, 'services').split(',')
+        if detected_distro.name == 'SuSE':
+            if detected_distro.version >= 15:
+                services_list.append('firewalld')
+            else:
+                services_list.append('SuSEfirewall2')
         if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
             services_list.extend(['opal_errd', 'opal-prd'])
             if os.path.exists('/proc/device-tree/bmc'):

--- a/generic/service_check.py
+++ b/generic/service_check.py
@@ -38,12 +38,12 @@ class service_check(Test):
         if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
             services_list.extend(['opal_errd', 'opal-prd'])
             if os.path.exists('/proc/device-tree/bmc'):
-                services_list.remove(['opal_errd'])
+                services_list.remove('opal_errd')
         else:
             services_list.extend(['rtas_errd'])
         if 'Ubuntu' in detected_distro.name:
             if detected_distro.version >= 17:
-                services_list.remove(['networking'])
+                services_list.remove('networking')
         services_failed = []
         runner = process.run
 

--- a/generic/service_check.py
+++ b/generic/service_check.py
@@ -25,6 +25,7 @@ from avocado.utils import process
 from avocado.utils.service import SpecificServiceManager
 from avocado.utils import distro
 from avocado.utils.wait import wait_for
+from avocado.utils.software_manager import SoftwareManager
 
 
 class service_check(Test):
@@ -35,11 +36,21 @@ class service_check(Test):
         config_file = self.datadir + '/services.cfg'
         parser.read(config_file)
         services_list = parser.get(detected_distro.name, 'services').split(',')
+
+        smm = SoftwareManager()
+        deps = []
+
         if detected_distro.name == 'SuSE':
+            deps.extend(['ppc64-diag', 'libvirt-daemon'])
             if detected_distro.version >= 15:
                 services_list.append('firewalld')
             else:
                 services_list.append('SuSEfirewall2')
+
+        for package in deps:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel(' %s is needed for the test to be run' % package)
+
         if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
             services_list.extend(['opal_errd', 'opal-prd'])
             if os.path.exists('/proc/device-tree/bmc'):

--- a/generic/service_check.py.data/services.cfg
+++ b/generic/service_check.py.data/services.cfg
@@ -3,7 +3,7 @@ services = sshd,ufw,networking,libvirtd
 [rhel]
 services = sshd,firewalld,network,libvirtd
 [SuSE]
-services = sshd,SuSEfirewall2,network,libvirtd
+services = sshd,network,libvirtd
 [fedora]
 services = sshd
 [centos]


### PR DESCRIPTION
1) Fix: service_check syntax 
Test failed with the following error as it was trying to remove a list instead of a string

L0047 ERROR|     services_list.remove(['networking'])
L0047 ERROR| ValueError: list.remove(x): x not in list

2) Fix: newly changed SuSE service 
Patch fixes newly changed firewall service in SuSE versions higher
than 15.

3) Fix: Packages for SuSE services
Added packages for SuSE service failures as pre-requisite

Signed-off-by: Harish <harish@linux.vnet.ibm.com>