### PR TITLE
nvme_cli_selftests.py remove depricated skip

### DIFF
--- a/io/disk/ssd/nvme_cli_selftests.py
+++ b/io/disk/ssd/nvme_cli_selftests.py
@@ -45,17 +45,17 @@ class NVMeCliSelfTest(Test):
         self.disk = self.params.get('disk', default='/dev/nvme0n1')
         cmd = 'ls %s' % self.device
         if process.system(cmd, ignore_status=True) is not 0:
-            self.skip("%s does not exist" % self.device)
+            self.cancel("%s does not exist" % self.device)
         smm = SoftwareManager()
         if not smm.check_installed("nvme-cli") and not \
                 smm.install("nvme-cli"):
-            self.skip('nvme-cli is needed for the test to be run')
+            self.cancel('nvme-cli is needed for the test to be run')
         python_packages = pip.get_installed_distributions()
         python_packages_list = [i.key for i in python_packages]
         python_pkgs = ['nose', 'nose2', 'pep8', 'flake8', 'pylint', 'epydoc']
         for py_pkg in python_pkgs:
             if py_pkg not in python_packages_list:
-                self.skip("python package %s not installed" % py_pkg)
+                self.cancel("python package %s not installed" % py_pkg)
         url = 'https://codeload.github.com/linux-nvme/nvme-cli/zip/master'
         tarball = self.fetch_asset("nvme-cli-master.zip", locations=[url],
                                    expire='7d')


### PR DESCRIPTION
This patch replaces depricated self.skip with self.cancel
With out this patch test will error "skip there is no attribute"

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>