### PR TITLE
Removed --help option test for bootlist

### DIFF
--- a/generic/ras_extended.py
+++ b/generic/ras_extended.py
@@ -140,8 +140,8 @@ class RASTools(Test):
     def test1_bootlist(self):
         self.log.info("===============Executing bootlist tool test===="
                       "===========")
-        list = ['--help', '-m normal -r',
-                '-m normal -o', '-m service -o', '-m both -o']
+        list = ['-m normal -r', '-m normal -o',
+                '-m service -o', '-m both -o']
         for list_item in list:
             cmd = "bootlist %s" % list_item
             self.run_cmd(cmd)


### PR DESCRIPTION
bootlist test faild as the return code is 255.

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>