### PR TITLE
Fix mac id param in vnic test

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -114,6 +114,7 @@ class NetworkVirtualization(Test):
         self.count = int(self.params.get('vnic_test_count', default="1"))
         self.device_ip = self.params.get('device_ip', '*', default=None)
         self.mac_id = self.params.get('mac_id', default="02:03:03:03:03:01")
+        self.mac_id = self.mac_id.replace(':', '')
         self.netmask = self.params.get('netmask', '*', default=None)
         self.peer_ip = self.params.get('peer_ip', default=None)
         self.login(self.hmc_ip, self.hmc_username, self.hmc_pwd)


### PR DESCRIPTION
mac id should be passed without the ':' in the HMC command.
So, removing it in the test.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>