### PR TITLE
Add check for numa tests

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado import main
-from avocado.utils import archive, build, process, distro
+from avocado.utils import archive, build, process, distro, memory
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -38,7 +38,6 @@ class Numactl(Test):
         Source:
         https://github.com/numactl/numactl
         '''
-
         # Check for basic utilities
         smm = SoftwareManager()
 
@@ -72,7 +71,10 @@ class Numactl(Test):
     def test(self):
 
         if build.make(self.sourcedir, extra_args='-k test', ignore_status=True):
-            self.fail('test failed, Please check debug log')
+            if len(memory.numa_nodes_with_memory()) < 2:
+                self.log.warn('Few tests failed due to less NUMA mem-nodes')
+            else:
+                self.fail('test failed, Please check debug log')
 
 
 if __name__ == "__main__":

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -43,8 +43,10 @@ class NumaTest(Test):
             'nr_pages', default=memsize / memory.get_page_size())
         self.map_type = self.params.get('map_type', default='private')
 
-        if len(memory.numa_nodes()) < 2:
-            self.cancel('Test requires two numa nodes to run')
+        nodes = memory.numa_nodes_with_memory()
+        if len(nodes) < 2:
+            self.cancel('Test requires two numa nodes to run.'
+                        'Node list with memory: %s' % nodes)
 
         pkgs = ['gcc', 'make']
         if dist.name == "Ubuntu":


### PR DESCRIPTION
Patch adds pre-check for few tests which requires NUMA memory nodes with newer avocado API

Signed-off-by: Harish <harish@linux.vnet.ibm.com>