### PR TITLE
Changing the default yaml file param to be empty

### DIFF
--- a/io/disk/fs_mark.py.data/fs_mark.yaml
+++ b/io/disk/fs_mark.py.data/fs_mark.yaml
@@ -1,5 +1,5 @@
-disk: ''
-dir: ''
+disk:
+dir:
 num_files: 1000
 size: 10240
 filesystem: !mux


### PR DESCRIPTION
Default yaml file parameter was '' instrad of Null.
Fixed that.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>