### PR TITLE
Change default parameter values for standalone test execution

### DIFF
--- a/memory/hugepage_sanity.py
+++ b/memory/hugepage_sanity.py
@@ -36,8 +36,8 @@ class HugepageSanity(Test):
 
     def setUp(self):
         smm = SoftwareManager()
-        self.hpagesize = int(self.params.get('hpagesize', default=''))
-        self.num_huge = int(self.params.get('num_pages', default=''))
+        self.hpagesize = int(self.params.get('hpagesize', default='16'))
+        self.num_huge = int(self.params.get('num_pages', default='1'))
 
         for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
Patch fixes the following error, as default value is missing when test is executed without any inputs.
ValueError: invalid literal for int() with base 10: ''. This patch fixes it.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>