### PR TITLE
Handle the depracation of datadir for cpu and io tests

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -54,13 +54,13 @@ class Ebizzy(Test):
         tarball = self.fetch_asset('http://liquidtelecom.dl.sourceforge.net'
                                    '/project/ebizzy/ebizzy/0.3'
                                    '/ebizzy-0.3.tar.gz')
-        data_dir = os.path.abspath(self.datadir)
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('.tar.')[0])
         self.sourcedir = os.path.join(self.workdir, version)
 
         patch = self.params.get(
             'patch', default='Fix-build-issues-with-ebizzy.patch')
+        data_dir = self.get_data(patch)
         os.chdir(self.sourcedir)
         p1 = 'patch -p0 < %s/%s' % (data_dir, patch)
         process.run(p1, shell=True)

--- a/cpu/linsched.py
+++ b/cpu/linsched.py
@@ -54,8 +54,7 @@ class Linsched(Test):
         git.get_repo('https://github.com/thejinxters/linux-scheduler-testing',
                      destination_dir=self.workdir)
         os.chdir(self.workdir)
-        fix_patch = 'patch -p1 < %s' % (
-            os.path.join(self.datadir, 'fix.patch'))
+        fix_patch = 'patch -p1 < %s' % self.get_data('fix.patch')
         process.run(fix_patch, shell=True, ignore_status=True)
 
         build.make(self.workdir)

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -51,7 +51,6 @@ class Dbench(Test):
             self.error('Gcc is needed for the test to be run')
 
         self.results = []
-        data_dir = os.path.abspath(self.datadir)
         tarball = self.fetch_asset(
             'http://samba.org/ftp/tridge/dbench/dbench-3.04.tar.gz')
         archive.extract(tarball, self.teststmpdir)
@@ -59,7 +58,7 @@ class Dbench(Test):
         self.sourcedir = os.path.join(self.teststmpdir, cb_version)
         os.chdir(self.sourcedir)
         patch = self.params.get('patch', default='dbench_startup.patch')
-        process.run('patch -p1 < %s' % data_dir + '/' + patch, shell=True)
+        process.run('patch -p1 < %s' % self.get_data(patch), shell=True)
         process.run('./configure')
         build.make(self.sourcedir)
 

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -118,7 +118,7 @@ class Disktest(Test):
         """
         Compiles the disktest
         """
-        c_file = os.path.join(self.datadir, "disktest.c")
+        c_file = self.get_data("disktest.c")
         shutil.copy(c_file, self.teststmpdir)
         build.make(self.teststmpdir, extra_args="disktest",
                    env={"CFLAGS": "-O2 -Wall -D_FILE_OFFSET_BITS=64 "

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -91,8 +91,7 @@ class FioTest(Test):
         self.log.info("Test will run on %s", self.dir)
         fio_job = self.params.get('fio_job', default='fio-simple.job')
         cmd = '%s/fio %s %s --filename=%s' % (self.sourcedir,
-                                              os.path.join(
-                                                  self.datadir, fio_job),
+                                              self.get_data(fio_job),
                                               self.dir, self.fio_file)
         process.system(cmd)
 

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -429,7 +429,7 @@ class IOZone(Test):
         make_dir = os.path.join(self.sourcedir, 'src', 'current')
         os.chdir(make_dir)
         patch = self.params.get('patch', default='makefile.patch')
-        patch = os.path.join(self.datadir, patch)
+        patch = self.get_data(patch)
         process.run('patch -p3 < %s' % patch, shell=True)
 
         d_distro = distro.detect()

--- a/io/nvmf/nvmftest.py
+++ b/io/nvmf/nvmftest.py
@@ -58,8 +58,8 @@ class NVMfTest(Test):
                 linux_modules.load_module("nvme-rdma")
         except CmdError:
             self.cancel("nvme-rdma module not loadable")
-        self.cfg_tmpl = os.path.join(self.datadir, "nvmf_template.cfg")
-        self.cfg_file = os.path.join(self.datadir, "nvmf.cfg")
+        self.cfg_tmpl = self.get_data("nvmf_template.cfg")
+        self.cfg_file = self.get_data("nvmf.cfg")
         self.nvmf_discovery_file = "/etc/nvme/discovery.conf"
 
     def create_cfg_file(self):


### PR DESCRIPTION
datadir is deprecated. get_data() should be used instead.
commit id: 53445a82cf37905a57b4aad958b3000c33ed64ff
https://github.com/avocado-framework/avocado/commit/53445a82cf37905a57b4aad958b3000c33ed64ff

Fixed it for cpu and io tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>