### PR TITLE
Fix: Replace self.datadir with self.get_data()

### DIFF
--- a/fs/flail.py
+++ b/fs/flail.py
@@ -39,8 +39,7 @@ class Flail(Test):
                 self.cancel(package + ' is needed for the test to be run')
         self.fs_type = self.params.get('fstype', default='xfs')
 
-        tarball = os.path.join(self.datadir, "flail-0.2.0.tar.gz")
-        archive.extract(tarball, self.workdir)
+        archive.extract(self.get_data("flail-0.2.0.tar.gz"), self.workdir)
         self.build_dir = os.path.join(self.workdir, 'flail-0.2.0')
 
         build.make(self.build_dir)

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -105,9 +105,9 @@ class Xfstests(Test):
             self.cancel('Unknown filesystem %s' % self.fs_to_test)
         mount = True
         self.devices = []
-        shutil.copyfile(os.path.join(self.datadir, 'local.config'),
+        shutil.copyfile(self.get_data('local.config'),
                         os.path.join(self.teststmpdir, 'local.config'))
-        shutil.copyfile(os.path.join(self.datadir, 'group'),
+        shutil.copyfile(self.get_data('group'),
                         os.path.join(self.teststmpdir, 'group'))
 
         if self.dev_type == 'loop':

--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -68,8 +68,7 @@ class Fsfuzzer(Test):
 
         if d_name == "ubuntu":
             # Patch for ubuntu
-            fuzz_fix_patch = 'patch -p1 < %s' % (
-                os.path.join(self.datadir, 'fsfuzz_fix.patch'))
+            fuzz_fix_patch = 'patch -p1 < %s' % self.get_data('fsfuzz_fix.patch')
             if process.system(fuzz_fix_patch, shell=True, ignore_status=True):
                 self.log.warn("Unable to apply sh->bash patch!")
 

--- a/generic/connectathon.py
+++ b/generic/connectathon.py
@@ -66,7 +66,6 @@ class Connectathon(Test):
                            package)
 
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        data_dir = os.path.abspath(self.datadir)
         git.get_repo('git://git.linux-nfs.org/projects/steved/cthon04.git',
                      destination_dir=self.workdir)
         os.chdir(self.workdir)

--- a/generic/interbench.py
+++ b/generic/interbench.py
@@ -56,15 +56,13 @@ class Interbench(Test):
         tarball = self.fetch_asset('http://slackware.cs.utah.edu/pub/kernel'
                                    '.org/pub/linux/kernel/people/ck/apps/'
                                    'interbench/interbench-0.31.tar.gz')
-        data_dir = os.path.abspath(self.datadir)
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('.tar.')[0])
         self.sourcedir = os.path.join(self.workdir, version)
 
         # Patch for make file
         os.chdir(self.sourcedir)
-        makefile_patch = 'patch -p1 < %s ' % (
-            os.path.join(data_dir, 'makefile_fix.patch'))
+        makefile_patch = 'patch -p1 < %s ' % self.get_data('makefile_fix.patch')
         process.run(makefile_patch, shell=True)
 
         build.make(self.sourcedir)

--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -63,9 +63,10 @@ class ltp(Test):
         if script == 'runltp':
             logfile = os.path.join(self.logdir, 'ltp.log')
             failcmdfile = os.path.join(self.logdir, 'failcmdfile')
-            skipfile = os.path.join(self.datadir, 'skipfile')
+
             args += (" -q -p -l %s -C %s -d %s -S %s"
-                     % (logfile, failcmdfile, self.workdir, skipfile))
+                     % (logfile, failcmdfile, self.workdir,
+                        self.get_data('skipfile')))
         ltpbin_dir = os.path.join(self.workdir, "ltp-master", 'bin')
         cmd = os.path.join(ltpbin_dir, script) + ' ' + args
         result = process.run(cmd, ignore_status=True)

--- a/generic/ras.py
+++ b/generic/ras.py
@@ -232,7 +232,7 @@ class RASTools(Test):
         self.log.info("===============Executing rtas_errd and rtas_dump tools"
                       " test===============")
         self.log.info("1 - Injecting event")
-        rtas_file = os.path.join(self.datadir, 'rtas')
+        rtas_file = self.get_data('rtas')
         self.run_cmd("/usr/sbin/rtas_errd -d -f %s" % rtas_file)
         self.log.info("2 - Checking if the event was dumped to /var/log/"
                       "platform")
@@ -260,7 +260,7 @@ class RASTools(Test):
         self.log.info("===============Executing rtas_event_decode tool test===="
                       "===========")
         cmd_result = process.run("rtas_event_decode -w 500 -dv -n 2302 < %s" %
-                                 os.path.join(self.datadir, 'rtas'), ignore_status=True,
+                                 self.get_data('rtas'), ignore_status=True,
                                  sudo=True, shell=True)
         if cmd_result.exit_status != 17:
             self.fail("%s command(s) failed in rtas_event_decode tool "

--- a/generic/service_check.py
+++ b/generic/service_check.py
@@ -33,8 +33,7 @@ class service_check(Test):
     def test(self):
         detected_distro = distro.detect()
         parser = ConfigParser.ConfigParser()
-        config_file = self.datadir + '/services.cfg'
-        parser.read(config_file)
+        parser.read(self.get_data('services.cfg'))
         services_list = parser.get(detected_distro.name, 'services').split(',')
 
         smm = SoftwareManager()

--- a/generic/servicelog.py
+++ b/generic/servicelog.py
@@ -93,7 +93,7 @@ class servicelog(Test):
         Manageservice.stop("rtas_errd")
         self.log.info("===============1. Creating notification tool ===="
                       "===========")
-        notify_script = os.path.join(self.datadir, "notify_script.sh")
+        notify_script = self.get_data("notify_script.sh")
         cmd = "chmod 777 %s" % notify_script
         process.run(cmd, ignore_status=True, sudo=True, shell=True)
         self.log.info("=======2 - Adding notification tool to servicelog ="

--- a/kernel/posixtest.py
+++ b/kernel/posixtest.py
@@ -51,7 +51,6 @@ class Posixtest(Test):
         tarball = self.fetch_asset("http://ufpr.dl.sourceforge.net"
                                    "/sourceforge/posixtest"
                                    "/posixtestsuite-1.5.2.tar.gz")
-        data_dir = os.path.abspath(self.datadir)
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('-1.')[0])
         self.sourcedir = os.path.join(self.workdir, version)

--- a/kernel/tlbflush.py
+++ b/kernel/tlbflush.py
@@ -46,14 +46,11 @@ class Tlbflush(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel("%s is needed for this test." % package)
 
-        data_dir = os.path.abspath(self.datadir)
-
-        shutil.copyfile(os.path.join(data_dir, 'tlbflush.c'),
+        shutil.copyfile(self.get_data('tlbflush.c'),
                         os.path.join(self.workdir, 'tlbflush.c'))
 
         os.chdir(self.workdir)
-        tlbflush_patch = 'patch -p1 < %s' % (
-            os.path.join(data_dir, 'tlbflush.patch'))
+        tlbflush_patch = 'patch -p1 < %s' % self.get_data('tlbflush.patch')
 
         process.run(tlbflush_patch, shell=True)
         cmd = 'gcc -DFILE_SIZE=$((128*1048576)) -g -O2 tlbflush.c \

--- a/memory/eatmemory.py
+++ b/memory/eatmemory.py
@@ -43,8 +43,7 @@ class eatmemory(Test):
         archive.extract(tarball, self.workdir)
         self.sourcedir = os.path.join(self.workdir, "eatmemory-master")
         # patch for getch remove
-        getch_patch = 'patch -p1 < %s' % (os.path.join(
-             self.datadir, 'eatmem_getch.patch'))
+        getch_patch = 'patch -p1 < %s' % self.get_data('eatmem_getch.patch')
         os.chdir(self.sourcedir)
         process.run(getch_patch, shell=True)
         build.make(self.sourcedir)

--- a/memory/fork_mem.py
+++ b/memory/fork_mem.py
@@ -53,10 +53,10 @@ class Forkoff(Test):
             if not smm.check_installed(packages) and not smm.install(packages):
                 self.cancel('%s is needed for the test to be run' % packages)
 
-        shutil.copyfile(os.path.join(self.datadir, 'forkoff.c'),
+        shutil.copyfile(self.get_data('forkoff.c'),
                         os.path.join(self.teststmpdir, 'forkoff.c'))
 
-        shutil.copyfile(os.path.join(self.datadir, 'Makefile'),
+        shutil.copyfile(self.get_data('Makefile'),
                         os.path.join(self.teststmpdir, 'Makefile'))
 
         build.make(self.teststmpdir)

--- a/memory/hugepage_sanity.py
+++ b/memory/hugepage_sanity.py
@@ -31,7 +31,7 @@ class HugepageSanity(Test):
     """
 
     def copyutil(self, file_name):
-        shutil.copyfile(os.path.join(self.datadir, file_name),
+        shutil.copyfile(self.get_data(file_name),
                         os.path.join(self.teststmpdir, file_name))
 
     def setUp(self):

--- a/memory/integrity.py
+++ b/memory/integrity.py
@@ -54,8 +54,7 @@ class Integrity(Test):
             if not smm.check_installed(packages) and not smm.install(packages):
                 self.cancel('%s is needed for the test to be run' % packages)
 
-        tarball = os.path.join(self.datadir, "Integritytests.tar")
-        archive.extract(tarball, self.workdir)
+        archive.extract(self.get_data("Integritytests.tar"), self.workdir)
         self.build_dir = os.path.join(self.workdir, 'Integritytests')
         build.make(self.build_dir)
 

--- a/memory/ksm_poison.py
+++ b/memory/ksm_poison.py
@@ -32,7 +32,7 @@ class KsmPoison(Test):
     """
 
     def copyutil(self, file_name):
-        shutil.copyfile(os.path.join(self.datadir, file_name),
+        shutil.copyfile(self.get_data(file_name),
                         os.path.join(self.teststmpdir, file_name))
 
     def setUp(self):

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -102,19 +102,17 @@ class libhugetlbfs(Test):
                 os.makedirs(self.hugetlbfs_dir)
             process.system('mount -t hugetlbfs none %s' % self.hugetlbfs_dir)
 
-        data_dir = os.path.abspath(self.datadir)
         git.get_repo('https://github.com/libhugetlbfs/libhugetlbfs.git',
                      destination_dir=self.workdir)
         os.chdir(self.workdir)
         patch = self.params.get('patch', default='elflink.patch')
-        process.run('patch -p1 < %s' % data_dir + '/' + patch, shell=True)
+        process.run('patch -p1 < %s' % self.get_data(patch), shell=True)
 
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
         if detected_distro.name in ["rhel", "fedora", "redhat", "centos"]:
-            falloc_patch = 'patch -p1 < %s ' % (
-                os.path.join(data_dir, 'falloc.patch'))
+            falloc_patch = 'patch -p1 < %s ' % self.get_data('falloc.patch')
             process.run(falloc_patch, shell=True)
 
         build.make(self.workdir, extra_args='BUILDTYPE=NATIVEONLY')

--- a/memory/memory_api.py
+++ b/memory/memory_api.py
@@ -35,7 +35,7 @@ class MemorySyscall(Test):
     """
 
     def copyutil(self, file_name):
-        shutil.copyfile(os.path.join(self.datadir, file_name),
+        shutil.copyfile(self.get_data(file_name),
                         os.path.join(self.teststmpdir, file_name))
 
     def setUp(self):

--- a/memory/mprotect.py
+++ b/memory/mprotect.py
@@ -32,7 +32,7 @@ class Mprotect(Test):
     """
 
     def copyutil(self, file_name):
-        shutil.copyfile(os.path.join(self.datadir, file_name),
+        shutil.copyfile(self.get_data(file_name),
                         os.path.join(self.teststmpdir, file_name))
 
     def setUp(self):

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -32,7 +32,7 @@ class NumaTest(Test):
     """
 
     def copyutil(self, file_name):
-        shutil.copyfile(os.path.join(self.datadir, file_name),
+        shutil.copyfile(self.get_data(file_name),
                         os.path.join(self.teststmpdir, file_name))
 
     def setUp(self):

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -92,10 +92,10 @@ class VATest(Test):
             if not smm.check_installed(packages) and not smm.install(packages):
                 self.cancel('%s is needed for the test to be run' % packages)
 
-        shutil.copyfile(os.path.join(self.datadir, 'va_test.c'),
+        shutil.copyfile(self.get_data('va_test.c'),
                         os.path.join(self.teststmpdir, 'va_test.c'))
 
-        shutil.copyfile(os.path.join(self.datadir, 'Makefile'),
+        shutil.copyfile(self.get_data('Makefile'),
                         os.path.join(self.teststmpdir, 'Makefile'))
 
         build.make(self.teststmpdir)

--- a/perf/blogbench.py
+++ b/perf/blogbench.py
@@ -45,7 +45,7 @@ class Blogbench(Test):
         os.chdir(self.blogbench_dir)
         patch = self.params.get('patch', default='config_guess.patch')
         process.run('patch -p1 config.guess %s' %
-                    os.path.join(self.datadir, patch), shell=True)
+                    self.get_data(patch), shell=True)
         process.system('./configure')
         build.make(self.blogbench_dir, extra_args='install-strip')
 

--- a/perf/lmbench.py
+++ b/perf/lmbench.py
@@ -52,7 +52,6 @@ class Lmbench(Test):
                 self.cancel("%s is needed for the test to be run" % package)
         tarball = self.fetch_asset('http://www.bitmover.com'
                                    '/lmbench/lmbench3.tar.gz')
-        data_dir = os.path.abspath(self.datadir)
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('.tar.')[0])
         self.sourcedir = os.path.join(self.workdir, version)
@@ -61,14 +60,13 @@ class Lmbench(Test):
 
         os.chdir(self.sourcedir)
 
-        makefile_patch = 'patch -p1 < %s' % (
-            os.path.join(data_dir, 'makefile.patch'))
-        build_patch = 'patch -p1 < %s' % (os.path.join(
-            data_dir, '0001-Fix-build-issues-with-lmbench.patch'))
-        lmbench_fix_patch = 'patch -p1 < %s' % (os.path.join(
-            data_dir, '0002-Changing-shebangs-on-lmbench-scripts.patch'))
-        ostype_fix_patch = 'patch -p1 < %s' % (
-            os.path.join(data_dir, 'fix_add_os_type.patch'))
+        makefile_patch = 'patch -p1 < %s' % self.get_data('makefile.patch')
+        build_patch = 'patch -p1 < %s' % self.get_data(
+            '0001-Fix-build-issues-with-lmbench.patch')
+        lmbench_fix_patch = 'patch -p1 < %s' % self.get_data(
+            '0002-Changing-shebangs-on-lmbench-scripts.patch')
+        ostype_fix_patch = 'patch -p1 < %s' % self.get_data(
+            'fix_add_os_type.patch')
 
         process.run(makefile_patch, shell=True)
         process.run(build_patch, shell=True)

--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -78,8 +78,7 @@ class Ltrace(Test):
 
             self.src_lt = os.path.join(self.workdir, "ltrace")
             os.chdir(self.src_lt)
-            process.run('patch -p1 < %s' %
-                        os.path.join(self.datadir, 'ltrace.patch'), shell=True)
+            process.run('patch -p1 < %s' % self.get_data('ltrace.patch'), shell=True)
         elif run_type == "distro":
             self.src_lt = os.path.join(self.workdir, "ltrace-distro")
             if not os.path.exists(self.src_lt):

--- a/toolchain/power_time_base_bug.py
+++ b/toolchain/power_time_base_bug.py
@@ -49,11 +49,11 @@ class PowerTimeBaseBug(Test):
                 self.cancel('%s is needed for the test to be run' % package)
 
         self.log.info("Tranferring the files ...")
-        shutil.copyfile(os.path.join(self.datadir, 'print_power_time_base.c'),
+        shutil.copyfile(self.get_data('print_power_time_base.c'),
                         os.path.join(self.teststmpdir, 'print_power_time_base.c'))
 
         self.log.info("About to compile ...")
-        shutil.copyfile(os.path.join(self.datadir, 'Makefile'),
+        shutil.copyfile(self.get_data('Makefile'),
                         os.path.join(self.teststmpdir, 'Makefile'))
 
         build.make(self.teststmpdir)


### PR DESCRIPTION
This patch replaces self.datadir with self.get_data() as former is deprecated. This patch addresses 25 such tests across fs, fuzz, generic, kernel, memory, perf, toolchain.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>