### PR TITLE
Fix issue of fio_file variable not existing

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -50,6 +50,7 @@ class FioTest(Test):
         """
         Build 'fio'.
         """
+        self.fio_file = 'fiotest-image'
         default_url = "http://brick.kernel.dk/snaps/fio-2.1.10.tar.gz"
         url = self.params.get('fio_tool_url', default=default_url)
         self.disk = self.params.get('disk', default=None)
@@ -81,8 +82,6 @@ class FioTest(Test):
             except PartitionError:
                 self.fail("Mounting disk %s on directory %s failed"
                           % (self.disk, self.dir))
-
-        self.fio_file = 'fiotest-image'
 
     def test(self):
         """


### PR DESCRIPTION
self.fio_file is created late in the setUp().
So, during setup failures, there is an error in tearDown() on the
variable not existing.
Fixed it by defining the variable early in the setUp()

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>