### PR TITLE
 ppc64_cpu: Fixes and enhancements

### DIFF
--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -76,7 +76,7 @@ class PPC64Test(Test):
         :params cmd1: Command 1
         :params cmd2: Command 2
         """
-        self.log.info("Testing %s" % test_name)
+        self.log.info("Testing %s", test_name)
         if str(cmd1) != str(cmd2):
             self.failures += 1
             self.failure_message += "%s test failed when SMT=%s\n" \
@@ -102,7 +102,7 @@ class PPC64Test(Test):
         self.smt_loop()
 
         if self.failures > 0:
-            self.log.debug("Number of failures is %s" % self.failures)
+            self.log.debug("Number of failures is %s", self.failures)
             self.log.debug(self.failure_message)
             self.fail()
 
@@ -172,7 +172,8 @@ class PPC64Test(Test):
             "/sys/devices/system/cpu/dscr_default").strip(), 16)
         self.equality_check("DSCR", op1, op2)
 
-    def smt_loop(self):
+    @staticmethod
+    def smt_loop():
         """
         Tests smt on/off in a loop
         """

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -168,7 +168,8 @@ class PPC64Test(Test):
         """
         op1 = process.system_output(
             "ppc64_cpu --dscr", shell=True).strip().split()[-1]
-        op2 = genio.read_file("/sys/devices/system/cpu/dscr_default").strip()
+        op2 = int(genio.read_file(
+            "/sys/devices/system/cpu/dscr_default").strip(), 16)
         self.equality_check("DSCR", op1, op2)
 
     def smt_loop(self):


### PR DESCRIPTION
1) ppc64_cpu: Change bash commands to python native code
This patch changes bash commands to python native code and reduces execution time.

2) Fix: dscr test 
dscr_default file has a hex value and hence the comparison fails. This patch fixes it.

3) Fix pylint issues

Signed-off-by: Harish <harish@linux.vnet.ibm.com>