### PR TITLE
vatest: Detect MMU and configure test

### DIFF
--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -21,7 +21,7 @@ import shutil
 
 from avocado import Test
 from avocado import main
-from avocado.utils import process, build, memory, genio, distro, cpu
+from avocado.utils import process, build, memory, genio, distro
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -44,7 +44,10 @@ class VATest(Test):
         self.hsizes = [1024, 2]
         page_chunker = memory.meminfo.Hugepagesize.m
         if distro.detect().arch in ['ppc64', 'ppc64le']:
-            if 'power8' in cpu.get_cpu_arch():
+            mmu_detect = genio.read_file(
+                '/proc/cpuinfo').strip().splitlines()[-1]
+            # Check for "Radix" as this MMU will be explicit in POWER
+            if 'Radix' not in mmu_detect:
                 self.hsizes = [16384, 16]
 
         if self.scenario_arg not in range(1, 13):

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -48,12 +48,18 @@ class VATest(Test):
                 '/proc/cpuinfo').strip().splitlines()[-1]
             # Check for "Radix" as this MMU will be explicit in POWER
             if 'Radix' not in mmu_detect:
-                self.hsizes = [16384, 16]
+                self.hsizes = [16]
+                # For now, 16G hugepages are possible only when it is default.
+                # So check and add to the possible pagesize list
+                if page_chunker == 16384:
+                    self.hsizes.extend([16384])
 
         if self.scenario_arg not in range(1, 13):
             self.cancel("Test need to skip as scenario will be 1-12")
         elif self.scenario_arg in [7, 8, 9]:
             self.log.info("Using alternate hugepages")
+            if len(self.hsizes) == 1:
+                self.cancel('Scenario is not applicable')
             if memory.meminfo.Hugepagesize.m == self.hsizes[0]:
                 page_chunker = self.hsizes[1]
             else:
@@ -62,6 +68,8 @@ class VATest(Test):
         self.exist_pages = memory.get_num_huge_pages()
         if self.scenario_arg in [10, 11, 12]:
             self.log.info("Using Multiple hugepages")
+            if len(self.hsizes) == 1:
+                self.cancel('Scenario is not applicable')
             if memory.meminfo.Hugepagesize.m != self.hsizes[0]:
                 self.hsizes.reverse()
 


### PR DESCRIPTION
1) Check MMU for setting different page sizes 

Patch checks for MMU rather than the previous implementation of check of different architecture. This allows machines with hash page table to run properly irrespective of the sub-arch.

2) Check 16G hugepage as default

This patch checks whether 16G hugepages is default, elsewhere it cannot be configured and used. So check and skip scenarios which are not applicable.

3) Fix pep8 and pylint issues

Signed-off-by: Harish <harish@linux.vnet.ibm.com>