### PR TITLE
Seperate the ppc64_cpu tests

### DIFF
--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -82,7 +82,7 @@ class PPC64Test(Test):
             self.failure_message += "%s test failed when SMT=%s\n" \
                 % (test_name, self.key)
 
-    def test(self):
+    def test_cmd_options(self):
         """
         Sets the SMT value, and calls each of the test, for each value.
         """
@@ -99,14 +99,10 @@ class PPC64Test(Test):
             self.smt_snoozedelay()
             self.dscr()
 
-        self.smt_loop()
-
         if self.failures > 0:
             self.log.debug("Number of failures is %s", self.failures)
             self.log.debug(self.failure_message)
             self.fail()
-
-        process.system_output("dmesg")
 
     def smt(self):
         """
@@ -172,20 +168,21 @@ class PPC64Test(Test):
             "/sys/devices/system/cpu/dscr_default").strip(), 16)
         self.equality_check("DSCR", op1, op2)
 
-    @staticmethod
-    def smt_loop():
+    def test_smt_loop(self):
         """
         Tests smt on/off in a loop
         """
         for _ in range(1, 100):
-            process.run("ppc64_cpu --smt=off && ppc64_cpu --smt=on",
-                        shell=True)
+            if process.system("ppc64_cpu --smt=off && ppc64_cpu --smt=on",
+                              shell=True):
+                self.fail('SMT loop test failed')
 
     def tearDown(self):
         """
         Sets back SMT to original value as was before the test.
         """
         process.system_output("ppc64_cpu --smt=%s" % self.curr_smt, shell=True)
+        process.system_output("dmesg")
 
 
 if __name__ == "__main__":

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -45,14 +45,14 @@ class PPC64Test(Test):
         if SoftwareManager().check_installed("powerpc-utils") is False:
             if SoftwareManager().install("powerpc-utils") is False:
                 self.cancel("powerpc-utils is not installing")
-        smt_op = process.system_output("ppc64_cpu --smt")
+        self.smt_str = "ppc64_cpu --smt"
+        smt_op = process.system_output(self.smt_str, shell=True)
         if "is not SMT capable" in smt_op:
             self.cancel("Machine is not SMT capable")
         if "Inconsistent state" in smt_op:
             self.cancel("Machine has mix of ST and SMT cores")
 
-        self.curr_smt = process.system_output(
-            "ppc64_cpu --smt", shell=True).strip().split("=")[-1].split()[-1]
+        self.curr_smt = smt_op.strip().split("=")[-1].split()[-1]
         self.smt_subcores = 0
         if os.path.exists("/sys/devices/system/cpu/subcores_per_core"):
             self.smt_subcores = 1
@@ -89,7 +89,8 @@ class PPC64Test(Test):
         for i in range(2, self.max_smt_value + 1):
             self.smt_values[i] = str(i)
         for self.key, self.value in self.smt_values.iteritems():
-            process.system_output("ppc64_cpu --smt=%s" % self.key, shell=True)
+            process.system_output("%s=%s" % (self.smt_str,
+                                             self.key), shell=True)
             process.system_output("ppc64_cpu --info")
             self.smt()
             self.core()
@@ -109,7 +110,7 @@ class PPC64Test(Test):
         Tests the SMT in ppc64_cpu command.
         """
         op1 = process.system_output(
-            "ppc64_cpu --smt", shell=True).strip().split("=")[-1].split()[-1]
+            self.smt_str, shell=True).strip().split("=")[-1].split()[-1]
         self.equality_check("SMT", op1, self.value)
 
     def core(self):
@@ -173,7 +174,7 @@ class PPC64Test(Test):
         Tests smt on/off in a loop
         """
         for _ in range(1, 100):
-            if process.system("ppc64_cpu --smt=off && ppc64_cpu --smt=on",
+            if process.system("%s=off && %s=on" % (self.smt_str, self.smt_str),
                               shell=True):
                 self.fail('SMT loop test failed')
 
@@ -181,7 +182,8 @@ class PPC64Test(Test):
         """
         Sets back SMT to original value as was before the test.
         """
-        process.system_output("ppc64_cpu --smt=%s" % self.curr_smt, shell=True)
+        process.system_output("%s=%s" % (self.smt_str,
+                                         self.curr_smt), shell=True)
         process.system_output("dmesg")
 
 


### PR DESCRIPTION
Seperated the ppc64_cpu tests into test_params and test_smt_loop.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>