### PR TITLE
Replacing ifdown and ifup with "ip" command.

### DIFF
--- a/io/net/net_data.py
+++ b/io/net/net_data.py
@@ -232,8 +232,8 @@ class NetDataTest(Test):
         if 'yes' in self.eth_state:
             process.system("ifconfig %s up" % self.iface, shell=True)
             if self.ip_set:
-                process.system("ifdown %s" % self.iface, shell=True)
-                process.system("ifup %s" % self.iface, shell=True)
+                process.system("ip link set %s down" % self.iface, shell=True)
+                process.system("ip link set %s up" % self.iface, shell=True)
         else:
             process.system("ifconfig %s down" % self.iface, shell=True)
 


### PR DESCRIPTION
Ubuntu18.04 (bionic) does not support ifdown and ifup commands by default.
So instead of ifup and ifdown we can carry out same functionality using
"ip link" command. changed the same in the net_data.py script and it is
working fine.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>