### PR TITLE
Fixed libhugetlbfs test

### DIFF
--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -99,7 +99,7 @@ class libhugetlbfs(Test):
                 self.hugetlbfs_dir = os.path.join(self.tmpdir, 'hugetlbfs')
                 os.makedirs(self.hugetlbfs_dir)
             process.system('mount -t hugetlbfs none %s' %
-                           self.hugetlbfs_dir, sudo=True)
+                           self.hugetlbfs_dir, sudo=True, ignore_status=True)
 
         git.get_repo('https://github.com/libhugetlbfs/libhugetlbfs.git',
                      destination_dir=self.workdir)
@@ -191,7 +191,8 @@ class libhugetlbfs(Test):
 
     def tearDown(self):
         if self.hugetlbfs_dir:
-            process.system('umount %s' % self.hugetlbfs_dir)
+            process.system('umount %s' %
+                           self.hugetlbfs_dir, ignore_status=True)
 
 
 if __name__ == "__main__":

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -68,8 +68,8 @@ class libhugetlbfs(Test):
             op = glob.glob("/usr/lib*/libpthread.a")
 
         if not op:
-            self.error("libpthread.a is required!!!"
-                       "\nTry installing glibc-static")
+            self.cancel("libpthread.a is required!!!"
+                        "\nTry installing glibc-static")
 
         # Get arguments:
         self.hugetlbfs_dir = self.params.get('hugetlbfs_dir', default=None)
@@ -83,16 +83,16 @@ class libhugetlbfs(Test):
                                                       verbose=False,
                                                       shell=True)
             if 'HugePages_' not in Hugepages_support:
-                self.error("No Hugepages Configured")
+                self.cancel("No Hugepages Configured")
             memory.set_num_huge_pages(pages_requested)
             pages_available = memory.get_num_huge_pages()
         else:
-            self.error("Kernel does not support hugepages")
+            self.cancel("Kernel does not support hugepages")
 
         # Check no of hugepages :
         if pages_available < pages_requested:
-            self.error('%d pages available, < %d pages requested'
-                       % (pages_available, pages_requested))
+            self.cancel('%d pages available, < %d pages requested'
+                        % (pages_available, pages_requested))
 
         # Check if hugetlbfs is mounted
         cmd_result = process.run('grep hugetlbfs /proc/mounts', verbose=False)

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -40,10 +40,7 @@ class libhugetlbfs(Test):
     '''
 
     def setUp(self):
-        # Check for root permission
-        if os.geteuid() != 0:
-            exit("You need to have root privileges to run this script."
-                 "\nPlease try again, using 'sudo'. Exiting.")
+
         # Check for basic utilities
         sm = SoftwareManager()
         detected_distro = distro.detect()
@@ -81,7 +78,7 @@ class libhugetlbfs(Test):
         if os.path.exists('/proc/sys/vm/nr_hugepages'):
             Hugepages_support = process.system_output('cat /proc/meminfo',
                                                       verbose=False,
-                                                      shell=True)
+                                                      shell=True, sudo=True)
             if 'HugePages_' not in Hugepages_support:
                 self.cancel("No Hugepages Configured")
             memory.set_num_huge_pages(pages_requested)
@@ -95,12 +92,14 @@ class libhugetlbfs(Test):
                         % (pages_available, pages_requested))
 
         # Check if hugetlbfs is mounted
-        cmd_result = process.run('grep hugetlbfs /proc/mounts', verbose=False)
+        cmd_result = process.run(
+            'grep hugetlbfs /proc/mounts', verbose=False, sudo=True)
         if not cmd_result:
             if not self.hugetlbfs_dir:
                 self.hugetlbfs_dir = os.path.join(self.tmpdir, 'hugetlbfs')
                 os.makedirs(self.hugetlbfs_dir)
-            process.system('mount -t hugetlbfs none %s' % self.hugetlbfs_dir)
+            process.system('mount -t hugetlbfs none %s' %
+                           self.hugetlbfs_dir, sudo=True)
 
         git.get_repo('https://github.com/libhugetlbfs/libhugetlbfs.git',
                      destination_dir=self.workdir)


### PR DESCRIPTION
Fixed libhugetlbfs test 
1-change self.error to self.cancle
2-Removed  root privilege check and used avocado lib param for this
3- added ignore_status=True as a param in process.system to aviod
to error out script when command failed