### PR TITLE
Using supported distro for MOFED install test

### DIFF
--- a/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
+++ b/io/net/infiniband/mofed_install_test.py.data/mofed_install_test.yaml
@@ -31,7 +31,7 @@ Options: !mux
     umad-dev-rw:
         option: --umad-dev-rw
     distro:
-        option: -U --distro rhel7.2 --with-vma
+        option: -U --distro `cat distro` --with-vma
     fw-update-only:
         option: --fw-update-only
     check-deps-only:


### PR DESCRIPTION
MOFED comes with a file which gives information on the distro
supported. Using that in the yaml parameter.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>