### PR TITLE
Diag fix

### DIFF
--- a/ras/diag_encl.py
+++ b/ras/diag_encl.py
@@ -78,6 +78,7 @@ class DiagEncl(Test):
             product_path = '/proc/device-tree/model'
             serial_path = '/proc/device-tree/system-id'
         product_name = genio.read_one_line(product_path).rstrip(' \t\r\n\0')
+        product_name = product_name.split(',')[1]
         serial_num = genio.read_one_line(serial_path).rstrip(' \t\r\n\0')
         product_name_xml = "-".join((machine_type, machine_model))
         if product_name_xml != product_name:

--- a/ras/diag_encl.py
+++ b/ras/diag_encl.py
@@ -52,7 +52,7 @@ class DiagEncl(Test):
         self.log.info("===========Executing diag_encl test==========")
         diag_path = '/var/log/ppc64-diag/diag_disk/'
         if not os.path.isdir(diag_path):
-            self.fail('diag_disk path does not exists.')
+            self.run_cmd_out("diag_encl -d")
         if not self.run_cmd_out("diag_encl -h |"
                                 " grep -Eai 'disk health'").strip():
             self.fail("'-d' option is not available in help message")

--- a/ras/diag_encl.py
+++ b/ras/diag_encl.py
@@ -31,13 +31,15 @@ class DiagEncl(Test):
     is_fail = 0
 
     def run_cmd(self, cmd):
-        if (process.run(cmd, ignore_status=True, sudo=True, shell=True)).exit_status:
+        if (process.run(cmd, ignore_status=True, sudo=True,
+                        shell=True)).exit_status:
             self.is_fail += 1
         return
 
     @staticmethod
     def run_cmd_out(cmd):
-        return process.system_output(cmd, shell=True, ignore_status=True, sudo=True)
+        return process.system_output(cmd, shell=True,
+                                     ignore_status=True, sudo=True)
 
     def setUp(self):
         if "ppc" not in distro.detect().arch:
@@ -51,12 +53,14 @@ class DiagEncl(Test):
         diag_path = '/var/log/ppc64-diag/diag_disk/'
         if not os.path.isdir(diag_path):
             self.fail('diag_disk path does not exists.')
-        if not self.run_cmd_out("diag_encl -h | grep -Eai 'disk health'").strip():
+        if not self.run_cmd_out("diag_encl -h |"
+                                " grep -Eai 'disk health'").strip():
             self.fail("'-d' option is not available in help message")
         for _ in range(4):
             self.run_cmd("diag_encl -d")
         xml_file_path = os.path.join(diag_path, '*diskAnalytics*')
-        no_of_files = self.run_cmd_out("ls -lrt %s | wc -l" % xml_file_path).strip()
+        no_of_files = self.run_cmd_out("ls -lrt %s |"
+                                       " wc -l" % xml_file_path).strip()
         if no_of_files == '0':
             self.fail("xml file not generated")
         if no_of_files > '1':


### PR DESCRIPTION
Fix diag_encl test 
1-fixed pep8 issue
2-when diag test run and /var/log/ppc64-diag/diag_disk/ not avilable
test failed so in that case created as using diag_encl -d
3-As test is failing as sys attribute and xml attribute  not matching
as sys attribute has IBM, appended and it always make test fail as
that is false alarm

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>