### PR TITLE
Fixperftool

### DIFF
--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -37,7 +37,7 @@ class Perftool(Test):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         kernel_ver = platform.uname()[2]
-        deps = ['gcc', 'make']
+        deps = ['gcc', 'make', 'gcc-c++']
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['linux-tools-common', 'linux-tools-%s' % kernel_ver])
         # FIXME: "redhat" as the distro name for RHEL is deprecated

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -43,7 +43,8 @@ class Perftool(Test):
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
-        elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos', 'redhat']:
+        elif detected_distro.name in ['rhel', 'SuSE', 'fedora',
+                                      'centos', 'redhat']:
             deps.extend(['perf'])
         else:
             self.cancel("Install the package for perf supported\
@@ -57,7 +58,8 @@ class Perftool(Test):
         tarball = self.fetch_asset("perftool.zip", locations=locations,
                                    expire='7d')
         archive.extract(tarball, self.workdir)
-        self.sourcedir = os.path.join(self.workdir, 'perftool-testsuite-master')
+        self.sourcedir = os.path.join(self.workdir,
+                                      'perftool-testsuite-master')
 
     def test(self):
         '''

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -36,10 +36,10 @@ class Perftool(Test):
         # Check for basic utilities
         smm = SoftwareManager()
         detected_distro = distro.detect()
-        kernel_ver = platform.uname()[2]
         deps = ['gcc', 'make', 'gcc-c++']
         if 'Ubuntu' in detected_distro.name:
-            deps.extend(['linux-tools-common', 'linux-tools-%s' % kernel_ver])
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
@@ -69,7 +69,7 @@ class Perftool(Test):
           Source:
           https://github.com/rfmvh/perftool-testsuite
         '''
-        self.count = 0
+        count = 0
         # Built in perf test
         for string in process.run("perf test").stderr.splitlines():
             if 'FAILED' in str(string.splitlines()):
@@ -81,10 +81,10 @@ class Perftool(Test):
                                    process_kwargs={'ignore_status': True}
                                    ).stdout.splitlines():
             if '-- [ FAIL ] --' in line:
-                self.count += 1
+                count += 1
                 self.log.info(line)
 
-        if self.count > 0:
+        if count > 0:
             self.fail("%s Test failed" % self.count)
 
 


### PR DESCRIPTION
Fixed perftool test
1- fixed pep8 issue
2- added gcc-c++ as prerequisite package as some of perf test require g++

LOG:

[stderr] make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
[stdout] ## [ PASS ] ## perf_mem :: cleanup SUMMARY
[stderr] make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
[stderr] /bin/sh: g++: command not found
[stderr] /bin/sh: g++: command not found
[stderr] /bin/sh: g++: command not found
[stderr] /bin/sh: g++: command not found
[stderr] /bin/sh: g++: command not found
[stderr] /bin/sh: g++: command not found
[stderr] /bin/sh: g++: command not found
[stderr] make[1]: *** [Makefile:21: test_opts] Error 127

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>