### PR TITLE
Jumbo Frames yaml for Virtual Networks

### DIFF
--- a/io/net/net_data.py.data/net_data_virt_net.yaml
+++ b/io/net/net_data.py.data/net_data_virt_net.yaml
@@ -1,0 +1,6 @@
+Interfaces:
+    Interface1:
+        peer_ip: ""
+        interface: ""
+MTU:
+    size_val: 9000 1500


### PR DESCRIPTION
Virtual Network devices do no support MTU values other than
1500 and 9000.
So, created a separate yaml for virtual network devices.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>