### PR TITLE
Hwinfo test 

### DIFF
--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -26,6 +26,9 @@ class Hwinfo(Test):
 
     is_fail = 0
 
+    def clear_dmesg(self):
+        process.run("dmesg -C ", sudo=True)
+
     def run_cmd(self, cmd):
         self.log.info("executing ============== %s =================" % cmd)
         if process.system(cmd, ignore_status=True, sudo=True):
@@ -44,6 +47,8 @@ class Hwinfo(Test):
             self.cancel("Fail to install hwinfo required for this test.")
 
     def test(self):
+
+        self.clear_dmesg()
         self.log.info(
             "===============Executing hwinfo tool test===============")
         list = self.params.get('list', default=['--all', '--cpu', '--disk'])
@@ -72,8 +77,7 @@ class Hwinfo(Test):
         self.run_cmd("hwinfo --debug 0 --disk --log=-")
         self.run_cmd("hwinfo --short --block")
         self.run_cmd("hwinfo --disk --save-config=all")
-        if "failed" in process.system_output("hwinfo --disk --save-config"
-                                             "=all | ""grep failed | tail -1",
+        if "failed" in process.system_output("hwinfo --disk --save-config=all",
                                              shell=True):
             self.is_fail += 1
             self.log.info("--save-config option failed")

--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -41,7 +41,7 @@ class Hwinfo(Test):
             self.cancel('Hwinfo not supported on RHEL')
         sm = SoftwareManager()
         if not sm.check_installed("hwinfo") and not sm.install("hwinfo"):
-            self.error("Fail to install hwinfo required for this test.")
+            self.cancel("Fail to install hwinfo required for this test.")
 
     def test(self):
         self.log.info(

--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -56,7 +56,8 @@ class Hwinfo(Test):
         self.run_cmd("hwinfo --disk --only %s" % disk_name)
         Unique_Id = process.system_output("hwinfo --disk --only %s | "
                                           "grep 'Unique' | head -1 | "
-                                          "cut -d':' -f2" % disk_name, shell=True)
+                                          "cut -d':' -f2" % disk_name,
+                                          shell=True)
         self.run_cmd("hwinfo --disk --save-config %s" % Unique_Id)
         self.run_cmd("hwinfo --disk --show-config %s" % Unique_Id)
         self.run_cmd("hwinfo --verbose --map")
@@ -71,8 +72,9 @@ class Hwinfo(Test):
         self.run_cmd("hwinfo --debug 0 --disk --log=-")
         self.run_cmd("hwinfo --short --block")
         self.run_cmd("hwinfo --disk --save-config=all")
-        if "failed" in process.system_output("hwinfo --disk --save-config=all | "
-                                             "grep failed | tail -1", shell=True):
+        if "failed" in process.system_output("hwinfo --disk --save-config"
+                                             "=all | ""grep failed | tail -1",
+                                             shell=True):
             self.is_fail += 1
             self.log.info("--save-config option failed")
         if self.is_fail >= 1:


### PR DESCRIPTION
Fixed hwinfo test
1- fixed pep8 issue
2- change self.error to self.cancel as if hwinfo package is not installed test should not error out

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>