### PR TITLE
Fix compilation fail on SuSE distros

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -94,7 +94,7 @@ class Kernbench(Test):
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
                          'popt-devel', 'libcap2', 'libcap-devel',
-                         'libcap-ng-devel'])
+                         'libcap-ng-devel', 'flex', 'bison', 'openssl-devel'])
         elif detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',
                          'libcap', 'libcap-devel', 'elfutils-libelf',

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -54,8 +54,9 @@ class kselftest(Test):
                          'libpopt-dev', 'libcap-ng0', 'libcap-ng-dev',
                          'libnuma-dev', 'libfuse-dev', 'elfutils', 'libelf1'])
         elif 'SuSE' in detected_distro.name:
-            deps.extend(['popt', 'glibc', 'glibc-devel', 'popt-devel',
-                         'libcap2', 'libcap-devel', 'libcap-ng-devel'])
+            deps.extend(['popt', 'glibc', 'glibc-devel', 'popt-devel', 'sudo',
+                         'libcap2', 'libcap-devel', 'libcap-ng-devel',
+                         'fuse', 'fuse-devel', 'glibc-devel-static'])
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon


### PR DESCRIPTION
Compilation fails on SuSE distros due to lack of few packages. This patch fixes it.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>