### PR TITLE
kernelbench.py: Move bison, flex to common dependencies

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -85,16 +85,15 @@ class Kernbench(Test):
         """
         smg = SoftwareManager()
         detected_distro = distro.detect()
-        deps = ['gcc', 'make', 'automake', 'autoconf', 'time']
+        deps = ['gcc', 'make', 'automake', 'autoconf', 'time', 'bison', 'flex']
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['libpopt0', 'libc6', 'libc6-dev', 'libpopt-dev',
                          'libcap-ng0', 'libcap-ng-dev', 'elfutils', 'libelf1',
-                         'libnuma-dev', 'libfuse-dev', 'libssl-dev', 'flex',
-                         'bison'])
+                         'libnuma-dev', 'libfuse-dev', 'libssl-dev'])
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
                          'popt-devel', 'libcap2', 'libcap-devel',
-                         'libcap-ng-devel', 'flex', 'bison', 'openssl-devel'])
+                         'libcap-ng-devel', 'openssl-devel'])
         elif detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',
                          'libcap', 'libcap-devel', 'elfutils-libelf',


### PR DESCRIPTION
bison, flex packages names are common across distributions. Move them
to common dependencies list.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>