### PR TITLE
memory/numa: Fix typo in the test description

### DIFF
--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -27,7 +27,7 @@ from avocado.utils.software_manager import SoftwareManager
 
 class NumaTest(Test):
     """
-    Excercises numa_move_pages and mbind call with 20% of the machine's free
+    Exercises numa_move_pages and mbind call with 20% of the machine's free
     memory
     """
 


### PR DESCRIPTION
Fix the spelling of 'Excercises' -> 'Exercises' in the
test description.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>