### PR TITLE
cpu/cpustress: Remove the unused list variable

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -267,7 +267,6 @@ class cpustresstest(Test):
         PowerVM and Guest only: Dynamic Resource Manager
         use drmgr command to hotplug and hotunplug cpus
         """
-        output = []
         if 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
             if "cpu_dlpar=yes" in process.system_output("drmgr -C",
                                                         ignore_status=True,


### PR DESCRIPTION
Remove the unused list variable output.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>