### PR TITLE
cpu/pci_hotplug: Remove unused variable 'cmd'

### DIFF
--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -45,7 +45,6 @@ class PCIHotPlugTest(Test):
             self.cancel("Processor is not ppc64")
         if os.path.exists('/proc/device-tree/bmc'):
             self.cancel("Test Unsupported! on this platform")
-        cmd = "cat /proc/cpuinfo"
         if cpu._list_matches(open('/proc/cpuinfo').readlines(),
                              'platform\t: pSeries\n'):
             PowerVM = True


### PR DESCRIPTION
cpuinfo is read from '/proc/cpuinfo', instead of executing the command
to read it. So remove the unused variable.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>