### PR TITLE
Execute numactl tests sequentially

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -70,7 +70,8 @@ class Numactl(Test):
 
     def test(self):
 
-        if build.make(self.sourcedir, extra_args='-k test', ignore_status=True):
+        if build.make(self.sourcedir, extra_args='-k -j 1'
+                      ' test', ignore_status=True):
             if len(memory.numa_nodes_with_memory()) < 2:
                 self.log.warn('Few tests failed due to less NUMA mem-nodes')
             else:


### PR DESCRIPTION
By default build.make() uses multiple cpus to execute. numactl tests fails sometimes due to parallel execution as it causes background change to numa_hit etc. This patch restricts it by
explicitly specifying -j flag for tests.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>