### PR TITLE
kernel/kernbench: Fix trivial spelling mistake

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -41,7 +41,7 @@ class Kernbench(Test):
 
     def time_build(self, threads=None, timefile=None, make_opts=None):
         """
-        Time the bulding of the kernel
+        Time the building of the kernel
         """
         os.chdir(self.sourcedir)
         build.make(self.sourcedir, extra_args='clean')


### PR DESCRIPTION
Fix the spelling of 'bulding' -> 'building' in the time_build()
description.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>