### PR TITLE
Convert dmesg switch '-c' to '-C'

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -79,7 +79,7 @@ class cpustresstest(Test):
 
     @staticmethod
     def __clear_dmesg():
-        process.run("dmesg -c", sudo=True)
+        process.run("dmesg -C", sudo=True)
 
     @staticmethod
     def __error_check():

--- a/fs/flail.py
+++ b/fs/flail.py
@@ -59,7 +59,7 @@ class Flail(Test):
             self.fail("some call traces seen please check")
 
     def clear_dmesg(self):
-        process.run("dmesg -c ", sudo=True)
+        process.run("dmesg -C ", sudo=True)
 
 
 if __name__ == "__main__":

--- a/fs/fs-fuzz.py
+++ b/fs/fs-fuzz.py
@@ -31,7 +31,7 @@ class FsFuzz(Test):
     """
 
     def clear_dmesg(self):
-        process.run("dmesg -c ", sudo=True)
+        process.run("dmesg -C ", sudo=True)
 
     def verify_dmesg(self):
         self.whiteboard = process.system_output("dmesg")

--- a/fs/fsshrink.py
+++ b/fs/fsshrink.py
@@ -30,7 +30,7 @@ class Fsshrink(Test):
     '''
 
     def clear_dmesg(self):
-        process.run("dmesg -c ", sudo=True)
+        process.run("dmesg -C ", sudo=True)
 
     def verify_dmesg(self):
         self.whiteboard = process.system_output("dmesg")

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -25,7 +25,7 @@ from avocado.utils.software_manager import SoftwareManager
 
 
 def clear_dmesg():
-    process.run("dmesg -c ", sudo=True)
+    process.run("dmesg -C ", sudo=True)
 
 
 def collect_dmesg(object):

--- a/generic/sysbench.py
+++ b/generic/sysbench.py
@@ -31,7 +31,7 @@ class Sysbench(Test):
     """
 
     def clear_dmesg(self):
-        process.run("dmesg -c ", sudo=True)
+        process.run("dmesg -C ", sudo=True)
 
     def verify_dmesg(self):
         self.whiteboard = process.system_output("dmesg")

--- a/io/disk/mvcli_test.py
+++ b/io/disk/mvcli_test.py
@@ -60,7 +60,7 @@ class MvcliTest(Test):
         self.run_command("chmod +x %s" % mvcli_path)
         self.base = "%s %s" % (mvcli_path, self.adapter_id)
         self.base_force = "echo y | %s %s" % (mvcli_path, self.adapter_id)
-        self.run_command("dmesg -c")
+        self.run_command("dmesg -C")
         if self.fw_upgrade == "yes":
             path = self.fetch_asset("fw", locations=[self.fw_url],
                                     expire="7d")

--- a/io/genwqe/genwqetest.py
+++ b/io/genwqe/genwqetest.py
@@ -153,7 +153,7 @@ class GenWQETest(Test):
             self.fail("genwqe_poke fails")
         time.sleep(10)
         recovered = 0
-        cmd = "dmesg -c"
+        cmd = "dmesg -C"
         for line in process.system_output(cmd, shell=True,
                                           ignore_status=True).splitlines():
             if "chip reload/recovery" in line:

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -38,7 +38,7 @@ errorlog = ['WARNING: CPU:', 'Oops',
 
 
 def clear_dmesg():
-    process.run("dmesg -c ", sudo=True)
+    process.run("dmesg -C ", sudo=True)
 
 
 def online(block):


### PR DESCRIPTION
dmesg buffer is cleared '-c', as well as with '-C'. Whereas the latter
does not prints the contain of dmesg before clearing it, while '-c'
prints the dmesg buffer before clearing it. We are not interested in
the dmesg before the test run's so convert the switch from '-c' to '-C'.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>