### PR TITLE
kernel/kernbench: Use olddefconfig to build kernel

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -48,7 +48,7 @@ class Kernbench(Test):
         if self.config_path is None:
             build.make(self.sourcedir, extra_args='defconfig')
         else:
-            build.make(self.sourcedir, extra_args='oldnoconfig')
+            build.make(self.sourcedir, extra_args='olddefconfig')
         if make_opts:
             build_string = "/usr/bin/time -o %s make %s -j %s vmlinux" % (
                 timefile, make_opts, threads)


### PR DESCRIPTION
Upstream Linux Kernel commit fb16d8912db5 ("kconfig: replace
'oldnoconfig' with 'olddefconfig', and keep the old name as an alias")
replaces 'oldnoconfig' with 'olddeconfig' and for compatibility reasons
maintains an alias, which is targeted to be removed by Kernel v4.19.

This patch switches over to 'olddefconfig', this also helps in avoiding
the depreciation usage warning about 'oldnoconfig'.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>