### PR TITLE
generic/stress-ng: Fix test failure message

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -162,7 +162,7 @@ class Stressng(Test):
                 if fail_pattern in log:
                     ERROR.append(log)
         if ERROR:
-            self.fail("Test failed with following errors in demsg :  %s " %
+            self.fail("Test failed with following errors in dmesg :  %s " %
                       "\n".join(ERROR))
 
 


### PR DESCRIPTION
Fix the typo in the test failure message.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>