### PR TITLE
fs/fsshrink.py: Remove depricated datadir

### DIFF
--- a/fs/fsshrink.py
+++ b/fs/fsshrink.py
@@ -41,7 +41,7 @@ class Fsshrink(Test):
                 self.fail("Test Failed : %s in dmesg" % fail_pattern)
 
     def setUp(self):
-        shutil.copy(os.path.join(self.datadir, 'test-shrink.sh'),
+        shutil.copy(self.get_data('test-shrink.sh'),
                     self.teststmpdir)
 
         self.clear_dmesg()


### PR DESCRIPTION
This patch removes depricated datadir from fs/fsshrink.py

With out patch job run will error out:
 (1/1) fs/fsshrink.py:Fsshrink.test: ERROR (0.00 s)

With patch job run will continue with out errors:
(1/1) fs/fsshrink.py:Fsshrink.test: PASS (123.51 s)

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>