### PR TITLE
[RFC] Convert non class member as static methods

### DIFF
--- a/io/disk/mvcli_test.py
+++ b/io/disk/mvcli_test.py
@@ -76,7 +76,8 @@ class MvcliTest(Test):
         except CmdError as details:
             self.fail("Command %s failed %s" % (cmd, details))
 
-    def run_cmd_output(self, cmd):
+    @staticmethod
+    def run_cmd_output(cmd):
         """
         Execute the command and return output
         """

--- a/io/net/vlan_test.py
+++ b/io/net/vlan_test.py
@@ -171,13 +171,15 @@ class VlanTest(Test):
         except CmdError as details:
             self.fail("Command %s failed %s" % (cmd, details))
 
-    def run_cmd_output(self, cmd):
+    @staticmethod
+    def run_cmd_output(cmd):
         """
         Execute the command and return output
         """
         return process.system_output(cmd, ignore_status=True,
                                      shell=True, sudo=True)
 
+    @staticmethod
     def ping_check_host(self, intf, ip):
         '''
         ping check for peer in host

--- a/ras/kdump.py
+++ b/ras/kdump.py
@@ -34,7 +34,8 @@ class KDUMP(Test):
     :avocado: tags=remote
     '''
 
-    def run_cmd_out(self, cmd):
+    @staticmethod
+    def run_cmd_out(cmd):
         return process.system_output(cmd, shell=True, ignore_status=True, sudo=True).strip()
 
     def setUp(self):

--- a/ras/kdump_nfs.py
+++ b/ras/kdump_nfs.py
@@ -34,7 +34,8 @@ class KDUMP(Test):
     :avocado: tags=remote
     '''
 
-    def run_cmd_out(self, cmd):
+    @staticmethod
+    def run_cmd_out(cmd):
         return process.system_output(cmd, shell=True, ignore_status=True, sudo=True).strip()
 
     def setUp(self):

--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -44,7 +44,8 @@ class Lshwrun(Test):
             self.is_fail += 1
             self.fail_cmd.append(cmd)
 
-    def run_cmd_out(self, cmd):
+    @staticmethod
+    def run_cmd_out(cmd):
         return process.system_output(cmd, shell=True,
                                      ignore_status=True, sudo=True)
 

--- a/ras/pstore.py
+++ b/ras/pstore.py
@@ -32,7 +32,8 @@ class PSTORE(Test):
     :avocado: tags=remote
     '''
 
-    def run_cmd_out(self, cmd):
+    @staticmethod
+    def run_cmd_out(cmd):
         return process.system_output(cmd, shell=True, ignore_status=True, sudo=True).strip()
 
     def setUp(self):

--- a/ras/servicelog.py
+++ b/ras/servicelog.py
@@ -36,7 +36,8 @@ class servicelog(Test):
             self.log.info("%s command failed", cmd)
         return
 
-    def run_cmd_out(self, cmd):
+    @staticmethod
+    def run_cmd_out(cmd):
         return process.system_output(cmd, shell=True, ignore_status=True, sudo=True)
 
     def setUp(self):


### PR DESCRIPTION
This series converts the non-class specific functions into staticmethod, mostly converts `run_cmd_out()` into staticmethod, expect for ` io/net/vlan_test.py` where another function `ping_check_host()` can also be converted into staticmethod. This series is inspired by review comments from pull request #1000 