### PR TITLE
io/disk/htx_block_devices: Fix run_smt function

### DIFF
--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -138,7 +138,7 @@ class HtxTest(Test):
         """
         for value in self.smt_values:
             process.system_output("ppc64_cpu --smt=%s" % value, shell=True)
-            process.system_output("ppc64_cpu --smt" % value, shell=True)
+            process.system_output("ppc64_cpu --smt", shell=True)
             process.system_output("ppc64_cpu --info")
 
     def is_block_device_in_mdt(self):


### PR DESCRIPTION
"ppc64_cpu --smt" command doesn't accept any arguments, rather prints
the current '--smt' state. This patch removes the argument from the
command to be executed.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>