### PR TITLE
Run kernel self-tests from distribution source

### DIFF
--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -6,3 +6,8 @@ setup:
             comp: "powerpc"
         mem_plug:
             comp: "memory-hotplug"
+    run_type: !mux
+        distro:
+            type: 'distro'
+        upstream:
+            type: 'upstream'


### PR DESCRIPTION
This patch enables self-tests to be run from source of different distributions. Each distribution source fetching and preparation differs, which is handled in this patch.

This patch also introduces an input to run upstream/distro source selftests.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>