### PR TITLE
perf/perf_events_test: Use genio to read/write file

### DIFF
--- a/perf/perf_events_test.py
+++ b/perf/perf_events_test.py
@@ -19,7 +19,7 @@ import platform
 import os
 from avocado import Test
 from avocado import main
-from avocado.utils import archive, build, process, distro
+from avocado.utils import archive, build, process, distro, genio
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -85,9 +85,9 @@ class Perf_subsystem(Test):
 
     def execute_perf_test(self):
         os.chdir(self.sourcedir)
-        self.run_cmd_out("echo -1 >/proc/sys/kernel/perf_event_paranoid")
-        if "-1" not in self.run_cmd_out("cat /proc/sys/kernel/perf_event_paranoid"):
-            self.error("Unable to set perf_event_paranoid to -1 ")
+        genio.write_one_line("/proc/sys/kernel/perf_event_paranoid", "-1")
+        if "-1" not in genio.read_one_line("/proc/sys/kernel/perf_event_paranoid"):
+            self.cancel("Unable to set perf_event_paranoid to -1 ")
         self.output = self.run_cmd_out("./run_tests.sh")
 
     def test(self):


### PR DESCRIPTION
Use the genio methods to read/write into `/proc` file, instead of
run_cmd_out and return by testcase cancel instead of error'ing out.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>