### PR TITLE
kernel/kernbench: Move the linux archive untar to setup

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -110,16 +110,16 @@ class Kernbench(Test):
             'url', default='https://github.com/torvalds/linux/archive'
             '/master.zip')
         self.config_path = os.path.join('/boot/config-', self.kernel_version)
+        # Uncompress the kernel archive to the work directory
+        tarball = self.fetch_asset("kernbench.zip", locations=[self.location],
+                                   expire='1d')
+        archive.extract(tarball, self.workdir)
 
     def test(self):
         """
         Kernel build Test
         """
         # Setting the kernel
-        # Uncompress the kernel archive to the work directory
-        tarball = self.fetch_asset("kernbench.zip", locations=[self.location],
-                                   expire='1d')
-        archive.extract(tarball, self.workdir)
         self.sourcedir = os.path.join(self.workdir, 'linux-master')
 
         self.log.info("Starting build the kernel")


### PR DESCRIPTION
To maintain the consistency across testcases, have the testcase get and
untar code in the setup. In this case, the linux source is the testcase.
So move the get and untar of linux archive to setup code.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>