### PR TITLE
toolchain/bcc: Fix the typo in error message

### DIFF
--- a/toolchain/bcc.py
+++ b/toolchain/bcc.py
@@ -44,7 +44,7 @@ class Bcc(Test):
         smm = SoftwareManager()
         # TODO: Add support for other distributions
         if not detected_distro == "ubuntu":
-            self.cancel("Upsupported OS %s" % detected_distro)
+            self.cancel("Unsupported OS %s" % detected_distro)
         for package in ['bison', 'build-essential', 'cmake', 'flex',
                         'libedit-dev', 'libllvm3.8', 'llvm-3.8-dev',
                         'libclang-3.8-dev', 'python', 'zlib1g-dev',


### PR DESCRIPTION
Fix a trivial typo in the error message 'Upsupported' -> 'Unsupported'.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>