### PR TITLE
Convert error to cancel for package installation failure

### DIFF
--- a/generic/connectathon.py
+++ b/generic/connectathon.py
@@ -62,8 +62,8 @@ class Connectathon(Test):
 
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
-                self.error("Fail to install %s required for this test." %
-                           package)
+                self.cancel("Fail to install %s required for this test." %
+                            package)
 
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
         git.get_repo('git://git.linux-nfs.org/projects/steved/cthon04.git',

--- a/generic/criu.py
+++ b/generic/criu.py
@@ -39,8 +39,8 @@ class CRIU(Test):
             self.cancel('Currently test is supported only on RHEL')
         for package in packages:
             if not sm.check_installed(package) and not sm.install(package):
-                self.error("Fail to install %s required for this test." %
-                           package)
+                self.cancel("Fail to install %s required for this test." %
+                            package)
         criu_version = self.params.get('criu_version', default='2.6')
         tarball = self.fetch_asset(
                   "http://download.openvz.org/criu/criu-%s.tar.bz2" % criu_version,

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -74,8 +74,8 @@ class Stressng(Test):
                          'zlib-devel', 'libaio-devel'])
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
-                self.log.info(
-                    '%s is needed, get the source and build', package)
+                self.cancel("%s is needed, get the source and build" %
+                            package)
 
         tarball = self.fetch_asset('stressng.zip',
                                    locations=['https://github.com/Colin'

--- a/perf/hackbench.py
+++ b/perf/hackbench.py
@@ -48,7 +48,7 @@ class Hackbench(Test):
         self.results = None
         sm = SoftwareManager()
         if not sm.check_installed("gcc") and not sm.install("gcc"):
-            self.error("Gcc is needed for the test to be run")
+            self.cancel("Gcc is needed for the test to be run")
         hackbench = self.fetch_asset('http://people.redhat.com'
                                      '/~mingo/cfs-scheduler/'
                                      'tools/hackbench.c')

--- a/ras/kdump.py
+++ b/ras/kdump.py
@@ -41,7 +41,7 @@ class KDUMP(Test):
     def setUp(self):
         sm = SoftwareManager()
         if not sm.check_installed("openssh*") and not sm.install("openssh*"):
-            self.error("Fail to install openssh required for this test.")
+            self.cancel("Fail to install openssh required for this test.")
         self.ip = self.params.get('ip', default='')
         try:
             socket.inet_aton(self.ip)

--- a/ras/ras.py
+++ b/ras/ras.py
@@ -46,8 +46,8 @@ class RASTools(Test):
         sm = SoftwareManager()
         for package in ("ppc64-diag", "powerpc-utils", "lsvpd", "ipmitool"):
             if not sm.check_installed(package) and not sm.install(package):
-                self.error("Fail to install %s required for this"
-                           " test." % package)
+                self.cancel("Fail to install %s required for this test." %
+                            package)
 
     @skipIf(IS_POWER_NV or IS_KVM_GUEST, "This test is not supported on KVM guest or PowerNV platform")
     def test1_set_poweron_time(self):

--- a/toolchain/libvecpf.py
+++ b/toolchain/libvecpf.py
@@ -43,7 +43,7 @@ class Libvecpf(Test):
         smm = SoftwareManager()
         for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):
-                self.error('%s is needed for the test to be run' % package)
+                self.cancel('%s is needed for the test to be run' % package)
         tarball = self.fetch_asset('libvecpf.zip', locations=[
                                    'https://github.com/Libvecpf/libvecpf'
                                    '/archive/master.zip'], expire='7d')


### PR DESCRIPTION
To maintain consistency across all the testcases, convert the error to
cancel if the package dependency is not meet.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>