### PR TITLE
perf/generic_events: Add support for POWER9 events

### DIFF
--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -16,37 +16,9 @@
 # Author: Shriya Kulkarni <shriyak@linux.vnet.ibm.com>
 
 import os
+import ConfigParser
 from avocado import Test
 from avocado import main
-
-
-def generic_events(x):
-    return {
-        'cpu-cycles': "0x1e",
-        'stalled-cycles-frontend': "0x100f8",
-        'stalled-cycles-backend': "0x4000a",
-        'instructions': "0x02",
-        'branch-instructions': "0x10068",
-        'branch-misses': "0x400f6",
-        'cache-references': "0x100ee",
-        'cache-misses': "0x3e054",
-        'L1-dcache-load-misses': "0x3e054",
-        'L1-dcache-loads': "0x100ee",
-        'L1-dcache-prefetches': "0xd8b8",
-        'L1-dcache-store-misses': "0x300f0",
-        'L1-icache-load-misses': "0x200fd",
-        'L1-icache-loads': "0x4080",
-        'L1-icache-prefetches': "0x408e",
-        'LLC-load-misses': "0x300fe",
-        'LLC-loads': "0x4c042",
-        'LLC-prefetches': "0x4e052",
-        'LLC-store-misses': "0x17082",
-        'LLC-stores': "0x17080",
-        'branch-load-misses': "0x400f6",
-        'branch-loads': "0x10068",
-        'dTLB-load-misses': "0x300fc",
-        'iTLB-load-misses': "0x400fc"
-    }.get(x, 9)
 
 
 class test_generic_events(Test):
@@ -57,14 +29,25 @@ class test_generic_events(Test):
     and compare the raw event code for each generic event
     """
 
+    def read_generic_events(self):
+        parser = ConfigParser.ConfigParser()
+        parser.optionxform = str
+        parser.read(self.get_data('raw_code.cfg'))
+        cpu_info = open('/proc/cpuinfo', 'r').read()
+        if 'POWER8' in cpu_info:
+            self.generic_events = dict(parser.items('POWER8'))
+        elif 'POWER9' in cpu_info:
+            self.generic_events = dict(parser.items('POWER9'))
+
     def test(self):
         nfail = 0
         dir = "/sys/bus/event_source/devices/cpu/events"
+        self.read_generic_events()
         os.chdir(dir)
         for file in os.listdir(dir):
             events_file = open(file, "r")
             event_code = events_file.readline()
-            val = generic_events(file)
+            val = self.generic_events.get(file, 9)
             raw_code = event_code.split('=', 2)[1].rstrip()
             if raw_code != val:
                 nfail += 1

--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -1,0 +1,53 @@
+[POWER8]
+cpu-cycles = 0x1e
+stalled-cycles-frontend = 0x100f8
+stalled-cycles-backend = 0x4000a
+instructions = 0x02
+branch-instructions = 0x10068
+branch-misses = 0x400f6
+cache-references = 0x100ee
+cache-misses = 0x3e054
+L1-dcache-load-misses = 0x3e054
+L1-dcache-loads = 0x100ee
+L1-dcache-prefetches = 0xd8b8
+L1-dcache-store-misses = 0x300f0
+L1-icache-load-misses = 0x200fd
+L1-icache-loads = 0x4080
+L1-icache-prefetches = 0x408e
+LLC-load-misses = 0x300fe
+LLC-loads = 0x4c042
+LLC-prefetches = 0x4e052
+LLC-store-misses = 0x17082
+LLC-stores = 0x17080
+branch-load-misses = 0x400f6
+branch-loads = 0x10068
+dTLB-load-misses = 0x300fc
+iTLB-load-misses = 0x400fc
+mem_access = 0x10401e0
+
+[POWER9]
+cpu-cycles = 0x1e
+stalled-cycles-frontend = 0x100f8
+stalled-cycles-backend = 0x1e054
+instructions = 0x02
+branch-instructions = 0x4d05e
+branch-misses = 0x400f6
+cache-references = 0x100fc
+cache-misses = 0x2c04e
+L1-dcache-load-misses = 0x2c04e
+L1-dcache-loads = 0x100fc
+L1-dcache-prefetches = 0x20054
+L1-dcache-store-misses = 0x300f0
+L1-icache-load-misses = 0x200fd
+L1-icache-loads = 0x4080
+L1-icache-prefetches = 0x488c
+LLC-load-misses = 0x300fe
+LLC-loads = 0x4c042
+LLC-prefetches = 0x4e052
+LLC-store-misses = 0x26880
+LLC-stores = 0x16880
+branch-load-misses = 0x400f6
+branch-loads = 0x4d05e
+dTLB-load-misses = 0x300fc
+iTLB-load-misses = 0x400fc
+


### PR DESCRIPTION
This patch series is motivated by #911, Where the raw code events file is adopted from it with a minor addition of event code for `mem_access` on `POWER8`. `perf_genericevents` file, will use the raw code events file in the second commit, instead of using the hard coded value. Each commit message explains in details about the changes made by the commits.