### PR TITLE
fs/blktest: Use inbuilt genio to write into /proc

### DIFF
--- a/fs/blktests.py
+++ b/fs/blktests.py
@@ -18,7 +18,7 @@ import re
 
 from avocado import Test
 from avocado import main
-from avocado.utils import process, build, archive
+from avocado.utils import process, build, archive, genio
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -53,8 +53,7 @@ class Blktests(Test):
         self.clear_dmesg()
         os.chdir(self.sourcedir)
 
-        process.system(
-            'echo 0 > /proc/sys/kernel/hung_task_timeout_secs', ignore_status=True)
+        genio.write_one_line("/proc/sys/kernel/hung_task_timeout_secs", "0")
         process.system('./check', ignore_status=True)
         dmesg = process.system_output('dmesg')
         match = re.search(r'Call Trace:', dmesg, re.M | re.I)


### PR DESCRIPTION
Use the inbuilt the genio library to write into /proc/, instead of
passing the command via system().

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>