### PR TITLE
Fixed lshw test issue for SUSE versions lower to 15

### DIFF
--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -54,7 +54,7 @@ class Lshwrun(Test):
         dist = distro.detect()
         if dist.name == "SuSE" and dist.version < 15:
             self.cancel("lshw not supported on SUES-%s. Please run " +
-                        "on SLES15 or higher versions only " % dist.version)
+                        "on SLES15 or any higher version only " % dist.version)
 
         for package in ("lshw", "net-tools", "iproute", "pciutils"):
             if not sm.check_installed(package) and not sm.install(package):

--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -18,6 +18,7 @@ from avocado import main
 from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import distro
 
 
 class Lshwrun(Test):
@@ -49,6 +50,12 @@ class Lshwrun(Test):
 
     def setUp(self):
         sm = SoftwareManager()
+
+        dist = distro.detect()
+        if dist.name == "SuSE" and dist.version < 15:
+            self.cancel("lshw not supported on SUES-%s. Please run " +
+                        "on SLES15 or higher versions only " % dist.version)
+
         for package in ("lshw", "net-tools", "iproute", "pciutils"):
             if not sm.check_installed(package) and not sm.install(package):
                 self.error("Fail to install %s required for this"


### PR DESCRIPTION
This test is not supported on any SUSE version lower to 15
Please run on SUSE15 or latest versions only

Signed-off-by: Kowshik Jois B S <kowshik.linux@gmail.com>