### PR TITLE
Corrected variable scope

### DIFF
--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -85,7 +85,7 @@ class Perftool(Test):
                 self.log.info(line)
 
         if count > 0:
-            self.fail("%s Test failed" % self.count)
+            self.fail("%s Test failed" % count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch corrects the variable scope.
With out this patch, the test case errors out saying self object
doesn't contain attribute named 'count'.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>