### PR TITLE
Remove unnecessary package for building stress-ng

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -69,7 +69,7 @@ class Stressng(Test):
                 'libcap-dev', 'libgcrypt11-dev', 'libkeyutils-dev',
                 'libsctp-dev', 'zlib1g-dev'])
         else:
-            deps.extend(['libattr-devel', 'libbsd-devel', 'libcap-devel',
+            deps.extend(['libattr-devel', 'libcap-devel',
                          'libgcrypt-devel', 'keyutils-libs-devel',
                          'zlib-devel', 'libaio-devel'])
         for package in deps:


### PR DESCRIPTION
Remove unnecessary package for building stress-ng, Also some rhel and sles releases does not provide it.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>