### PR TITLE
Fixing eatmemory test issue and removing aadmin_tools test from ltp.yaml

### DIFF
--- a/generic/ltp.py.data/ltp.yaml
+++ b/generic/ltp.py.data/ltp.yaml
@@ -39,8 +39,6 @@ setup:
                 args: '-f fcntl-locktests'
             connectors:
                 args: '-f connectors'
-            aadmin_tools:
-                args: '-f admin_tools'
             timers:
                 args: '-f timers'
             power_management_tests:


### PR DESCRIPTION
1. eatmemeory tests failing as "patch" package not installed in the test system, hence added "patch" in dependency package list
2. aadmin_tools tests are removed from ltp, hence removing the tests from ltp.yaml file
   Reference : https://github.com/linux-test-project/ltp/commit/0fc9b8624bea8acfdb408bf5ff4916b1453e3daa

signed-off by:spoorthy@linux.vnet.ibm.com