### PR TITLE
Fixing eatmemory test failure

### DIFF
--- a/memory/eatmemory.py
+++ b/memory/eatmemory.py
@@ -32,7 +32,7 @@ class eatmemory(Test):
 
     def setUp(self):
         sm = SoftwareManager()
-        deps = ['gcc', 'make']
+        deps = ['gcc', 'make', 'patch']
         for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.error(package + ' is needed for the test to be run')


### PR DESCRIPTION
eatmemeory test requires 'patch' package to be installed in the system
Hence added patch to the dependency package list

signedoff-by: spoorthy@linux.vnet.ibm.com