### PR TITLE
Removing aadmin_tools tests from ltp

### DIFF
--- a/generic/ltp.py.data/ltp.yaml
+++ b/generic/ltp.py.data/ltp.yaml
@@ -39,8 +39,6 @@ setup:
                 args: '-f fcntl-locktests'
             connectors:
                 args: '-f connectors'
-            aadmin_tools:
-                args: '-f admin_tools'
             timers:
                 args: '-f timers'
             power_management_tests:


### PR DESCRIPTION
aadmin_tools tests are removed from ltp
Reference : https://github.com/linux-test-project/ltp/commit/0fc9b8624bea8acfdb408bf5ff4916b1453e3daa

signedoff-by: spoorthy@linux.vnet.ibm.com