### PR TITLE
Handling mount dir on fs_mark test

### DIFF
--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -79,19 +79,23 @@ class FSMark(Test):
             except PartitionError:
                 self.fail("Mounting disk %s on directory %s failed"
                           % (self.disk, self.dirs))
+            self.link = "/tmp/link"
+            os.symlink(self.dirs, self.link)
 
     def test(self):
         """
         Run fs_mark
         """
         os.chdir(self.sourcedir)
-        cmd = "./fs_mark -d %s -s %s -n %s" % (self.dirs, self.size, self.num)
+        cmd = "./fs_mark -d %s -s %s -n %s" % (self.link, self.size, self.num)
         process.run(cmd)
 
     def tearDown(self):
         '''
         Cleanup of disk used to perform this test
         '''
+        if self.link:
+            os.unlink(self.link)
         if self.disk is not None:
             self.log.info("Unmounting disk %s on directory %s",
                           self.disk, self.dirs)


### PR DESCRIPTION
fs_mark binary requires the mount dir length to be less than
40 characters. But avocado workdir is longer. To handle this,
we create a symbolic link to the workdir and provide that as
input to fs_mark command.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>