### PR TITLE
ppc64_cpu: Add support for POWER9 PowerVM config

### DIFF
--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -62,6 +62,9 @@ class PPC64Test(Test):
         self.key = 0
         self.value = ""
         self.max_smt_value = 4
+        if cpu.get_cpu_arch().lower() == 'power9':
+            if 'Hash' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0'):
+                self.max_smt_value = 8
         if cpu.get_cpu_arch().lower() == 'power8':
             self.max_smt_value = 8
         if cpu.get_cpu_arch().lower() == 'power6':


### PR DESCRIPTION
On a POWER9 machine different SMT levels are supported based on the environment.
On PowerVM LPAR runing Linux SMT8 is supported while SMT4 is supported with Linux running in non virtualized mode.
This patch Adds support for POWER9 PowerVM LPAR.
SMT8 is supported inside POWER9 PowerVM LPAR running Linux.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>
