### PR TITLE
fixed ebizzy output parsing

### DIFF
--- a/cpu/em_smt_folding_test.py
+++ b/cpu/em_smt_folding_test.py
@@ -94,7 +94,7 @@ class SmtFolding(Test):
         '''
         output = process.system_output("taskset -c %s ./ebizzy -t1"
                                        " -S 6 -s 4096" % self.cpu, shell=True)
-        return output.splitlines()[0]
+        return output.split()[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ebizzy returns the throughput followed with records/s, this
needs to be parsed using split syntax than splitlines to
get only the throughput.

Signed-off-by: Kalpana Shetty <kalshett@in.ibm.com>