### PR TITLE
Fix issue with unmounting page pools

### DIFF
--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -193,7 +193,7 @@ class libhugetlbfs(Test):
             self.fail(error)
 
     def tearDown(self):
-        for _ in range(0, self.page_sizes):
+        for _ in range(0, len(self.page_sizes)):
             if process.system('umount %s' %
                               self.hugetlbfs_dir, ignore_status=True):
                 self.log.warn("umount of hugetlbfs dir failed")


### PR DESCRIPTION
unmounting failed with
TypeError: range() integer end argument expected, got list.

This patch fixes the above issue.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>