### PR TITLE
hwinfo.py: split in to different tests

### DIFF
--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -24,8 +24,6 @@ from avocado.utils.software_manager import SoftwareManager
 
 class Hwinfo(Test):
 
-    is_fail = 0
-
     def clear_dmesg(self):
         process.run("dmesg -C ", sudo=True)
 
@@ -33,8 +31,7 @@ class Hwinfo(Test):
         self.log.info("executing ============== %s =================" % cmd)
         if process.system(cmd, ignore_status=True, sudo=True):
             self.log.info("%s command failed" % cmd)
-            self.is_fail += 1
-        return
+            self.fail("hwinfo: %s command failed to execute" % cmd)
 
     def setUp(self):
         # FIXME: "redhat" as the distro name for RHEL is deprecated
@@ -45,45 +42,63 @@ class Hwinfo(Test):
         sm = SoftwareManager()
         if not sm.check_installed("hwinfo") and not sm.install("hwinfo"):
             self.cancel("Fail to install hwinfo required for this test.")
-
-    def test(self):
-
         self.clear_dmesg()
-        self.log.info(
-            "===============Executing hwinfo tool test===============")
-        list = self.params.get('list', default=['--all', '--cpu', '--disk'])
-        for list_item in list:
+        self.disk_name = process.system_output("df -h | egrep '(s|v)d[a-z][1-8]' | "
+                                               "tail -1 | cut -d' ' -f1",
+                                               shell=True).strip("12345")
+        self.Unique_Id = process.system_output("hwinfo --disk --only %s | "
+                                               "grep 'Unique' | head -1 | "
+                                               "cut -d':' -f2" % self.disk_name,
+                                               shell=True)
+
+    def test_list(self):
+        lists = self.params.get('list', default=['--all', '--cpu', '--disk'])
+        for list_item in lists:
             cmd = "hwinfo %s" % list_item
             self.run_cmd(cmd)
-        disk_name = process.system_output("df -h | egrep '(s|v)d[a-z][1-8]' | "
-                                          "tail -1 | cut -d' ' -f1",
-                                          shell=True).strip("12345")
-        self.run_cmd("hwinfo --disk --only %s" % disk_name)
-        Unique_Id = process.system_output("hwinfo --disk --only %s | "
-                                          "grep 'Unique' | head -1 | "
-                                          "cut -d':' -f2" % disk_name,
-                                          shell=True)
-        self.run_cmd("hwinfo --disk --save-config %s" % Unique_Id)
-        self.run_cmd("hwinfo --disk --show-config %s" % Unique_Id)
+
+    def test_disk(self):
+        self.run_cmd("hwinfo --disk --only %s" % self.disk_name)
+
+    def test_unique_id_save(self):
+        self.run_cmd("hwinfo --disk --save-config %s" % self.Unique_Id)
+
+    def test_unique_id_show(self):
+        self.run_cmd("hwinfo --disk --show-config %s" % self.Unique_Id)
+
+    def test_verbose_map(self):
         self.run_cmd("hwinfo --verbose --map")
+
+    def test_log_file(self):
         self.run_cmd("hwinfo --all --log FILE")
         if (not os.path.exists('./FILE')) or (os.stat("FILE").st_size == 0):
             self.log.info("--log option failed")
-            self.is_fail += 1
+            self.fail("hwinfo: failed with --log option")
+
+    def test_dump_0(self):
         self.run_cmd("hwinfo --dump-db 0")
+
+    def test_dump_1(self):
         self.run_cmd("hwinfo --dump-db 1")
+
+    def test_version(self):
         self.run_cmd("hwinfo --version")
+
+    def test_help(self):
         self.run_cmd("hwinfo --help")
+
+    def test_debug(self):
         self.run_cmd("hwinfo --debug 0 --disk --log=-")
+
+    def test_short_block(self):
         self.run_cmd("hwinfo --short --block")
+
+    def test_save_config(self):
         self.run_cmd("hwinfo --disk --save-config=all")
         if "failed" in process.system_output("hwinfo --disk --save-config=all",
                                              shell=True):
-            self.is_fail += 1
             self.log.info("--save-config option failed")
-        if self.is_fail >= 1:
-            self.fail("%s command(s) failed in hwinfo tool verification" %
-                      self.is_fail)
+            self.fail("hwinfo: --save-config option failed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Split in to different tests.
Earlier under one tests all the commands were run, now each and every
command runs in different test.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>