### PR TITLE
Fixed cpu:sensors test

### DIFF
--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -76,9 +76,9 @@ class Sensors(Test):
 
             config_check = linux_modules.check_kernel_config(
                 'CONFIG_SENSORS_IBMPOWERNV')
-            if config_check == 0:
+            if config_check == linux_modules.ModuleConfig.NOT_SET:
                 self.cancel('Config is not set')
-            elif config_check == 1:
+            elif config_check == linux_modules.ModuleConfig.MODULE:
                 if linux_modules.load_module('ibmpowernv'):
                     if linux_modules.module_is_loaded('ibmpowernv'):
                         self.log.info('Module Loaded Successfully')


### PR DESCRIPTION
fixed cpu:sensors as avocado:utils:linux_modules.check_kernel_config
return ModuleConfig enum

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>