### PR TITLE
Using lsrsrc to get HMC and Server details

### DIFF
--- a/io/pci/dlpar.py.data/README
+++ b/io/pci/dlpar.py.data/README
@@ -17,14 +17,10 @@ Links :
 -> https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz#md5=55a61a054aa66812daf5161a0d5d7eda
 
 input parameters
-hmc_ip: ltciofvtr-hmc.pok.stglabs.ibm.com
 hmc_pwd: abc1234
 hmc_username: hscroot
-lpar_1: ltcalpine-lp3-venkat
 lpar_2: ltcalpine-lp8-venkat
-server: ltcalpine-fsp-8408-SN10A7AAV
 pci_device: "0017:01:00.0"
 User need to pass the pci_device of drc to do the action of DLPAR
-lpar_1 is the name of lpar where DLPAR remove and add operation will be done
 lpar_2 is the name of lpar where DLPAR move operation will be done
 num_of_dlpar: Dlpar operations runs number of times specified here

--- a/io/pci/dlpar.py.data/dlpar.yaml
+++ b/io/pci/dlpar.py.data/dlpar.yaml
@@ -1,11 +1,8 @@
 ubuntu_url: 'http://ausgsa.ibm.com/projects/r/rsctdev/builds/muthu/rmuts006a/ppc64le'
 debs: ['src_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core_3.2.0.6-15111_ppc64el.deb', 'rsct.basic_3.2.0.6-15111_ppc64el.deb', 'devices.chrp.base.servicerm_2.5.0.1-15111_ppc64el.deb', 'dynamicrm_2.0.1-3_ppc64el.deb']
 url: 
-hmc_ip: 
 hmc_pwd: 
 hmc_username: 
-lpar_1: 
 lpar_2: 
-server: 
 pci_device:
 num_of_dlpar: 


### PR DESCRIPTION
HMC, LPAR Name, Server Name are found out using lsrsrc now.
So, users no longer need to provide these informations.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>