### PR TITLE
Using interface name for nvme test

### DIFF
--- a/io/disk/ssd/nvme_cli_selftests.py
+++ b/io/disk/ssd/nvme_cli_selftests.py
@@ -41,7 +41,8 @@ class NVMeCliSelfTest(Test):
         """
         Download 'nvme-cli'.
         """
-        self.device = self.params.get('device', default='/dev/nvme0')
+        self.device = self.params.get('device', default='nvme0')
+        self.device = "/dev/%s" % self.device
         self.disk = self.params.get('disk', default='/dev/nvme0n1')
         self.test = self.params.get('test', default='')
         if not self.test:

--- a/io/disk/ssd/nvme_cli_selftests.py.data/nvme_cli_selftests.yaml
+++ b/io/disk/ssd/nvme_cli_selftests.py.data/nvme_cli_selftests.yaml
@@ -1,4 +1,4 @@
-device: /dev/nvme0
+device: nvme0
 disk: /dev/nvme0n1
 test: !mux
     nvme_id_ctrl_test:

--- a/io/disk/ssd/nvmetest.py.data/README.txt
+++ b/io/disk/ssd/nvmetest.py.data/README.txt
@@ -15,7 +15,8 @@ This Suite creates namespace, and performs the following tests:
 * reset_sysfs
 
 This test needs to be run as root.
+The suite selects one of the interface on the device and runs tests on it.
+If there are no namespaces on the nvme device, the test does not run.
 Inputs Needed (in multiplexer file):
 ------------------------------------
-Device      -       NVMe device
-Namespace   -       Namespace in the NVMe device
+Device      -       NVMe device / interface (Eg: nvme0)

--- a/io/disk/ssd/nvmetest.py.data/nvmetest.yaml
+++ b/io/disk/ssd/nvmetest.py.data/nvmetest.yaml
@@ -1,5 +1,4 @@
 Devices: !mux
     device1:
-        device: /dev/nvme0
-        namespace: 1
+        device: nvme0
         firmware_url:


### PR DESCRIPTION
Previously NVMe tests required to get:
1. device name (/dev/nvme0)
2. namespace id (1, 2)

The logical way to do is, get the
1. interface name (nvme0) and use it instead
2. find the namespace on the interface, and skip if none exists.

This commit takes care of these changes for 2 of the nvme tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>