### PR TITLE
Fix htx_block_devices test

### DIFF
--- a/io/disk/htx_block_devices.py.data/Readme.txt
+++ b/io/disk/htx_block_devices.py.data/Readme.txt
@@ -14,6 +14,8 @@ user in yaml file.
 Inputs:
 ------
 disk: '/dev/sdb /dev/sdc'
+all: True or False (True if all disks in selected mdt needs to be run.
+Overrides disks selected)
 time_limit: 1 (In hours)
 mdt_file: 'mdt.io'
 smt_change: True or False

--- a/io/disk/htx_block_devices.py.data/Readme.txt
+++ b/io/disk/htx_block_devices.py.data/Readme.txt
@@ -14,6 +14,6 @@ user in yaml file.
 Inputs:
 ------
 disk: '/dev/sdb /dev/sdc'
-time_limit: 2 (In hours)
+time_limit: 1 (In hours)
 mdt_file: 'mdt.io'
 smt_change: True or False

--- a/io/disk/htx_block_devices.py.data/htx_all_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_all_devices.yaml
@@ -1,0 +1,5 @@
+disk: ''
+all: True
+time_limit: 24
+mdt_file: 'mdt.hd'
+smt_change: False

--- a/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
@@ -1,4 +1,4 @@
-disk: '/dev/sdb'
-time_limit: 2
+disk: '/dev/sdb /dev/sdc'
+time_limit: 1
 mdt_file: 'mdt.hd'
-smt_change: True
+smt_change: False

--- a/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
@@ -1,4 +1,5 @@
 disk: '/dev/sdb /dev/sdc'
+all: False
 time_limit: 1
 mdt_file: 'mdt.hd'
 smt_change: False


### PR DESCRIPTION
1.    Enabling running HTX for all disks possible
    
    Sometimes, we need to run HTX for all disks in the system.
    This commit enables this functionality, via a yaml parameter.
    
2.    Fix htx_block_devices test
    
    * Made the test to build open-power/HTX for all distros.
    * Handle SMT change case for all code blocks.
    * Minor fixes
