### PR TITLE
Adopt linux_modules API changes

### DIFF
--- a/generic/rcutorture.py
+++ b/generic/rcutorture.py
@@ -44,7 +44,7 @@ class Rcutorture(Test):
         self.results = []
         self.log.info("Check if CONFIG_RCU_TORTURE_TEST is enabled\n")
         ret = linux_modules.check_kernel_config('CONFIG_RCU_TORTURE_TEST')
-        if ret == 0:
+        if ret == linux_modules.ModuleConfig.NOT_SET:
             self.cancel("CONFIG_RCU_TORTURE_TEST is not set in .config !!\n")
 
         self.log.info("Check rcutorture module is already  loaded\n")

--- a/kernel/livepatch.py
+++ b/kernel/livepatch.py
@@ -52,7 +52,7 @@ class Livepatch(Test):
         process.run("dmesg -C ", sudo=True)
 
     def check_kernel_support(self):
-        if linux_modules.check_kernel_config("CONFIG_LIVEPATCH") != 2:
+        if linux_modules.check_kernel_config("CONFIG_LIVEPATCH") == linux_modules.ModuleConfig.NOT_SET:
             self.fail("Livepatch support not available")
 
     def setUp(self):

--- a/ras/kprobe.py
+++ b/ras/kprobe.py
@@ -51,7 +51,7 @@ class Kprobe(Test):
         process.run("dmesg -C ", sudo=True)
 
     def check_kernel_support(self):
-        if linux_modules.check_kernel_config("CONFIG_OPTPROBES") != 2:
+        if linux_modules.check_kernel_config("CONFIG_OPTPROBES") == linux_modules.ModuleConfig.NOT_SET:
             return 0
         return 1
 


### PR DESCRIPTION
Adopt linux_modules API changes
ModuleConfig.NOT_SET
to test scripts
generic/rcutorture.py
kernel/livepatch.py
ras/kprobe.py

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>