### PR TITLE
Correct kernel-syms name

### DIFF
--- a/kernel/livepatch.py
+++ b/kernel/livepatch.py
@@ -72,7 +72,7 @@ class Livepatch(Test):
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
                          'popt-devel', 'libcap2', 'libcap-devel',
-                         'kernel-symm', 'libcap-ng-devel', 'openssl-devel',
+                         'kernel-syms', 'libcap-ng-devel', 'openssl-devel',
                          'kernel-source'])
         elif detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',

--- a/ras/kprobe.py
+++ b/ras/kprobe.py
@@ -69,7 +69,7 @@ class Kprobe(Test):
                          'libnuma-dev', 'libfuse-dev', 'libssl-dev', linux_headers])
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
-                         'popt-devel', 'libcap2', 'libcap-devel', 'kernel-symm',
+                         'popt-devel', 'libcap2', 'libcap-devel', 'kernel-syms',
                          'libcap-ng-devel', 'openssl-devel', 'kernel-source'])
         elif detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',

--- a/ras/kretprobe.py
+++ b/ras/kretprobe.py
@@ -62,7 +62,7 @@ class Kretprobe(Test):
                          'libnuma-dev', 'libfuse-dev', 'libssl-dev', linux_headers])
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
-                         'popt-devel', 'libcap2', 'libcap-devel', 'kernel-symm',
+                         'popt-devel', 'libcap2', 'libcap-devel', 'kernel-syms',
                          'libcap-ng-devel', 'openssl-devel', 'kernel-source'])
         elif detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',


### PR DESCRIPTION
Corrected kernel-syms package name in the following files
kernel/livepatch.py
ras/kprobe.py
ras/kretprobe.py

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>