### PR TITLE
Changing the method of rsct package installation for dlpar

### DIFF
--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -63,30 +63,18 @@ class DlparPci(Test):
         '''
         self.install_packages()
         self.rsct_service_start()
-        self.hmc_ip = self.get_mcp_component("HMCIPAddr")
-        if not self.hmc_ip:
-            self.cancel("HMC IP not got")
-        self.hmc_user = self.params.get("hmc_username", default='hscroot')
-        self.hmc_pwd = self.params.get("hmc_pwd", '*', default='abc123')
-        self.lpar_1 = self.get_mcp_component("NodeNameList")
-        if not self.lpar_1:
-            self.cancel("LPAR Name not got")
-        self.lpar_1 = "ltczep9-lp1"
-        self.login(self.hmc_ip, self.hmc_user, self.hmc_pwd)
-        cmd = 'lssyscfg -r sys  -F name'
-        output = self.run_command(cmd)
-        self.server = ''
-        for line in output:
-            if line in self.lpar_1:
-                self.server = line
-        if not self.server:
-            self.cancel("Managed System not got")
+        self.hmc_ip = self.params.get("hmc_ip", '*', default=None)
+        self.hmc_pwd = self.params.get("hmc_pwd", '*', default=None)
+        self.hmc_username = self.params.get("hmc_username", '*', default=None)
+        self.lpar_1 = self.params.get("lpar_1", '*', default=None)
         self.lpar_2 = self.params.get("lpar_2", '*', default=None)
         self.pci_device = self.params.get("pci_device", '*', default=None)
+        self.server = self.params.get("server", '*', default=None)
         self.loc_code = pci.get_slot_from_sysfs(self.pci_device)
         self.num_of_dlpar = int(self.params.get("num_of_dlpar", default='1'))
         if self.loc_code is None:
             self.cancel("Failed to get the location code for the pci device")
+        self.login(self.hmc_ip, self.hmc_username, self.hmc_pwd)
         self.run_command("uname -a")
         cmd = 'lshwres -r io -m %s --rsubtype slot --filter lpar_names=%s ' \
               '-F drc_index,lpar_id,drc_name,bus_id' % (self.server,
@@ -101,18 +89,6 @@ class DlparPci(Test):
 
         self.log.info("lpar_id : %s, loc_code: %s, drc_index: %s, phb: %s",
                       self.lpar_id, self.loc_code, self.drc_index, self.phb)
-
-    @staticmethod
-    def get_mcp_component(component):
-        '''
-        probes IBM.MCP class for mentioned component and returns it.
-        '''
-        for line in process.system_output('lsrsrc IBM.MCP %s' % component,
-                                          ignore_status=True, shell=True,
-                                          sudo=True).splitlines():
-            if component in line:
-                return line.split()[-1].strip('{}\"')
-        return ''
 
     def login(self, ip_addr, username, password):
         '''
@@ -153,10 +129,13 @@ class DlparPci(Test):
         Install required packages
         '''
         smm = SoftwareManager()
+        packages = ['ksh', 'src', 'rsct.basic', 'rsct.core.utils',
+                    'rsct.core', 'DynamicRM']
         detected_distro = distro.detect()
         self.log.info("Test is running on: %s", detected_distro.name)
-        if not smm.check_installed("ksh") and not smm.install("ksh"):
-            self.cancel('ksh is needed for the test to be run')
+        for pkg in packages:
+            if not smm.check_installed(pkg) and not smm.install(pkg):
+                self.cancel('%s is needed for the test to be run' % pkg)
         if detected_distro.name == "Ubuntu":
             if not smm.check_installed("python-paramiko") and not \
                                       smm.install("python-paramiko"):
@@ -169,13 +148,6 @@ class DlparPci(Test):
                 shutil.copy(deb_install, self.workdir)
                 process.system("dpkg -i %s/%s" % (self.workdir, deb),
                                ignore_status=True, sudo=True)
-        else:
-            url = self.params.get('url', default=None)
-            rpm_install = self.fetch_asset(url, expire='7d')
-            shutil.copy(rpm_install, self.workdir)
-            os.chdir(self.workdir)
-            process.run('chmod +x ibmtools')
-            process.run('./ibmtools --install --managed')
 
     def rsct_service_start(self):
         '''
@@ -195,7 +167,6 @@ class DlparPci(Test):
 
         output = process.system_output("lssrc -a", ignore_status=True,
                                        shell=True, sudo=True)
-
         if "inoperative" in output:
             self.cancel("Failed to start the rsct and rsct_rm services")
 

--- a/io/pci/dlpar.py.data/README
+++ b/io/pci/dlpar.py.data/README
@@ -16,11 +16,17 @@ RHEL :
 Links :
 -> https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz#md5=55a61a054aa66812daf5161a0d5d7eda
 
+For rsct and DynamicRM packages, please make sure that the repo is configured manualy in the OS, script will take care of installation part 
+
 input parameters
+hmc_ip: ltciofvtr-hmc.pok.stglabs.ibm.com
 hmc_pwd: abc1234
 hmc_username: hscroot
+lpar_1: ltcalpine-lp3-venkat
 lpar_2: ltcalpine-lp8-venkat
+server: ltcalpine-fsp-8408-SN10A7AAV
 pci_device: "0017:01:00.0"
 User need to pass the pci_device of drc to do the action of DLPAR
+lpar_1 is the name of lpar where DLPAR remove and add operation will be done
 lpar_2 is the name of lpar where DLPAR move operation will be done
 num_of_dlpar: Dlpar operations runs number of times specified here


### PR DESCRIPTION
Since ibmtool is no longer working/available for install rsct and
DynamicRM package installation for dlpar operation, I have added the
the package names and thier install check skipping the ibmtool.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>