### PR TITLE
Bonding yaml for infiniband and virtual networks

### DIFF
--- a/io/net/bonding.py.data/bonding_infiniband.yaml
+++ b/io/net/bonding.py.data/bonding_infiniband.yaml
@@ -1,0 +1,11 @@
+Test: !mux
+    active-backup:
+        bonding_mode: "1"
+host_interfaces: ""
+peer_ip: ""
+peer_interfaces: ""
+bond_name: "bondtest"
+user_name: "root"
+peer_bond_needed: False 
+peer_wait_time: "10"
+sleep_time: "5"

--- a/io/net/bonding.py.data/bonding_virtual.yaml
+++ b/io/net/bonding.py.data/bonding_virtual.yaml
@@ -1,0 +1,13 @@
+Test: !mux
+    active-backup:
+        bonding_mode: "1"
+    802.3ad:
+        bonding_mode: "4"
+host_interfaces: ""
+peer_ip: ""
+peer_interfaces: ""
+bond_name: "bondtest"
+user_name: "root"
+peer_bond_needed: False 
+peer_wait_time: "10"
+sleep_time: "5"


### PR DESCRIPTION
Infiniband supports only active backup bonding mode.
Virtual networks support only active backup and 802.3ad bonding
modes.

So, adding yaml files for them.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>