### PR TITLE
iperf : fix the speed calculation

### DIFF
--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -78,8 +78,8 @@ class Iperf(Test):
         build.make(self.iperf_dir)
         self.iperf = os.path.join(self.iperf_dir, 'src')
         self.expected_tp = self.params.get("EXPECTED_THROUGHPUT", default="85")
-        speed = int(read_file("/sys/class/net/%s/speed" % self.iface))
-        self.expected_tp = int(self.expected_tp) * speed / 100
+        self.speed = int(read_file("/sys/class/net/%s/speed" % self.iface))
+        self.expected_tp = int(self.expected_tp) * self.speed / 100
 
     def test(self):
         """
@@ -94,7 +94,7 @@ class Iperf(Test):
             self.fail("FAIL: Iperf Run failed")
         for line in result.stdout.splitlines():
             if 'sender' in line:
-                tput = int(line.split()[6].split('.')[0])
+                tput = int(line.split()[6].split('.')[0]) * self.speed / 10
                 if tput < self.expected_tp:
                     self.fail("FAIL: Throughput Actual - %d, Expected - %d"
                               % (tput, self.expected_tp))


### PR DESCRIPTION
iperf test failed due to improper throughput expression
TestFail: FAIL: Throughput Actual - 9, Expected - 9000

the correct formula to get throughput = actual * speed / 10
Now the test works fine for all 1G, 10G and 100G speeds

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>