### PR TITLE
Change the netperf test yaml parameters

### DIFF
--- a/io/net/netperf_test.py.data/netperf_test.yaml
+++ b/io/net/netperf_test.py.data/netperf_test.yaml
@@ -1,10 +1,10 @@
 interface: ""
 peer_ip: ""
 peer_user_name: "root"
-TIMEOUT: "600"
-NETSERVER_RUN: 0
+TIMEOUT: "720"
+NETSERVER_RUN: 1
 EXPECTED_THROUGHPUT: 90
-duration: 600
+duration: 120
 minimum_iterations: 1
 maximum_iterations: 5
 netperf_download: "https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.zip"


### PR DESCRIPTION
Some of the yaml parameters were not compatible with each other.
600s run for netperf and 5 iterations were not completed before
600s timeout.
Also, the netserver_run parameter is set to 1 by default.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>