### PR TITLE
Building HTX with hxedapl on supported systems

### DIFF
--- a/io/net/htx_nic_devices.py
+++ b/io/net/htx_nic_devices.py
@@ -96,7 +96,9 @@ class HtxNicTest(Test):
         htx_path = os.path.join(self.teststmpdir, "HTX-master")
         os.chdir(htx_path)
 
-        exercisers = ["hxecapi_afu_dir", "hxedapl", "hxecapi", "hxeocapi"]
+        exercisers = ["hxecapi_afu_dir", "hxecapi", "hxeocapi"]
+        if not smm.check_installed('dapl-devel'):
+            exercisers.append("hxedapl")
         for exerciser in exercisers:
             process.run("sed -i 's/%s//g' %s/bin/Makefile" % (exerciser,
                                                               htx_path))


### PR DESCRIPTION
dapl-devel is provided by MOFED, which is not installe via any
repositories, rather MOFED installs all needed packages.
So, we only build HTX with hxedapl on such systems where
dapl-devel is installed via MOFED.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>