### PR TITLE
hugepage_sanity.c: fix the missing braces

### DIFF
--- a/memory/hugepage_sanity.py.data/hugepage_sanity.c
+++ b/memory/hugepage_sanity.py.data/hugepage_sanity.c
@@ -179,9 +179,10 @@ main(int argc, char *argv[])
 
 	if (!check_alloc_free_huge_page(size, no_page))
 		printf("Test Passed!!\n");
-	else
+	else {
 		printf("Test Failed!!\n");
 		return -1;
+	}
 	return 0;
 
 }


### PR DESCRIPTION
minor fix to add the missing braces, commit 7a4b8a introduced
to return -1 appropriately on failure but missed the braces.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>