### PR TITLE
Make softwareraid test accept user given raid name

### DIFF
--- a/io/disk/softwareraid.py.data/Readme
+++ b/io/disk/softwareraid.py.data/Readme
@@ -2,7 +2,9 @@ mdadm - manage MD devices aka Linux Software RAID
 
 Values to be passed in yaml file:
 
-* Name of the devices on which this scripts should be run.
+* Devices on which this scripts should be run.
+
+* Raid Name to be created, optional parameter.
 
 * Raid levels to be created
 

--- a/io/disk/softwareraid.py.data/softwareraid_cleanup.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid_cleanup.yaml
@@ -1,4 +1,5 @@
 disks: /dev/sde1 /dev/sde2 /dev/sde3 /dev/sde4 /dev/sdd1
+raidname: /dev/md/avocado
 setup: False
 run_test: False
 cleanup: True

--- a/io/disk/softwareraid.py.data/softwareraid_setup.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid_setup.yaml
@@ -1,4 +1,5 @@
 disks: /dev/sde1 /dev/sde2 /dev/sde3 /dev/sde4 /dev/sdd1
+raidname: /dev/md/avocado
 setup: True
 run_test: False
 cleanup: False


### PR DESCRIPTION
Softwareraid test creates raid devices only by the name
/dev/md/mdsraid. So, we are making it take the raid name from
the user via yaml, and defaults to /dev/md/mdsraid.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>