### PR TITLE
Changing bonding interface parameter in yaml

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -68,7 +68,7 @@ class Bonding(Test):
                 self.cancel("test skipped because mode not specified")
         interfaces = netifaces.interfaces()
         self.user = self.params.get("user_name", default="root")
-        self.host_interfaces = self.params.get("host_interfaces",
+        self.host_interfaces = self.params.get("bond_interfaces",
                                                default="").split(",")
         if not self.host_interfaces:
             self.cancel("user should specify host interfaces")

--- a/io/net/bonding.py.data/README.txt
+++ b/io/net/bonding.py.data/README.txt
@@ -13,7 +13,7 @@ In this test we enable mode 0 in peer machine and enable all modes in host machi
 -----------------------------
 Inputs Needed To Run Tests:
 ------------------------------
-host_interfaces --> Interfaces in the Host machine requird for Bonding
+bond_interfaces --> Interfaces in the Host machine requird for Bonding
 peerip --> peer ip address
 peer_interfaces --> This is needed only if a Bond interface is to be created in the Peer machine.
 bond_name --> to create bond

--- a/io/net/bonding.py.data/bonding.yaml
+++ b/io/net/bonding.py.data/bonding.yaml
@@ -13,7 +13,7 @@ Test: !mux
         bonding_mode: "5"
     balance-alb:
         bonding_mode: "6"
-host_interfaces: ""
+bond_interfaces: ""
 peer_ip: ""
 peer_interfaces: ""
 bond_name: "bondtest"

--- a/io/net/bonding.py.data/bonding_infiniband.yaml
+++ b/io/net/bonding.py.data/bonding_infiniband.yaml
@@ -1,7 +1,7 @@
 Test: !mux
     active-backup:
         bonding_mode: "1"
-host_interfaces: ""
+bond_interfaces: ""
 peer_ip: ""
 peer_interfaces: ""
 bond_name: "bondtest"

--- a/io/net/bonding.py.data/bonding_single.yaml
+++ b/io/net/bonding.py.data/bonding_single.yaml
@@ -1,5 +1,5 @@
 bonding_mode: ""
-host_interfaces: ""
+bond_interfaces: ""
 peer_ip: ""
 peer_interfaces: ""
 bond_name: "bondtest"

--- a/io/net/bonding.py.data/bonding_virtual.yaml
+++ b/io/net/bonding.py.data/bonding_virtual.yaml
@@ -3,7 +3,7 @@ Test: !mux
         bonding_mode: "1"
     802.3ad:
         bonding_mode: "4"
-host_interfaces: ""
+bond_interfaces: ""
 peer_ip: ""
 peer_interfaces: ""
 bond_name: "bondtest"


### PR DESCRIPTION
Bonding test needed input interfaces as host_interfaces, which is
now changed into bond_interfaces.
This is needed, since when we run multiple tests with bonding,
and if they need to run on the bond interface created, then the
parameter name on bonding test and other tests need to be
different.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>