### PR TITLE
Use library functions & provide input parameters in THP test

### DIFF
--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -45,9 +45,11 @@ class Thp(Test):
         '''
 
         # Set params as per available memory in system
-        self.mem_path = os.path.join(data_dir.get_tmp_dir(), 'thp_space')
-        free_mem = memory.meminfo.MemFree.m
-        self.dd_timeout = 900
+        self.mem_path = self.params.get(
+            "t_dir", default=os.path.join(data_dir.get_tmp_dir(), 'thp_space'))
+        free_mem = self.params.get(
+            "mem_size", default=memory.meminfo.MemFree.m)
+        self.dd_timeout = self.params.get("dd_timeout", default=900)
         self.thp_split = None
         try:
             memory.read_from_vmstat("thp_split_page")

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -46,7 +46,7 @@ class Thp(Test):
 
         # Set params as per available memory in system
         self.mem_path = os.path.join(data_dir.get_tmp_dir(), 'thp_space')
-        free_mem = int(memory.freememtotal() / 1024)
+        free_mem = memory.meminfo.MemFree.m
         self.dd_timeout = 900
         self.thp_split = None
         try:
@@ -56,7 +56,7 @@ class Thp(Test):
             self.thp_split = "thp_split"
 
         # Set block size as hugepage size * 2
-        self.block_size = (memory.get_huge_page_size() / 1024) * 2
+        self.block_size = memory.meminfo.Hugepagesize.m * 2
         self.count = free_mem / self.block_size
 
         # Mount device as per free memory size

--- a/memory/transparent_hugepages.py.data/transparent_hugepages.yaml
+++ b/memory/transparent_hugepages.py.data/transparent_hugepages.yaml
@@ -1,0 +1,11 @@
+setup:
+    memory: !mux
+        quick:
+            mem_size: 100
+            dd_timeout: 30
+        long:
+            mem_size: 2048
+            dd_timeout: 200
+    tmpdir: !mux
+        default:
+            t_dir: "/tmp/thp_mnt"


### PR DESCRIPTION
* Use library functions to fetch machine configuration
Patch replaces library functions to fetch machine configuration

* Provide ways to run thp test with input parameters
Patch provides ways to run thp tests with custom inputs which also provides a way
to use the test when system memory is fragmented and existing memory could not be
used with dd operation.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>