### PR TITLE
Disk size enhancement for lvsetup

### DIFF
--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -111,6 +111,9 @@ class Lvsetup(Test):
         lv_utils.lv_mount(self.vg_name, self.lv_name, self.mount_loc,
                           create_filesystem=self.fs_name)
         lv_utils.lv_umount(self.vg_name, self.lv_name)
+        lv_utils.vg_reactivate(self.vg_name, export=True)
+        lv_utils.lv_mount(self.vg_name, self.lv_name, self.mount_loc)
+        lv_utils.lv_umount(self.vg_name, self.lv_name)
         lv_utils.lv_take_snapshot(self.vg_name, self.lv_name,
                                   self.lv_snapshot_name,
                                   self.lv_snapshot_size)

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -53,7 +53,6 @@ class Lvsetup(Test):
         self.disk = self.params.get('disks', default=None)
         vg_name = self.params.get('vg_name', default='avocado_vg')
         lv_name = self.params.get('lv_name', default='avocado_lv')
-        self.lv_size = self.params.get('lv_size', default='1G')
         self.fs_name = self.params.get('fs', default='ext4').lower()
         if self.fs_name == 'xfs':
             pkg = 'xfsprogs'
@@ -66,10 +65,6 @@ class Lvsetup(Test):
             self.cancel("Package %s is missing and could not be installed" % pkg)
         lv_snapshot_name = self.params.get(
             'lv_snapshot_name', default='avocado_sn')
-        self.lv_snapshot_size = self.params.get(
-            'lv_snapshot_size', default='1G')
-        self.ramdisk_vg_size = self.params.get(
-            'ramdisk_vg_size', default='10000')
         self.ramdisk_basedir = self.params.get(
             'ramdisk_basedir', default=os.path.join(self.workdir, 'ramdisk'))
         self.ramdisk_sparse_filename = self.params.get(
@@ -87,6 +82,17 @@ class Lvsetup(Test):
         if not os.path.isdir(self.mount_loc):
             os.makedirs(self.mount_loc)
         self.lv_snapshot_name = lv_snapshot_name
+
+        if self.disk:
+            # converting bytes to megabytes, and considering only half the size
+            self.lv_size = int(lv_utils.get_diskspace(self.disk)) / 2097152
+        else:
+            self.lv_size = '1G'
+        self.lv_size = self.params.get('lv_size', default=self.lv_size)
+        self.lv_snapshot_size = self.params.get('lv_snapshot_size',
+                                                default=self.lv_size)
+        self.ramdisk_vg_size = self.params.get(
+            'ramdisk_vg_size', default=self.lv_size)
 
     @avocado.fail_on(lv_utils.LVException)
     def test_snapshot(self):

--- a/io/disk/lvsetup.py.data/lvsetup.yaml
+++ b/io/disk/lvsetup.py.data/lvsetup.yaml
@@ -2,7 +2,6 @@ scenario: !mux
 # btrfs needs minimum LV size of 641M
     real:
         disks: /dev/vde
-        lv_size: "641M"
 filesystem: !mux
     ext2:
         fs: ext2


### PR DESCRIPTION
Removing the necessity to provide a lv size, ramdisk size, etc
by calculating them, if not provided in yaml.
In case disk is not provided, lvsetup creates a loop device, for
which case also this behaviour is same, by defaulting it to 1G.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>