### PR TITLE
Split the htx_network test into start, check, stop

### DIFF
--- a/io/net/htx_nic_devices.py.data/README.txt
+++ b/io/net/htx_nic_devices.py.data/README.txt
@@ -5,7 +5,7 @@ ready for the execution and also updates bpt file with necessary
 data. Once configuration is done test starts executing the stress
 test on all the interfaces provided in input yaml file
 
-User can mention the time limit to be executed in hours.
+User can mention the time limit to be executed in minutes.
 
 This test assumes below packages to be installed on both host & peer
 	pexpect

--- a/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+++ b/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
@@ -6,4 +6,5 @@ peer_user: "root"
 host_interfaces: ""
 peer_interfaces: ""
 net_ids: ""
-time_limit: 1
+# time limit in minutes
+time_limit: 2


### PR DESCRIPTION
Split the htx_network test into start, check, stop, so that the
test can be start to make HTX run in background and other tests
can be run in parallel, and HTX can be stopped later.
test_check can be used whenever necessary, to check if HTX is
still running in the background.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>