### PR TITLE
 Fix: unit reported for disk space & replace total memory with free memory

### DIFF
--- a/memory/sum_check.py
+++ b/memory/sum_check.py
@@ -30,7 +30,7 @@ class SumCheck(Test):
     def setUp(self):
         self.iter = int(self.params.get('iterations', default='5'))
         self.memsize = int(self.params.get(
-            'mem_size', default=memory.memtotal() * 0.9))
+            'mem_size', default=memory.meminfo.MemFree.k * 0.9))
         self.ddfile = os.path.join(self.workdir, 'ddfile')
         if (disk.freespace(self.workdir) / 1024) < self.memsize:
             self.cancel('%sM is needed for the test to be run' %

--- a/memory/sum_check.py
+++ b/memory/sum_check.py
@@ -33,7 +33,8 @@ class SumCheck(Test):
             'mem_size', default=memory.memtotal() * 0.9))
         self.ddfile = os.path.join(self.workdir, 'ddfile')
         if (disk.freespace(self.workdir) / 1024) < self.memsize:
-            self.cancel('%sM is needed for the test to be run' % self.memsize)
+            self.cancel('%sM is needed for the test to be run' %
+                        (self.memsize / 1024))
 
     def test(self):
         mdsum = []


### PR DESCRIPTION
* Fix: Wrong unit reported for disk space
Patch fixes wrong report of disk space needed after comparison with system memory

* sumcheck: Use free memory instead of total memory
Patch replaces free memory instead of total memory as there is a risk of reaching "out of memory" when write exceeds existing free memory which in some cases could be less than 90 percent of total memory

Signed-off-by: Harish <harish@linux.vnet.ibm.com>