### PR TITLE
Use memory.meminfo library to avoid memory derivations

### DIFF
--- a/generic/interbench.py
+++ b/generic/interbench.py
@@ -49,8 +49,8 @@ class Interbench(Test):
                     sm_manager.install(pkg)):
                 self.cancel("%s is needed for the test to be run" % pkg)
 
-        disk_free_mb = (disk.freespace(self.teststmpdir) / 1024) / 1024
-        if memory.memtotal()/1024 > disk_free_mb:
+        disk_free_b = disk.freespace(self.teststmpdir)
+        if memory.meminfo.MemTotal.b > disk_free_b:
             self.cancel('Disk space is less than total memory. Skipping test')
 
         tarball = self.fetch_asset('http://slackware.cs.utah.edu/pub/kernel'

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -144,7 +144,7 @@ class Stressng(Test):
                                 ignore_status=True, sudo=True)
             if self.ttimeout and self.v_stressors:
                 timeout = ' --timeout %s ' % str(
-                    int(self.ttimeout) + int(memory.memtotal() / 1024 / 1024))
+                    int(self.ttimeout) + int(memory.meminfo.MemTotal.g))
             if self.v_stressors:
                 for stressor in self.v_stressors.split(' '):
                     stress_cmd = ' --%s %s %s' % (stressor,

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -75,7 +75,7 @@ class Disktest(Test):
         self.fstype = self.params.get('fs', default='ext4')
 
         gigabytes = int(lv_utils.get_diskspace(self.disk)) / 1073741824
-        memory_mb = memory.memtotal() / 1024
+        memory_mb = memory.meminfo.MemTotal.m
         self.chunk_mb = gigabytes * 950
         if memory_mb > self.chunk_mb:
             self.cancel("Chunk size has to be greater or equal to RAM size. "

--- a/memory/fork_mem.py
+++ b/memory/fork_mem.py
@@ -47,7 +47,7 @@ class Forkoff(Test):
                 'Please use a non-zero value for number'
                 ' of iterations, processes and memory to be used')
 
-        self.freemem = int((0.85 * memory.freememtotal()) / 1024)
+        self.freemem = int(0.85 * memory.meminfo.MemFree.m)
         # Check for basic utilities
         for packages in ['gcc', 'make']:
             if not smm.check_installed(packages) and not smm.install(packages):

--- a/memory/memcached.py
+++ b/memory/memcached.py
@@ -61,7 +61,7 @@ class Memcached(Test):
 
         # Memcached Required Args
         memory_to_use = self.params.get("memory_to_use",
-                                        default=(memory.freememtotal() / 1024))
+                                        default=memory.meminfo.MemFree.m)
         port_no = self.params.get("port_no", default='12111')
         memcached_args = self.params.get('memcached_args', default='')
         self.memcached_cmd = 'memcached -u %s -p %s -m %d  %s &'\

--- a/memory/memory_api.py
+++ b/memory/memory_api.py
@@ -41,7 +41,7 @@ class MemorySyscall(Test):
     def setUp(self):
         smm = SoftwareManager()
         self.memsize = int(self.params.get(
-            'memory_size', default=(memory.freememtotal() / 1024)) * 1048576 * 0.5)
+            'memory_size', default=memory.meminfo.MemFree.m) * 1048576 * 0.5)
         self.induce_err = self.params.get('induce_err', default=0)
 
         for package in ['gcc', 'make']:
@@ -69,7 +69,7 @@ class MemorySyscall(Test):
             self.fail("Unexpected application abort, check for possible issues")
 
         self.log.info("Testing mremap with minimal memory and expand it")
-        if process.system('./mremap %s' % str(int(memory.freememtotal())), ignore_status=True):
+        if process.system('./mremap %s' % str(memory.meminfo.MemFree.k), ignore_status=True):
             self.fail('Mremap expansion failed')
 
 

--- a/memory/memtester.py
+++ b/memory/memtester.py
@@ -58,8 +58,7 @@ class Memtester(Test):
         '''
         Run memtester
         '''
-        mem = self.params.get('memory', default=int(
-            memory.freememtotal() / 1024))
+        mem = self.params.get('memory', default=memory.meminfo.MemFree.m)
         runs = self.params.get('runs', default=1)
         phyaddr = self.params.get('physaddr', default=None)
 

--- a/memory/mprotect.py
+++ b/memory/mprotect.py
@@ -37,12 +37,12 @@ class Mprotect(Test):
 
     def setUp(self):
         smm = SoftwareManager()
-        memsize = int(memory.freememtotal() * 1024 * 0.9)
         self.nr_pages = self.params.get('nr_pages', default=None)
         self.in_err = self.params.get('induce_err', default=0)
         self.failure = self.params.get('failure', default=False)
 
         if not self.nr_pages:
+            memsize = int(memory.meminfo.MemFree.b * 0.9)
             self.nr_pages = memsize / memory.get_page_size()
 
         for package in ['gcc', 'make']:

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -38,7 +38,7 @@ class NumaTest(Test):
     def setUp(self):
         smm = SoftwareManager()
         dist = distro.detect()
-        memsize = int(memory.freememtotal() * 1024 * 0.2)
+        memsize = int(memory.meminfo.MemFree.b * 0.2)
         self.nr_pages = self.params.get(
             'nr_pages', default=memsize / memory.get_page_size())
         self.map_type = self.params.get('map_type', default='private')

--- a/memory/stutter.py
+++ b/memory/stutter.py
@@ -54,9 +54,7 @@ class Stutter(Test):
         archive.extract(tarball, self.workdir)
         self.sourcedir = os.path.join(self.workdir, 'stutter-master')
 
-        mem_byte = str(memory.memtotal())
-        print mem_byte
-        self._memory = self.params.get('memory', default=mem_byte)
+        self._memory = self.params.get('memory', default=memory.meminfo.MemTotal.k)
         self._iteration = self.params.get('iteration', default='10')
         self._logdir = self.params.get('logdir', default='/var/tmp/logdir')
         self._rundir = self.params.get('rundir', default='/tmp')

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -82,9 +82,8 @@ class ThpDefrag(Test):
                               verbose=False, ignore_status=True, shell=True)):
                 self.fail('Defrag command Failed %s' % defrag_cmd)
 
-        total = memory.memtotal()
         hugepagesize = memory.get_huge_page_size()
-        nr_full = int(0.8 * (total / hugepagesize))
+        nr_full = int(0.8 * (memory.meminfo.MemTotal.k / hugepagesize))
 
         # Sets max possible hugepages before defrag on
         nr_hp_before = self.set_max_hugepages(nr_full)

--- a/perf/stress.py
+++ b/perf/stress.py
@@ -72,8 +72,8 @@ class Stress(Test):
             # Sometimes the default memory used by each memory worker (256 M)
             # might make our machine go OOM and then funny things might start
             # to  happen. Let's avoid that.
-            mb = (memory.freememtotal() +
-                  memory.read_from_meminfo('SwapFree') / 2)
+            mb = (memory.meminfo.MemFree.k +
+                  memory.meminfo.SwapFree.k / 2)
             memory_per_thread = (mb * 1024) / threads
 
         if file_size_per_thread is None:


### PR DESCRIPTION
Patch makes memory library usage uniform across tests which avoids unwanted calculations and provides better readability

Signed-off-by: Harish <harish@linux.vnet.ibm.com>