### PR TITLE
Separate HTX test into start, check and stop

### DIFF
--- a/io/disk/htx_block_devices.py.data/Readme.txt
+++ b/io/disk/htx_block_devices.py.data/Readme.txt
@@ -13,9 +13,8 @@ user in yaml file.
 
 Inputs:
 ------
-disk: '/dev/sdb /dev/sdc'
+htx_disk: '/dev/sdb /dev/sdc'
 all: True or False (True if all disks in selected mdt needs to be run.
 Overrides disks selected)
-time_limit: 1 (In hours)
+time_limit: 1 (In minutes)
 mdt_file: 'mdt.io'
-smt_change: True or False

--- a/io/disk/htx_block_devices.py.data/htx_all_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_all_devices.yaml
@@ -1,5 +1,4 @@
-disk: ''
+htx_disks: ''
 all: True
 time_limit: 24
 mdt_file: 'mdt.hd'
-smt_change: False

--- a/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
@@ -1,5 +1,4 @@
-disk: '/dev/sdb /dev/sdc'
+htx_disks: ''
 all: False
 time_limit: 1
 mdt_file: 'mdt.hd'
-smt_change: False


### PR DESCRIPTION
1. Separate HTX test into start, check (monitor), stop. This
allows us to start HTX in the background, and run other tests,
and stop when done.

2. Since this voids the SMT test being done as part of HTX, we
are removing that.

3. disk param is renamed to htx_disks as we need a way to
differentiate the disks for htx and disks for other tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>