### PR TITLE
Split HTX to start, check and stop tests

### DIFF
--- a/generic/htx_test.py.data/htx_test.yaml
+++ b/generic/htx_test.py.data/htx_test.yaml
@@ -1,3 +1,3 @@
-time_limit: 2
+time_limit: 2 # in minutes
 mdt_file: 'mdt.all'
 smt_change: True


### PR DESCRIPTION
This allows us to start HTX in the background, and run other tests and stop when done.

Since this voids the SMT test being done as part of HTX, we are removing that.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>
Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>