### PR TITLE
Fix: Install package for numa tests to run

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -21,7 +21,7 @@
 
 from avocado import Test
 from avocado import main
-from avocado.utils import build
+from avocado.utils import build, distro
 from avocado.utils import process, archive
 import os
 import re
@@ -40,7 +40,16 @@ class ltp(Test):
 
     def setUp(self):
         sm = SoftwareManager()
+        dist = distro.detect()
+
         deps = ['gcc', 'make', 'automake', 'autoconf']
+        if dist.name == "Ubuntu":
+            deps.extend(['libnuma-dev'])
+        elif dist.name in ["centos", "rhel", "fedora"]:
+            deps.extend(['numactl-devel'])
+        elif dist.name == "SuSE":
+            deps.extend(['libnuma-devel'])
+
         for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)

--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -70,7 +70,7 @@ class ltp(Test):
         logfile = os.path.join(self.logdir, 'ltp.log')
         failcmdfile = os.path.join(self.logdir, 'failcmdfile')
 
-        args += (" -q -p -l %s -C %s -d %s -S %s"
+        args += (" -q -p -l %s -C %s -d %s -S %s -M 3"
                  % (logfile, failcmdfile, self.workdir,
                     self.get_data('skipfile')))
         ltpbin_dir = os.path.join(self.workdir, "ltp-master", 'bin')


### PR DESCRIPTION
numa bucket in LTP fails with
test requires libnuma >= 2 and it's development packages

Patch installs and enables numa tests to be run

Signed-off-by: Harish <harish@linux.vnet.ibm.com>