### PR TITLE
Remove SMT specific details

### DIFF
--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -38,7 +38,6 @@ class HtxTest(Test):
     :see:https://github.com/open-power/HTX.git
     :param mdt_file: mdt file used to trigger HTX
     :params time_limit: how much time(hours) you want to run this stress.
-    :smt_change : if user want to change smt value as well while running test
     """
 
     def setUp(self):

--- a/generic/htx_test.py.data/htx_test.yaml
+++ b/generic/htx_test.py.data/htx_test.yaml
@@ -1,3 +1,2 @@
 time_limit: 2 # in minutes
 mdt_file: 'mdt.all'
-smt_change: True


### PR DESCRIPTION
Patch removes leftover SMT details in HTX

Signed-off-by: Harish <harish@linux.vnet.ibm.com>