### PR TITLE
Fix: hard lockup detection after stress

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -154,7 +154,7 @@ class Stressng(Test):
         collect_dmesg(self)
         ERROR = []
         pattern = ['WARNING: CPU:', 'Oops', 'Segfault', 'soft lockup',
-                   'Unable to handle', 'Hard LOCKUP']
+                   'Unable to handle', 'ard LOCKUP']
         logs = process.system_output('dmesg').splitlines()
         for fail_pattern in pattern:
             for log in logs:


### PR DESCRIPTION
After stress runs, on newer distro kernels the Hard lockup pattern has changed.
eg. hard LOCKUP @ _raw_spin_lock_irq+0x20/0xe0

This patch allows to support new and old kernel lockups

Signed-off-by: Harish <harish@linux.vnet.ibm.com>