### PR TITLE
Fix: Handle HTX test run based on mdt availability

### DIFF
--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -51,6 +51,11 @@ class HtxTest(Test):
         self.mdt_file = self.params.get('mdt_file', default='mdt.mem')
         self.time_limit = int(self.params.get('time_limit', default=2)) * 60
         self.failed = False
+        if str(self.name.name).endswith('test_start'):
+            # Build HTX only at the start phase of test
+            self.setup_htx()
+        if not os.path.exists("/usr/lpp/htx/mdt/%s" % self.mdt_file):
+            self.cancel("MDT file %s not found due to config" % self.mdt_file)
 
     def setup_htx(self):
         """
@@ -90,21 +95,16 @@ class HtxTest(Test):
         os.chdir('htx_package')
         if process.system('./installer.sh -f'):
             self.fail("Installation of htx fails:please refer job.log")
-
-    def test_start(self):
-        """
-        Execute 'HTX' with appropriate parameters.
-        """
-        self.setup_htx()
         self.log.info("Starting the HTX Deamon")
         process.run('/usr/lpp/htx/etc/scripts/htxd_run')
 
         self.log.info("Creating the HTX mdt files")
         process.run('htxcmdline -createmdt')
 
-        if not os.path.exists("/usr/lpp/htx/mdt/%s" % self.mdt_file):
-            self.failed = True
-            self.fail("MDT file %s not found" % self.mdt_file)
+    def test_start(self):
+        """
+        Execute 'HTX' with appropriate parameters.
+        """
 
         self.log.info("selecting the mdt file")
         cmd = "htxcmdline -select -mdt %s" % self.mdt_file

--- a/generic/htx_test.py.data/htx_mem.yaml
+++ b/generic/htx_test.py.data/htx_mem.yaml
@@ -1,0 +1,24 @@
+setup:
+    time_limit: 5 # in minutes
+    mdt: !mux
+        inter_node:
+            mdt_file: 'mdt.mem_inter_node'
+        tlbie:
+            mdt_file: 'mdt.mem_tlbie'
+        cache_hit:
+            mdt_file: 'mdt.mem.max_cache_hit'
+        cache_miss:
+            mdt_file: 'mdt.mem.max_cache_miss'
+        prefetch:
+            mdt_file: 'mdt.mem.hw_prefetch'
+        reload:
+            mdt_file: 'mdt.mem.dl1_reloads_from_caches'
+        io:
+            mdt_file: 'mdt.mem.io'
+        nest:
+            mdt_file: 'mdt.mem_nest'
+        nest_io:
+            mdt_file: 'mdt.mem_nest_inter_io'
+        mem_all:
+            time_limit: 120
+            mdt_file: 'mdt.mem'


### PR DESCRIPTION
Patch provides a way to skip tests if the specified mdt is not generated and subsequent monitor would also skip.

Currently monitor and stops test runs even if MDT is not available. This patch addresses it.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>