### PR TITLE
livepatch.py: Corrected openssl-devel package name

### DIFF
--- a/kernel/livepatch.py
+++ b/kernel/livepatch.py
@@ -72,7 +72,7 @@ class Livepatch(Test):
         elif 'SuSE' in detected_distro.name:
             deps.extend(['libpopt0', 'glibc', 'glibc-devel',
                          'popt-devel', 'libcap2', 'libcap-devel',
-                         'kernel-syms', 'libcap-ng-devel', 'openssl-devel',
+                         'kernel-syms', 'libcap-ng-devel', 'libopenssl-devel',
                          'kernel-source'])
         elif detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',


### PR DESCRIPTION
In SuSE openssl-devel package is shipped as libopenssl-devel.

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>