### PR TITLE
lshw.py: correct iproute package name for SuSE

### DIFF
--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -64,7 +64,7 @@ class Lshwrun(Test):
         if dist.name == "SuSE" and dist.version < 15:
             self.cancel("lshw not supported on SUES-%s. Please run " +
                         "on SLES15 or higher versions only " % dist.version)
-        if dist.name == 'Ubuntu' and dist.version.version >= 18:
+        if (dist.name == 'Ubuntu' and dist.version.version >= 18) or dist.name == "SuSE":
             packages.extend(['iproute2'])
         else:
             packages.extend(['iproute'])


### PR DESCRIPTION
SuSE has iproute2 package

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>