### PR TITLE
stutter.py: corrected int variable to string

### DIFF
--- a/memory/stutter.py
+++ b/memory/stutter.py
@@ -63,7 +63,7 @@ class Stutter(Test):
             os.makedirs(self._logdir)
 
         # export env variable, used by test script
-        os.environ['MEMTOTAL_BYTES'] = self._memory
+        os.environ['MEMTOTAL_BYTES'] = str(self._memory)
         os.environ['ITERATIONS'] = self._iteration
         os.environ['LOGDIR_RESULTS'] = self._logdir
         os.environ['TESTDISK_DIR'] = self._rundir


### PR DESCRIPTION
Patch fixes issue with setting environment variable which expects
string argument.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>