### PR TITLE
gdb.py:in Suse removed texi2html package

### DIFF
--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -36,8 +36,11 @@ class GDB(Test):
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
-        elif dist.name in ['SuSE', 'rhel', 'fedora', 'redhat']:
+        elif dist.name in ['rhel', 'fedora', 'redhat']:
             packages.extend(['gcc-c++', 'binutils-devel', 'texi2html'])
+        elif dist.name == 'SuSE':
+            packages.extend(['gcc-c++', 'binutils-devel'])
+
         else:
             self.fail('no packages list for your distro.')
         for package in packages:


### PR DESCRIPTION
texi2html package is not supported in suse

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>