### PR TITLE
cpupower.py: cpufreq feature only supported on PowerNV

### DIFF
--- a/cpu/cpupower.py
+++ b/cpu/cpupower.py
@@ -14,13 +14,15 @@
 # Copyright: 2016 IBM
 # Author: Pavithra D P <pavithra@linux.vnet.ibm.com>
 
-import os
 import random
 import platform
 from avocado import Test
 from avocado import main
-from avocado.utils import process, distro
+from avocado import skipIf
+from avocado.utils import process, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
+
+IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
 
 
 class cpupower(Test):
@@ -31,9 +33,8 @@ class cpupower(Test):
     :avocado: tags=cpu,power,privileged
     """
 
+    @skipIf(not IS_POWER_NV, "This test is not supported on PowerVM platform")
     def setUp(self):
-        if not os.path.exists('/sys/devices/system/cpu/cpu0/cpufreq'):
-            self.cancel('sysfs directory for cpufreq is unavailable.')
         smm = SoftwareManager()
         detected_distro = distro.detect()
         kernel_ver = platform.uname()[2]

--- a/cpu/em_cpufreq.py
+++ b/cpu/em_cpufreq.py
@@ -13,13 +13,15 @@
 #
 # Copyright: 2017 IBM
 # Author: Shriya Kulkarni <shriyak@linux.vnet.ibm.com>
-import os
 import random
 import platform
 from avocado import Test
 from avocado import main
+from avocado import skipIf
 from avocado.utils import process, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
+
+IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
 
 
 class Cpufreq(Test):
@@ -28,13 +30,8 @@ class Cpufreq(Test):
 
     :avocado: tags=cpu,power
     """
-
+    @skipIf(not IS_POWER_NV, "This test is not supported on PowerVM platform")
     def setUp(self):
-        """
-        Verify the system is Baremetal and cpupower tool is installed.
-        """
-        if not os.path.exists('/sys/devices/system/cpu/cpu0/cpufreq'):
-            self.cancel('CPUFREQ is supported only on Power NV')
         smm = SoftwareManager()
         detected_distro = distro.detect()
         if 'Ubuntu' in detected_distro.name:


### PR DESCRIPTION
In PowerVM cpufreq is not supported
so changed the script that cpufreq supports only in PowerNV environment

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>