### PR TITLE
Add kernel-alt source package name

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -14,6 +14,7 @@
 # Author: Abdul Haleem <abdhalee@linux.vnet.ibm.com>
 
 import os
+import platform
 import re
 import glob
 import shutil
@@ -86,7 +87,13 @@ class kselftest(Test):
         else:
             # Make sure kernel source repo is configured
             if detected_distro.name in ['centos', 'fedora', 'rhel']:
-                self.buldir = smg.get_source('kernel', self.workdir)
+                src_name = 'kernel'
+                if detected_distro.name == 'rhel':
+                    # Check for "el*a" where ALT always ends with 'a'
+                    if platform.uname()[2].split(".")[-2].endswith('a'):
+                        self.log.info('Using ALT as kernel source')
+                        src_name = 'kernel-alt'
+                self.buldir = smg.get_source(src_name, self.workdir)
                 self.buldir = os.path.join(
                     self.buldir, os.listdir(self.buldir)[0])
             elif 'Ubuntu' in detected_distro.name:

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -79,7 +79,8 @@ class kselftest(Test):
                     "Fail to install %s required for this test." % (package))
 
         if self.run_type == 'upstream':
-            location = ["https://github.com/torvalds/linux/archive/master.zip"]
+            location = self.params.get('location', default='https://github.c'
+                                       'om/torvalds/linux/archive/master.zip')
             tarball = self.fetch_asset("kselftest.zip", locations=location,
                                        expire='1d')
             archive.extract(tarball, self.workdir)

--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -11,3 +11,4 @@ setup:
             type: 'distro'
         upstream:
             type: 'upstream'
+            location: "https://github.com/torvalds/linux/archive/master.zip"


### PR DESCRIPTION
RHEL provides a kernel-alt for few of the architectures like PPC and ARM. This patch adds support for detecting such environment and using the kernel source name accordingly

Signed-off-by: Harish <harish@linux.vnet.ibm.com>