### PR TITLE
Cancel tests if enviroinment is not suitable

### DIFF
--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -92,7 +92,10 @@ class NumaTest(Test):
         cmd = './numa_test -m %s -n %s' % (self.map_type, self.nr_pages)
         if self.hpage:
             cmd = '%s -h' % cmd
-        if process.system(cmd, shell=True, sudo=True, ignore_status=True):
+        ret = process.system(cmd, shell=True, sudo=True, ignore_status=True)
+        if ret == 255:
+            self.cancel("Environment prevents test! Check logs for issues")
+        elif ret != 0:
             self.fail('Please check the logs for failure')
 
 

--- a/memory/numa_test.py.data/numa_test.c
+++ b/memory/numa_test.py.data/numa_test.c
@@ -26,7 +26,7 @@
 #include <getopt.h>
 #include <hugetlbfs.h>
 
-#define errmsg(x, ...) fprintf(stderr, x, ##__VA_ARGS__),exit(1)
+#define errmsg(x, ...) fprintf(stderr, x, ##__VA_ARGS__),exit(255)
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #define PROTFLAG PROT_READ|PROT_WRITE
 

--- a/memory/numa_test.py.data/util.c
+++ b/memory/numa_test.py.data/util.c
@@ -81,7 +81,7 @@ int *get_numa_nodes_to_use(int max_node, unsigned long memory_to_use)
 		printf("Nodes used in test %d %d \n", nodes_to_use[0], nodes_to_use[1]);
 	} else {
 		printf("memory is not found in 2 nodes\n");
-		exit(1);
+		exit(255);
 	}
 	return nodes_to_use;
 }


### PR DESCRIPTION
Before the actual tests starts, there may be failures owing to the existing environment. Patch skips the test rather than reporting a false failure.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>