### PR TITLE
Add package required for basic utilities used in ltp

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -42,7 +42,7 @@ class ltp(Test):
         sm = SoftwareManager()
         dist = distro.detect()
 
-        deps = ['gcc', 'make', 'automake', 'autoconf']
+        deps = ['gcc', 'make', 'automake', 'autoconf', 'psmisc']
         if dist.name == "Ubuntu":
             deps.extend(['libnuma-dev'])
         elif dist.name in ["centos", "rhel", "fedora"]:


### PR DESCRIPTION
Patch adds package required for basic utilities like killall which is used in ltp

Signed-off-by: Harish <harish@linux.vnet.ibm.com>