### PR TITLE
DLPAR: Finding LPAR name when string is appended

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -84,6 +84,7 @@ class LPM(Test):
         for line in output:
             if line in self.lpar:
                 self.server = line
+                break
         if not self.server:
             self.cancel("Managed System not got")
 
@@ -101,6 +102,7 @@ class LPM(Test):
         for line in output:
             if "%s-" % self.lpar in line:
                 self.lpar = line
+                break
 
         if not self.is_lpar_in_server(current_server, self.lpar):
             self.cancel("%s not in %s" % (self.lpar, current_server))

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -78,6 +78,11 @@ class DlparPci(Test):
         for line in output:
             if line in self.lpar_1:
                 self.server = line
+        cmd = 'lssyscfg -r lpar -F name -m %s' % self.server
+        output = self.run_command(cmd)
+        for line in output:
+            if "%s-" % self.lpar_1 in line:
+                self.lpar_1 = line
         if not self.server:
             self.cancel("Managed System not got")
         self.lpar_2 = self.params.get("lpar_2", '*', default=None)

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -78,11 +78,13 @@ class DlparPci(Test):
         for line in output:
             if line in self.lpar_1:
                 self.server = line
+                break
         cmd = 'lssyscfg -r lpar -F name -m %s' % self.server
         output = self.run_command(cmd)
         for line in output:
             if "%s-" % self.lpar_1 in line:
                 self.lpar_1 = line
+                break
         if not self.server:
             self.cancel("Managed System not got")
         self.lpar_2 = self.params.get("lpar_2", '*', default=None)


### PR DESCRIPTION
LPAR names are usually appended with string which identifies the
usage / user of the LPAR. With the recent code change finding
LPAR name with lsrsrc, such LPAR names are ignored and test
cancels. This commit handles such strings appended and gets the
LPAR name.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>