### PR TITLE
Fix: kselftest.py missing brace and SuSE source installation 

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -100,6 +100,7 @@ class kselftest(Test):
             elif 'Ubuntu' in detected_distro.name:
                 self.buldir = smg.get_source('linux', self.workdir)
             elif 'SuSE' in detected_distro.name:
+                smg._source_install('kernel-default')
                 smg.get_source('kernel-source', self.workdir)
                 packages = '/usr/src/packages/'
                 os.chdir(os.path.join(packages, 'SOURCES'))

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -81,7 +81,7 @@ class kselftest(Test):
         if self.run_type == 'upstream':
             location = self.params.get('location', default='https://github.c'
                                        'om/torvalds/linux/archive/master.zip')
-            tarball = self.fetch_asset("kselftest.zip", locations=location,
+            tarball = self.fetch_asset("kselftest.zip", locations=[location],
                                        expire='1d')
             archive.extract(tarball, self.workdir)
             self.buldir = os.path.join(self.workdir, 'linux-master')


### PR DESCRIPTION
Fix: Missing braces in kernel selftests

Commit 25c5c9 introduced an issue with braces missing when an
asset is fetched. Patch fixes it

Fix: SuSE distribution selftest runs

SuSE with its recent distributions does not install dependency
packages to be installed when using kernel-source as package name.
Patch fixes it by adding a kernel-default source installation.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>