### PR TITLE
Add memory specific changes to LTP

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -21,12 +21,17 @@
 
 from avocado import Test
 from avocado import main
-from avocado.utils import build, distro
+from avocado.utils import build, distro, genio
 from avocado.utils import process, archive
+from avocado.utils.partition import Partition
 import os
 import re
 
 from avocado.utils.software_manager import SoftwareManager
+
+
+def collect_dmesg(obj):
+    obj.whiteboard = process.system_output("dmesg")
 
 
 class ltp(Test):
@@ -37,10 +42,46 @@ class ltp(Test):
                  "-f $test")
     """
     failed_tests = list()
+    mem_tests = ['-f mm', '-f hugetlb']
+
+    @staticmethod
+    def mount_point(mount_dir):
+        lines = genio.read_file('/proc/mounts').rstrip('\t\r\0').splitlines()
+        for substr in lines:
+            mp = substr.split(" ")[1]
+            if mp == mount_dir:
+                return True
+        return False
+
+    def check_thp(self):
+        self.thp = False
+        if 'thp_file_alloc' in genio.read_file('/proc/vm'
+                                               'stat').rstrip('\t\r\n\0'):
+            self.thp = True
+        return self.thp
+
+    def setup_tmpfs_dir(self):
+        # check for THP page cache
+        self.check_thp()
+
+        if not os.path.isdir(self.mount_dir):
+            os.makedirs(self.mount_dir)
+
+        self.device = None
+        if not self.mount_point(self.mount_dir):
+            if self.thp:
+                self.device = Partition(
+                    device="none", mountpoint=self.mount_dir,
+                    mount_options="huge=always")
+            else:
+                self.device = Partition(
+                    device="none", mountpoint=self.mount_dir)
+            self.device.mount(mountpoint=self.mount_dir, fstype="tmpfs")
 
     def setUp(self):
         sm = SoftwareManager()
         dist = distro.detect()
+        self.args = self.params.get('args', default='')
 
         deps = ['gcc', 'make', 'automake', 'autoconf']
         if dist.name == "Ubuntu":
@@ -49,6 +90,15 @@ class ltp(Test):
             deps.extend(['numactl-devel'])
         elif dist.name == "SuSE":
             deps.extend(['libnuma-devel'])
+        self.ltpbin_dir = self.mount_dir = None
+        if self.args in self.mem_tests:
+            self.mount_dir = self.params.get('tmpfs_mount_dir', default=None)
+            if self.mount_dir:
+                self.setup_tmpfs_dir()
+            over_commit = self.params.get('overcommit', default=True)
+            if not over_commit:
+                process.run('echo 2 > /proc/sys/vm/overcommit_memory',
+                            shell=True, ignore_status=True)
 
         for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
@@ -59,22 +109,22 @@ class ltp(Test):
         ltp_dir = os.path.join(self.workdir, "ltp-master")
         os.chdir(ltp_dir)
         build.make(ltp_dir, extra_args='autotools')
-        ltpbin_dir = os.path.join(ltp_dir, 'bin')
-        os.mkdir(ltpbin_dir)
-        process.system('./configure --prefix=%s' % ltpbin_dir)
+        if not self.ltpbin_dir:
+            self.ltpbin_dir = os.path.join(ltp_dir, 'bin')
+        os.mkdir(self.ltpbin_dir)
+        process.system('./configure --prefix=%s' % self.ltpbin_dir)
         build.make(ltp_dir)
         build.make(ltp_dir, extra_args='install')
 
     def test(self):
-        args = self.params.get('args', default='')
         logfile = os.path.join(self.logdir, 'ltp.log')
         failcmdfile = os.path.join(self.logdir, 'failcmdfile')
 
-        args += (" -q -p -l %s -C %s -d %s -S %s -M 3"
-                 % (logfile, failcmdfile, self.workdir,
-                    self.get_data('skipfile')))
-        ltpbin_dir = os.path.join(self.workdir, "ltp-master", 'bin')
-        cmd = os.path.join(ltpbin_dir, 'runltp') + ' ' + args
+        self.args += (" -q -p -l %s -C %s -d %s -S %s -M 3"
+                      % (logfile, failcmdfile, self.workdir,
+                         self.get_data('skipfile')))
+        self.ltpbin_dir = os.path.join(self.workdir, "ltp-master", 'bin')
+        cmd = "%s %s" % (os.path.join(self.ltpbin_dir, 'runltp'), self.args)
         result = process.run(cmd, ignore_status=True)
         # Walk the ltp.log and try detect failed tests from lines like these:
         # msgctl04                                           FAIL       2
@@ -85,8 +135,13 @@ class ltp(Test):
                     value = re.split(r'\s+', line)
                     self.failed_tests.append(value[0])
 
+        collect_dmesg(self)
         if self.failed_tests:
             self.fail("LTP tests failed: %s" % self.failed_tests)
+
+    def tearDown(self):
+        if self.mount_dir:
+            self.device.unmount()
 
 
 if __name__ == "__main__":

--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -30,6 +30,14 @@ from avocado.utils.partition import Partition
 from avocado.utils.software_manager import SoftwareManager
 
 
+def clear_dmesg():
+    process.run("dmesg -c ", sudo=True)
+
+
+def collect_dmesg(obj):
+    obj.whiteboard = process.system_output("dmesg")
+
+
 class LTP(Test):
 
     """
@@ -99,6 +107,7 @@ class LTP(Test):
         for package in deps:
             if not smg.check_installed(package) and not smg.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
+        clear_dmesg()
         url = "https://github.com/linux-test-project/ltp/archive/master.zip"
         tarball = self.fetch_asset("ltp-master.zip", locations=[url])
         archive.extract(tarball, self.workdir)
@@ -131,6 +140,7 @@ class LTP(Test):
                     value = re.split(r'\s+', line)
                     self.failed_tests.append(value[0])
 
+        collect_dmesg(self)
         if self.failed_tests:
             self.fail("LTP tests failed: %s" % self.failed_tests)
 

--- a/generic/ltp.py.data/ltp-mem.yaml
+++ b/generic/ltp.py.data/ltp-mem.yaml
@@ -1,0 +1,12 @@
+setup:
+    general: !mux
+        runltp: !mux
+            mm:
+                args: '-f mm'
+                overcommit: True
+            hugetlb:
+                args: '-f hugetlb'
+                overcommit: False
+            thp-page-cache:
+                args: '-f mm'
+                tmpfs_mount_dir: '/mnt/thp/'


### PR DESCRIPTION
Patch adds necessary changes to run few memory tests which needs setup before actual test execution.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>