### PR TITLE
Change print statements to log.info

### DIFF
--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -46,7 +46,7 @@ class SoftwareRaid(Test):
 
         smm = SoftwareManager()
         if not smm.check_installed("mdadm"):
-            print "Mdadm must be installed before continuing the test"
+            self.log.info("Mdadm must be installed before continuing the test")
             if SoftwareManager().install("mdadm") is False:
                 self.cancel("Unable to install mdadm")
         cmd = "mdadm -V"

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -64,9 +64,9 @@ class TcpdumpTest(Test):
         for line in process.run(cmd, shell=True,
                                 ignore_status=True).stderr.splitlines():
             if "packets dropped by interface" in line:
+                self.log.info(line)
                 if int(line[0]) >= (int(self.drop) * int(self.count) / 100):
                     self.fail("%s, more than %s percent" % (line, self.drop))
-                print line
         obj.stop()
 
 

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -95,7 +95,7 @@ class PCIHotPlugTest(Test):
         if process.system_output(cmd, shell=True).strip('\n') is not '':
             self.return_code = 1
         else:
-            print "Adapter %s removed successfully" % self.device
+            self.log.info("Adapter %s removed successfully", self.device)
 
     def hotplug_add(self):
         """
@@ -107,7 +107,7 @@ class PCIHotPlugTest(Test):
         if process.system_output(cmd, shell=True).strip('\n') is '':
             self.return_code = 2
         else:
-            print "Adapter %s added back successfully" % self.device
+            self.log.info("Adapter %s added back successfully", self.device)
 
     def check_add_remove(self):
         """

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -43,15 +43,17 @@ def clear_dmesg():
 def online(block):
     try:
         memory.hotplug(block)
+        return ""
     except IOError:
-        print "memory%s : Resource is busy" % block
+        return "memory%s : Resource is busy" % block
 
 
 def offline(block):
     try:
         memory.hotunplug(block)
+        return ""
     except IOError:
-        print "memory%s : Resource is busy" % block
+        return "memory%s : Resource is busy" % block
 
 
 def get_hotpluggable_blocks(path, ratio):
@@ -122,17 +124,19 @@ class MemStress(Test):
                 self.hotplug_all(self.blocks_hotpluggable)
         clear_dmesg()
 
-    @staticmethod
-    def hotunplug_all(blocks):
+    def hotunplug_all(self, blocks):
         for block in blocks:
             if memory._check_memory_state(block):
-                offline(block)
+                err = offline(block)
+                if err:
+                    self.log.error(err)
 
-    @staticmethod
-    def hotplug_all(blocks):
+    def hotplug_all(self, blocks):
         for block in blocks:
             if not memory._check_memory_state(block):
-                online(block)
+                err = online(block)
+                if err:
+                    self.log.error(err)
 
     @staticmethod
     def __is_auto_online():
@@ -172,10 +176,14 @@ class MemStress(Test):
         self.log.info("\nTEST: Memory toggle\n")
         for _ in range(self.iteration):
             for block in self.blocks_hotpluggable:
-                offline(block)
+                err = offline(block)
+                if err:
+                    self.log.error(err)
                 self.log.info("memory%s block hotunplugged", block)
                 self.run_stress()
-                online(block)
+                err = online(block)
+                if err:
+                    self.log.error(err)
                 self.log.info("memory%s block hotplugged", block)
         self.__error_check()
 
@@ -209,7 +217,9 @@ class MemStress(Test):
             for block in mem_blocks:
                 self.log.info(
                     "offline memory%s in numa node%s", block, node)
-                offline(block)
+                err = offline(block)
+                if err:
+                    self.log.error(err)
             self.run_stress()
         self.__error_check()
 

--- a/ras/kdump.py
+++ b/ras/kdump.py
@@ -96,7 +96,7 @@ class KDUMP(Test):
         session_check.run("ls -lrt /var/crash", 100, "True")
         crash_dir = self.run_cmd_out("cat %s | grep drwxr | tail -1 | cut -d' ' -f%s" % (log_file, f_val))
         path_crash_dir = os.path.join("/var/crash", crash_dir)
-        print path_crash_dir
+        self.log.info(path_crash_dir)
         session_check.run("ls -lrt %s" % path_crash_dir, 100, "True")
         for files in file_list:
             if files not in open(log_file).read():

--- a/ras/kdump_nfs.py
+++ b/ras/kdump_nfs.py
@@ -149,7 +149,7 @@ class KDUMP(Test):
                                             self.prompt_server, "\n", log_file_server, 100, 10, None)
         if self.distro == "rhel":
             nfs_dir_path = os.path.join(self.nfs_path, "var", "crash")
-        print nfs_dir_path
+        self.log.info(nfs_dir_path)
         session_check.run("ls -lrt %s;" % nfs_dir_path, 100, "True")
         crash_dir = self.run_cmd_out("cat %s | grep drwxr | awk '{print $NF}' | tail -1" % log_file_server)
         path_crash_dir = os.path.join(nfs_dir_path, crash_dir)


### PR DESCRIPTION
Patch replaces print statements to log.info so that we can avoid both python2 and python3 compatibility

Signed-off-by: Harish <harish@linux.vnet.ibm.com>