### PR TITLE
Fix: xfstests.py for proper test_range

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -293,6 +293,7 @@ class Xfstests(Test):
             with open(self.exclude_file, 'a') as fp:
                 for test in test_list:
                     fp.write('%s/%s\n' % (test_type, test))
+        return test_list
 
     def _get_tests_for_group(self, group):
         """


### PR DESCRIPTION
Test failed to run when test_range is specified as the create_list method does not return any value here

self.test_list = self._create_test_list(self.test_range)

Patch fixes it by returning the test list

Signed-off-by: Harish <harish@linux.vnet.ibm.com>