### PR TITLE
Add test to create namespaces with different modes with single region

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -183,6 +183,7 @@ class NdctlTest(Test):
         self.dist = distro.detect()
         self.package = self.params.get('package', default='upstream')
         self.cnt = self.params.get('namespace_cnt', default=4)
+        self.preserve_setup = self.params.get('preserve_change', default=False)
 
         if 'SuSE' not in self.dist.name:
             self.cancel('Unsupported OS %s' % self.dist.name)
@@ -406,9 +407,10 @@ class NdctlTest(Test):
             self.fail("Failed to check namespace metadata")
 
     def tearDown(self):
-        if self.get_json(short_opt='-N'):
-            self.destroy_namespace(force=True)
-        self.disable_region()
+        if not self.preserve_setup:
+            if self.get_json(short_opt='-N'):
+                self.destroy_namespace(force=True)
+            self.disable_region()
 
 
 if __name__ == "__main__":

--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -274,7 +274,9 @@ class NdctlTest(Test):
         """
         failed_modes = []
         self.enable_region()
-        region = self.get_json(short_opt='-R')[0]
+        region = self.params.get('region', default=None)
+        if not region:
+            region = self.get_json(short_opt='-R')[0]
         self.log.info("Using %s for different namespace modes", region)
         self.disable_namespace(region=region)
         self.destroy_namespace(region=region)
@@ -299,7 +301,9 @@ class NdctlTest(Test):
         Test multiple namespace with single region
         """
         self.enable_region()
-        region = self.get_json(short_opt='-R')[0]
+        region = self.params.get('region', default=None)
+        if not region:
+            region = self.get_json(short_opt='-R')[0]
         self.log.info("Using %s for muliple namespace regions", region)
         self.disable_namespace(region=region)
         self.destroy_namespace(region=region)
@@ -317,7 +321,9 @@ class NdctlTest(Test):
         Test multiple namespace modes with single region
         """
         self.enable_region()
-        region = self.get_json(short_opt='-R')[0]
+        region = self.params.get('region', default=None)
+        if not region:
+            region = self.get_json(short_opt='-R')[0]
         self.log.info("Using %s for muliple namespace regions", region)
         self.disable_namespace(region=region)
         self.destroy_namespace(region=region)
@@ -356,7 +362,9 @@ class NdctlTest(Test):
         Test namespace reconfiguration
         """
         self.enable_region()
-        region = self.get_json(short_opt='-R')[0]
+        region = self.params.get('region', default=None)
+        if not region:
+            region = self.get_json(short_opt='-R')[0]
         self.log.info("Using %s for reconfiguring namespace", region)
         self.disable_namespace()
         self.destroy_namespace()
@@ -383,7 +391,9 @@ class NdctlTest(Test):
         Verify metadata for sector mode namespaces
         """
         self.enable_region()
-        region = self.get_json(short_opt='-R')[0]
+        region = self.params.get('region', default=None)
+        if not region:
+            region = self.get_json(short_opt='-R')[0]
         self.disable_namespace()
         self.destroy_namespace()
         self.log.info("Creating sector namespace using %s", region)

--- a/memory/ndctl.py.data/ndctl.yaml
+++ b/memory/ndctl.py.data/ndctl.yaml
@@ -1,6 +1,7 @@
 config:
     namespace_cnt: 4
     region: 'region0'
+    preserve_change: True
     version: !mux
         upstream:
             package : 'upstream'

--- a/memory/ndctl.py.data/ndctl.yaml
+++ b/memory/ndctl.py.data/ndctl.yaml
@@ -1,5 +1,6 @@
 config:
     namespace_cnt: 4
+    region: 'region0'
     version: !mux
         upstream:
             package : 'upstream'


### PR DESCRIPTION
Add test to create namespaces with different modes with single region

Signed-off-by: Harish <harish@linux.vnet.ibm.com>