### PR TITLE
Add support to run xfstests on nvdimm devices power

### DIFF
--- a/fs/xfstests.py.data/nvdimm.yaml
+++ b/fs/xfstests.py.data/nvdimm.yaml
@@ -1,0 +1,20 @@
+setup:
+    skip_dangerous: True
+    scratch_mnt: '/mnt/scratch_pmem'
+    test_mnt: '/mnt/test_pmem'
+    mount_opt: '-o dax'
+    fs_type: !mux
+        fs_ext4:
+            fs: 'ext4'
+            mkfs_opt: '-b 65536'
+            #test_range: '388'
+            #exclude: '1-400'
+            #gen_exclude: '1-387,389-600'
+            #share_exclude: '1-600'
+        fs_xfs:
+            fs: 'xfs'
+            mkfs_opt: '-b size=65536 -s size=4096'
+    disk_type: !mux
+        type: 'disk'
+        disk_test: /dev/pmem0
+        disk_scratch: /dev/pmem0.1

--- a/fs/xfstests.py.data/nvdimm_log.yaml
+++ b/fs/xfstests.py.data/nvdimm_log.yaml
@@ -1,0 +1,23 @@
+setup:
+    skip_dangerous: True
+    scratch_mnt: '/mnt/scratch_pmem'
+    test_mnt: '/mnt/test_pmem'
+    mount_opt: '-o dax'
+    fs_type: !mux
+        fs_ext4:
+            fs: 'ext4'
+            mkfs_opt: '-b 65536'
+            #test_range: '388'
+            #gen_exclude: '27'
+            #share_exclude: '1-300'
+        fs_xfs:
+            fs: 'xfs'
+            mkfs_opt: '-b size=65536 -s size=4096'
+            logdev_opt: '-l logdev'
+            #gen_exclude: '388'
+    disk_type: !mux
+        type: 'disk'
+        disk_test: /dev/pmem0
+        disk_scratch: /dev/pmem0.1
+        log_test: /dev/pmem1s
+        log_scratch: /dev/pmem1.1s


### PR DESCRIPTION
Patch adds support to run Xfstests suite with NVDIMM devices on power architecture

Signed-off-by: Harish <harish@linux.vnet.ibm.com>