### PR TITLE
Addressing the -x error during rdma tests

### DIFF
--- a/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended.yaml
@@ -20,8 +20,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
@@ -24,8 +24,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
@@ -14,8 +14,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:


### PR DESCRIPTION
-x option is part of input file to run rdma tests. The help states

-x, --gid-index=<index>  Test uses GID with GID index (Default : IB - no gid . ETH - 0)

current values were -x=1 which is invalid.  Removing the option as it is creating more confusions during the tests.

Signed-off-by: Manvanthara Puttashankar <manvanth@linux.vnet.ibm.com>