### PR TITLE
Cover different MTU size based test for pingpong

### DIFF
--- a/io/net/infiniband/ib_pingpong.py.data/README.txt
+++ b/io/net/infiniband/ib_pingpong.py.data/README.txt
@@ -14,3 +14,4 @@ install MOFED iso
 Note:
 -----
 1. Generate sshkey for your test partner to run the test uninterrupted.
+2. Ensure to run the tests from cfg file so that all the MTU sizes can be tested accordingly.

--- a/io/net/infiniband/ib_pingpong.py.data/ib_pingpong.yaml
+++ b/io/net/infiniband/ib_pingpong.py.data/ib_pingpong.yaml
@@ -1,19 +1,19 @@
 Test: !mux
     ud_pingpong:
         tool: ibv_ud_pingpong
-        test_opt: -s 4000,basic,-n 100000,-e
-        ext_test_opt: -s 4000 -n 1000,-e -n 10000,-s 4000 -e -n 10000
+        test_opt: -s 1024,basic,-n 100000,-e
+        ext_test_opt: -s 1024 -n 1000,-e -n 10000,-s 1024 -e -n 10000
     uc_pingpong:
         tool: ibv_uc_pingpong
-        test_opt: -s 4000,basic,-n 100000,-e,-r 2000,-l 2,-m 1024
+        test_opt: -s 1024,basic,-n 100000,-e,-r 2000,-l 2,-m 1024
         ext_test_opt: -s 524288,-s 524288 -n 10000,-s 524288 -n 100000,-e -s 524288 -n 10000
     rc_pingpong:
         tool: ibv_rc_pingpong
-        test_opt: -s 4000,basic,-n 100000,-e,-r 2000,-l 2,-m 1024
+        test_opt: -s 1024,basic,-n 100000,-e,-r 2000,-l 2,-m 1024
         ext_test_opt: -s 524288,-s 524288 -n 10000,-s 524288 -n 100000,-e -s 524288 -n 10000
     srq_pingpong:
         tool: ibv_srq_pingpong
-        test_opt: -s 4000,basic,-n 100000,-e,-r 2000,-l 2,-m 1024,-q 10
+        test_opt: -s 1024,basic,-n 100000,-e,-r 2000,-l 2,-m 1024,-q 10
         ext_test_opt: -s 524288,-s 524288 -n 10000,-s 524288 -n 100000,-q 32,-e -s 524288 -n 10000 -q 32
 parameters:
     ext_flag: "1"

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended.yaml
@@ -20,8 +20,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
@@ -24,8 +24,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
@@ -14,8 +14,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/network_test.py.data/network_test_infiniband.yaml
+++ b/io/net/network_test.py.data/network_test_infiniband.yaml
@@ -1,0 +1,11 @@
+interface:
+peer_ip:
+mtu: !mux
+    1500:
+        mtu: 1500
+    2000:
+        mtu: 2000
+    3000:
+        mtu: 3000
+    4000:
+        mtu: 4000


### PR DESCRIPTION
 Cover different MTU size based test for pingpong
    
    This requires fix in both avocado-fvt-wrapper and avocado-misc-tests
    
    1. under avocado-fvt-wrapper,seperate cfg will be created to cover both ROCE and Infiniband based MTU testing of pingpong.
    
    2. under avocado-misc-tests, network mtu yaml has been created for infiniband specific MTU sizes and also -s option is made generic for all MTU sizes.
