### PR TITLE
Fixed dapltest scripts to run correctly

### DIFF
--- a/io/net/infiniband/dapl.sh
+++ b/io/net/infiniband/dapl.sh
@@ -21,27 +21,12 @@
 
 PATH=$(avocado "exec-path"):$PATH
 
-# Install dependencies
-if [[ `python -c 'from avocado.utils.software_manager import SoftwareManager; \
-   print SoftwareManager().install("dapl*")'` == 'False' ]]
-then
-    avocado_debug 'Dapl Packages not installed'
-    exit
-fi
-
-# Load Modules
-modules=(ib_uverbs ib_ucm ib_cm ib_mad ib_sa ib_umad ib_addr rdma_cm rdma_ucm \
-    ib_core mlx4_core mlx5_core mlx5_ib ib_ipoib mlx4_en mlx4_ib)
-for i in "${modules[@]}"; do
-    modprobe $i || avocado_debug 'not able to load module'$i
-done
-
 # Parsing Input
 host_param=$(eval "echo $HOST_PARAM")
 peer_param=$(eval "echo $PEER_PARAM")
 
 # Timeout
-timeout=2m
+timeout=6m
 
 # Runs dapltest on client and server
 dapl_exec()
@@ -70,12 +55,13 @@ dapl_exec()
 testdapl()
 {
     if [[ $dapl_interface != "" ]] && [[ $dapl_peer_interface != "" ]]; then
-        if type "dapltest" > /dev/null
+        if type "dapltest" > /dev/null || [[ `python -c 'from avocado.utils.software_manager import SoftwareManager; \
+               print SoftwareManager().install("dapl*")'` == 'True' ]]
         then
-            dapl_exec dapltest "$host_param" "$peer_param"
+            dapl_exec dapltest "$peer_param" "$host_param"
         else
-            avocado_debug "Cmd dapltest doesn't exist, Test will be skipped"
-            exit 1
+           avocado_debug 'Dapl Packages could not be installed, Test will be skipped'
+           exit
         fi
     else
         avocado_debug "DAPL interface not specified, Test will be skipped"

--- a/io/net/infiniband/dapl.sh.data/README.txt
+++ b/io/net/infiniband/dapl.sh.data/README.txt
@@ -9,5 +9,8 @@ dapl_peer_interface - RDMA Interface on the Host. Can be taken from the file dat
 Note:
 -----
 1. Ensure the dat.conf has details of your dapl interface under test (refer: man dat.conf)
+    a.  For infiniband interface the ofa-v2-ib0 entry is available by default in /etc/dat.conf
+    b.  However for ROCE devices, Interface being tested needs to be added manually for both host and peer. For example if your interface is enP24p1s0f0. Add the below line manually in /etc/dat.conf
+          ofa-v2-enP24p1s0f0 u2.0 nonthreadsafe default libdaplofa.so.2 dapl.2.0 "enP24p1s0f0 0" ""
 2. Generate sshkey for your test partner to run the test uninterrupted. 
 

--- a/io/net/infiniband/dapl.sh.data/dapl.yaml
+++ b/io/net/infiniband/dapl.sh.data/dapl.yaml
@@ -1,18 +1,18 @@
-peer_ip: "16.16.16.17"
-dapl_interface: ofa-v2-ib1
-dapl_peer_interface: ofa-v2-ib1
+peer_ip: "10.10.1.10"
+dapl_interface: ofa-v2-enP24p1s0f0
+dapl_peer_interface: ofa-v2-enP20p112s0f0
 Parameters: !mux
     first:
-        HOST_PARAM: -T S -D $dapl_interface
-        PEER_PARAM: -T Q -s $peer_ip -D $dapl_peer_interface -d
+        HOST_PARAM: -T Q -s $peer_ip -D $dapl_interface -d
+        PEER_PARAM: -T S -D $dapl_peer_interface
     second:
-        HOST_PARAM: -T S -D $dapl_interface -d
-        PEER_PARAM: -T T -d -s $peer_ip -D $dapl_peer_interface client SR 4096 2 server SR 4096 2
+        HOST_PARAM: -T T -d -s $peer_ip -D $dapl_interface -n 53000 client SR 4096 2 server SR 4096 2
+        PEER_PARAM: -T S -d -n 53000 -D $dapl_peer_interface
     third:
-        HOST_PARAM: -T S -D $dapl_interface
-        PEER_PARAM: -T T -V -d -t 2 -w 4 -i 5555 -s $peer_ip -D $dapl_peer_interface client RW 4096 1 server RW 2048 4 client SR 1024 4 server SR 4096 2 client SR 1024 3 -f server SR 2048 1 -f
+        HOST_PARAM: -T T -V -d -t 2 -w 4 -i 5555 -s $peer_ip -D $dapl_interface client RW 4096 1 server RW 2048 4 client SR 1024 4 server SR 4096 2 client SR 1024 3 -f server SR 2048 1 -f
+        PEER_PARAM: -T S -D $dapl_peer_interface
     fourth:
-        HOST_PARAM: -T S -D $dapl_interface
-        PEER_PARAM: -T P -d -s $peer_ip -D $dapl_peer_interface -i 100 RW 4096 2
+        HOST_PARAM: -T P -d -s $peer_ip -D $dapl_interface -i 100 RW 4096 2
+        PEER_PARAM: -T S -D $dapl_peer_interface
     fifth:
-        HOST_PARAM: -T L -D $dapl_interface -d -w 16 -m 1000
+        PEER_PARAM: -T L -D $dapl_interface -d -w 16 -m 1000

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended.yaml
@@ -20,8 +20,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended.yaml
@@ -16,8 +16,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended.yaml
@@ -24,8 +24,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended.yaml
@@ -14,8 +14,6 @@ test_opt: !mux
         test_opt: -Q 5
     -w_100M:
         test_opt: -w 100M
-    -x_1:
-        test_opt: -x 1
     -y_10G:
         test_opt: -y 10G
     -z:


### PR DESCRIPTION
    Fixed dapltest scripts to run correctly
    
    dapltest was wrongly giving an passed state eventhough the tests were not even attempted.  Re-written the logic and also added more dapltest combinations.