### PR TITLE
Replacing ifconfig commands with ip commands

### DIFF
--- a/io/net/infiniband/ip_over_ib.py
+++ b/io/net/infiniband/ip_over_ib.py
@@ -127,7 +127,7 @@ class IPOverIB(Test):
         Bringup IPoIB Interface
         '''
         self.log.info("Bringup Interface %s with %s mode", self.iface, arg1)
-        cmd = "timeout %s ifconfig %s down" % (self.tmo, self.iface)
+        cmd = "timeout %s ip link set %s down" % (self.tmo, self.iface)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("interface setup test failed")
         time.sleep(2)
@@ -139,7 +139,7 @@ class IPOverIB(Test):
         cmd = "timeout %s cat /sys/class/net/%s/mode" % (self.tmo, self.iface)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("interface setup test failed")
-        cmd = "timeout %s ifconfig %s up" % (self.tmo, self.iface)
+        cmd = "timeout %s ip link set %s up" % (self.tmo, self.iface)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("interface setup test failed")
 

--- a/io/net/vlan_test.py
+++ b/io/net/vlan_test.py
@@ -312,7 +312,7 @@ class VlanTest(Test):
         self.run_host_command(cmd)
         self.run_host_command("ip link set %s.%s up" % (self.host_intf,
                                                         vlan_num))
-        cmd = "ifconfig %s.%s" % (self.host_intf, vlan_num)
+        cmd = "ip addr show %s.%s" % (self.host_intf, vlan_num)
         self.run_host_command(cmd)
 
     def conf_peer_vlan_intf(self, vlan_num):
@@ -329,7 +329,7 @@ class VlanTest(Test):
         self.run_peer_command(cmd)
         self.run_peer_command("ip link set %s.%s up" % (self.peer_intf,
                                                         vlan_num))
-        cmd = "ifconfig %s.%s" % (self.peer_intf, vlan_num)
+        cmd = "ip addr show %s.%s" % (self.peer_intf, vlan_num)
         self.run_peer_command(cmd)
 
     def restore_host_intf(self):


### PR DESCRIPTION
In two file replacing ifconfig commands with ip commands.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>