### PR TITLE
Fix issue in Test as if machine is not smt capable [Waiting for avocado util]

### DIFF
--- a/cpu/em_cpuhotplug.py
+++ b/cpu/em_cpuhotplug.py
@@ -37,6 +37,8 @@ class Cpuhotplug_Test(Test):
         if distro.detect().arch not in ['ppc64', 'ppc64le']:
             self.cancel("Only supported in powerpc system")
 
+        if not cpu._is_smt():
+            self.cancel("Machine is not SMT capable : Test not relevent")
         self.loop = int(self.params.get('test_loop', default=100))
         self.nfail = 0
         self.CORES = process.system_output("lscpu | grep 'Core(s) per socket:'"


### PR DESCRIPTION
test is not relvent to run

LOG:

07:30:49 INFO | Command 'ppc64_cpu --smt=8' finished with 255 after 0.012934923172s
07:30:49 ERROR|
07:30:49 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_framework-68.0-py2.7.egg/avocado/core/test.py:829
07:30:49 ERROR| Traceback (most recent call last):
07:30:49 ERROR|   File "/home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/tests/avocado-misc-tests/cpu/em_cpuhotplug.py", line 59, in setUp
07:30:49 ERROR|     process.system("ppc64_cpu --smt=%s" % self.max_smt, shell=True)
07:30:49 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_framework-68.0-py2.7.egg/avocado/utils/process.py", line 1446, in system
07:30:49 ERROR|     encoding=encoding)
07:30:49 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_framework-68.0-py2.7.egg/avocado/utils/process.py", line 1383, in run
07:30:49 ERROR|     raise CmdError(cmd, sp.result)
07:30:49 ERROR| CmdError: Command 'ppc64_cpu --smt=8' failed.
07:30:49 ERROR| stdout: ''
07:30:49 ERROR| stderr: 'Machine is not SMT capable\n'
07:30:49 ERROR| additional_info: None

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>