### PR TITLE
[python3] Move memory tests to run with python3

### DIFF
--- a/memory/dma_memtest.py
+++ b/memory/dma_memtest.py
@@ -95,7 +95,7 @@ class DmaMemtest(Test):
            :param est_size: Estimated size of uncompressed linux tarball
         '''
         mem_str = process.system_output('grep MemTotal /proc/meminfo')
-        mem = int(re.search(r'\d+', mem_str).group(0))
+        mem = int(re.search(r'\d+', mem_str.decode()).group(0))
         mem = int(mem / 1024)
         sim_cps = (1.5 * mem) / est_size
 
@@ -152,7 +152,7 @@ class DmaMemtest(Test):
                 try:
                     self.log.info('Comparing linux.orig with %s', tmp_dir)
                     process.system('diff -U3 -rN linux.orig linux.%s' % j)
-                except process.CmdError, error:
+                except process.CmdError as error:
                     self.nfail += 1
                     self.log.info('Error comparing trees: %s', error)
 

--- a/memory/fork_mem.py
+++ b/memory/fork_mem.py
@@ -76,8 +76,8 @@ class Forkoff(Test):
         os.chdir(self.teststmpdir)
 
         self.run_test(self.freemem, 1, self.itern)
-        self.run_test(self.freemem / self.procs, self.procs, self.itern)
-        self.run_test(self.minmem, self.freemem / self.minmem, self.itern)
+        self.run_test(self.freemem // self.procs, self.procs, self.itern)
+        self.run_test(self.minmem, self.freemem // self.minmem, self.itern)
 
         if self.fails:
             self.fail("The following test(s) failed: %s" % self.fails)

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -69,8 +69,8 @@ def get_hotpluggable_blocks(path, ratio):
         Return number of blocks in chunks of 100
         """
         if num % 2:
-            return num / 100 + 1
-        return num / 100
+            return num // 100 + 1
+        return num // 100
     count = chunks(len(mem_blocks) * ratio)
     return mem_blocks[:count]
 
@@ -150,7 +150,7 @@ class MemStress(Test):
         logs = process.system_output("dmesg -Txl 1,2,3,4").splitlines()
         for error in ERRORLOG:
             for log in logs:
-                if error in log:
+                if error in log.decode():
                     err_list.append(log)
         if "\n".join(err_list):
             collect_dmesg(self)
@@ -189,14 +189,14 @@ class MemStress(Test):
 
     def test_dlpar_mem_hotplug(self):
         if 'ppc' in platform.processor() and 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
-            if "mem_dlpar=yes" in process.system_output("drmgr -C", ignore_status=True, shell=True):
+            if b"mem_dlpar=yes" in process.system_output("drmgr -C", ignore_status=True, shell=True):
                 self.log.info("\nDLPAR remove memory operation\n")
-                for _ in range(len(self.blocks_hotpluggable) / 2):
+                for _ in range(len(self.blocks_hotpluggable) // 2):
                     process.run(
                         "drmgr -c mem -d 5 -w 30 -r", shell=True, ignore_status=True, sudo=True)
                 self.run_stress()
                 self.log.info("\nDLPAR add memory operation\n")
-                for _ in range(len(self.blocks_hotpluggable) / 2):
+                for _ in range(len(self.blocks_hotpluggable) // 2):
                     process.run(
                         "drmgr -c mem -d 5 -w 30 -a", shell=True, ignore_status=True, sudo=True)
                 self.__error_check()

--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -69,7 +69,7 @@ class NdctlTest(Test):
         """
         Get the value of a field in given json
         """
-        for key, value in json_op.iteritems():
+        for key, value in json_op.items():
             if key == field:
                 return value
         return None
@@ -82,12 +82,12 @@ class NdctlTest(Test):
             def_align = 16 * 1024 * 1024
         else:
             def_align = 2 * 1024 * 1024
-        if ((size / self.cnt) % def_align) != 0:
+        if ((size // self.cnt) % def_align) != 0:
             self.log.warn("Namespace would fail as it is not %sM "
                           "aligned! Changing the number of "
-                          "namespaces", def_align / (1024 * 1024))
+                          "namespaces", def_align // (1024 * 1024))
             for count in range(self.cnt, 1, -1):
-                if ((size / count) % def_align) == 0:
+                if ((size // count) % def_align) == 0:
                     self.log.info("Changing namespaces to %s", count)
                     return count
         return self.cnt
@@ -315,7 +315,7 @@ class NdctlTest(Test):
             self.size = self.get_json_val(self.get_json(
                 long_opt='-r %s' % region)[0], 'size')
             ch_cnt = self.get_aligned_count(self.size)
-            self.size = self.size / ch_cnt
+            self.size = self.size // ch_cnt
         else:
             # Assuming self.cnt is aligned
             ch_cnt = self.cnt
@@ -361,7 +361,7 @@ class NdctlTest(Test):
                 self.size = self.get_json_val(self.get_json(
                     long_opt='-r %s' % region)[0], 'size')
                 ch_cnt = self.get_aligned_count(self.size)
-                self.size = self.size / ch_cnt
+                self.size = self.size // ch_cnt
             else:
                 # Assuming size is aligned
                 ch_cnt = self.cnt
@@ -390,7 +390,7 @@ class NdctlTest(Test):
         new_ns = self.get_json()[0]
         self.log.info("Checking namespace changes")
         failed_vals = []
-        for key, val in new_ns.iteritems():
+        for key, val in new_ns.items():
             if key in list(set(old_ns.keys()) - set(['uuid', 'dev'])):
                 if old_ns[key] != val:
                     failed_vals.append({key: val})

--- a/memory/sum_check.py
+++ b/memory/sum_check.py
@@ -34,9 +34,9 @@ class SumCheck(Test):
         self.memsize = int(self.params.get(
             'mem_size', default=memory.meminfo.MemFree.k * 0.9))
         self.ddfile = os.path.join(self.workdir, 'ddfile')
-        if (disk.freespace(self.workdir) / 1024) < self.memsize:
+        if (disk.freespace(self.workdir) // 1024) < self.memsize:
             self.cancel('%sM is needed for the test to be run' %
-                        (self.memsize / 1024))
+                        (self.memsize // 1024))
 
     def test(self):
         mdsum = []

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -59,7 +59,7 @@ class Thp(Test):
 
         # Set block size as hugepage size * 2
         self.block_size = memory.meminfo.Hugepagesize.m * 2
-        self.count = free_mem / self.block_size
+        self.count = free_mem // self.block_size
 
         # Mount device as per free memory size
         if not os.path.exists(self.mem_path):

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -49,15 +49,15 @@ class ThpDefrag(Test):
 
         # Get required mem info
         self.mem_path = os.path.join(data_dir.get_tmp_dir(), 'thp_space')
-        self.block_size = int(mmap.PAGESIZE) / 1024
+        self.block_size = int(mmap.PAGESIZE) // 1024
         # add mount point
         if os.path.exists(self.mem_path):
             os.makedirs(self.mem_path)
         self.device = Partition(device="none", mountpoint=self.mem_path)
         self.device.mount(mountpoint=self.mem_path, fstype="tmpfs")
-        free_space = (disk.freespace(self.mem_path)) / 1024
+        free_space = (disk.freespace(self.mem_path)) // 1024
         # Leaving out some free space in tmpfs
-        self.count = (free_space / self.block_size) - 3
+        self.count = (free_space // self.block_size) - 3
 
     @avocado.fail_on
     def test(self):

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -54,10 +54,10 @@ class ThpSwapping(Test):
 
         # If swap is enough fill all memory with dd
         if self.swap_free[0] > (mem - mem_free):
-            self.count = (mem / self.hugepage_size) / 2
+            self.count = (mem // self.hugepage_size) // 2
             tmpfs_size = mem
         else:
-            self.count = (mem_free / self.hugepage_size) / 2
+            self.count = (mem_free // self.hugepage_size) // 2
             tmpfs_size = mem_free
 
         if swap <= 0:

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -121,7 +121,7 @@ class VATest(Test):
         result = process.run('./va_test %s' %
                              args, shell=True, ignore_status=True)
         for line in result.stdout.splitlines():
-            if 'failed' in line:
+            if b'failed' in line:
                 self.fail("test failed, Please check debug log for failed"
                           "test cases")
 


### PR DESCRIPTION
Move memory tests to run with python3.
Tested on latest RHEL and SuSE releases.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>