### PR TITLE
Fix perf:perftool 

### DIFF
--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -71,7 +71,7 @@ class Perftool(Test):
         '''
         count = 0
         # Built in perf test
-        for string in process.run("perf test").stderr.splitlines():
+        for string in process.run("perf test", ignore_status=True).stderr.splitlines():
             if 'FAILED' in str(string.splitlines()):
                 self.log.info("Test case failed is %s"
                               % str(string.splitlines()))

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -72,9 +72,8 @@ class Perftool(Test):
         count = 0
         # Built in perf test
         for string in process.run("perf test", ignore_status=True).stderr.splitlines():
-            if 'FAILED' in str(string.splitlines()):
-                self.log.info("Test case failed is %s"
-                              % str(string.splitlines()))
+            if 'FAILED' in string:
+                self.log.info("Test case failed is %s" % string)
 
         # perf testsuite
         for line in build.run_make(self.sourcedir, extra_args='check',


### PR DESCRIPTION
as if command failed test error out and next block of test not at able to execute so adding
igonre_status=True in process.run

without patch:

19:05:59 INFO    : Running: /usr/bin/avocado run  avocado-misc-tests/perf/perftool.py --force-job-id 1a69a2ba6a8609322110aa064d6f895551fa1cad
JOB ID     : 1a69a2ba6a8609322110aa064d6f895551fa1cad
JOB LOG    : /home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/results/job-2019-07-23T19.06-1a69a2b/job.log
 (1/1) avocado-misc-tests/perf/perftool.py:Perftool.test: ERROR: Command 'perf test' failed.\nstdout: ''\nstderr: " 1: vmlinux symtab matches kallsyms            : Skip\n 2: Detect openat syscall event                : Ok\n 3: Detect openat syscall event on all cpus    : Ok\n 4: Read samples using the mmap interface     ... (29.57 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 30.31 s
JOB HTML   : /home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/results/job-2019-07-23T19.06-1a69a2b/results.html
19:06:31 INFO    :
19:06:32 INFO    : Summary of test results can be found below:
TestSuite                                                                   TestRun    Summary

host_perf1_perf1                                                            Run        Successfully executed
/home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/results/job-2019-07-23T19.06-1a69a2b/job.log
1

with patch:

19:08:07 INFO    : Check for environment
19:08:07 INFO    : Creating temporary mux dir
19:08:09 INFO    :
19:08:09 INFO    : Running Host Tests Suite perf1_perf1
19:08:09 INFO    : Running: /usr/bin/avocado run  avocado-misc-tests/perf/perftool.py --force-job-id ff469469fbdee1d64d641869d0fb24a4c6487825
JOB ID     : ff469469fbdee1d64d641869d0fb24a4c6487825
JOB LOG    : /home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/results/job-2019-07-23T19.08-ff46946/job.log
 (1/1) avocado-misc-tests/perf/perftool.py:Perftool.test: FAIL: 123 Test failed (472.16 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 472.78 s
JOB HTML   : /home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/results/job-2019-07-23T19.08-ff46946/results.html
19:16:04 INFO    :
19:16:04 INFO    : Summary of test results can be found below:
TestSuite                                                                   TestRun    Summary

host_perf1_perf1                                                            Run        Successfully executed
/home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/results/job-2019-07-23T19.08-ff46946/job.log
19:16:04 INFO    : Removing temporary mux dir

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>