### PR TITLE
Fix environment detection logic for em_cpufreq test

### DIFF
--- a/cpu/em_cpufreq.py
+++ b/cpu/em_cpufreq.py
@@ -21,7 +21,7 @@ from avocado import skipIf
 from avocado.utils import process, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
 
-IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
+IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
 
 
 class Cpufreq(Test):


### PR DESCRIPTION
cpu/em_cpufreq.py tests fails to run on PowerNV with following message:
SKIP 1-cpu/em_cpufreq.py:Cpufreq.test -> TestSkipError: This test is not supported on PowerVM platform

This test was written to run on PowerNV. The logic to detect PowerNV platform
does not work. This patch corrects it.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>