### PR TITLE
lshw.py corrected string formatting issue

### DIFF
--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -62,7 +62,7 @@ class Lshwrun(Test):
         dist = distro.detect()
         packages = ['lshw', 'net-tools', 'pciutils']
         if dist.name == "SuSE" and dist.version < 15:
-            self.cancel("lshw not supported on SUES-%s. Please run " +
+            self.cancel("lshw not supported on SUES-%s. Please run "
                         "on SLES15 or higher versions only " % dist.version)
         if (dist.name == 'Ubuntu' and dist.version.version >= 18) or dist.name == "SuSE":
             packages.extend(['iproute2'])


### PR DESCRIPTION
with out patch:

ERROR: not all arguments converted during string formatting

With patch:
CANCEL: lshw not supported on SUES-12. Please run on SLES15 or higher versions only

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>