### PR TITLE
perf_c2c.py: removed arch dependency

### DIFF
--- a/perf/perf_c2c.py
+++ b/perf/perf_c2c.py
@@ -42,10 +42,6 @@ class perf_c2c(Test):
         detected_distro = distro.detect()
         self.distro_name = detected_distro.name
 
-        if 'ppc64' not in detected_distro.arch:
-            self.cancel('This test is not supported on %s architecture'
-                        % detected_distro.arch)
-
         deps = ['gcc', 'make']
         if 'Ubuntu' in self.distro_name:
             deps.extend(['linux-tools-common', 'linux-tools-%s' %


### PR DESCRIPTION
perf c2c runs on any architecture, this patch removes the checking
of ppc64.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>