### PR TITLE
Change the way of reading PowerNV data from proc fs

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -23,8 +23,7 @@ import platform
 from random import randint
 from avocado import Test
 from avocado import main
-from avocado.utils import process
-from avocado.utils import cpu
+from avocado.utils import process, cpu
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -267,7 +266,7 @@ class cpustresstest(Test):
         PowerVM and Guest only: Dynamic Resource Manager
         use drmgr command to hotplug and hotunplug cpus
         """
-        if 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
+        if 'PowerNV' not in cpu._get_cpu_info():
             if "cpu_dlpar=yes" in process.system_output("drmgr -C",
                                                         ignore_status=True,
                                                         shell=True):

--- a/cpu/em_cpufreq.py
+++ b/cpu/em_cpufreq.py
@@ -21,7 +21,7 @@ from avocado import skipIf
 from avocado.utils import process, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
 
-IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
+IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
 
 
 class Cpufreq(Test):

--- a/cpu/em_smt_folding_test.py
+++ b/cpu/em_smt_folding_test.py
@@ -97,8 +97,7 @@ class SmtFolding(Test):
 
     def dlpar_cpu_hotplug(self):
 
-        if 'PowerNV' not in \
-                genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0'):
+        if 'PowerNV' not in cpu._get_cpu_info():
             if "cpu_dlpar=yes" in process.system_output("drmgr -C",
                                                         ignore_status=True,
                                                         shell=True):

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -21,9 +21,8 @@ Test for sensors command
 from avocado import Test
 from avocado import main
 from avocado.utils import process, linux_modules
-from avocado.utils import distro
+from avocado.utils import distro, cpu
 from avocado.utils.software_manager import SoftwareManager
-from avocado.utils import cpu
 
 # TODO: Add possible errors of sensors command
 ERRORS = ['I/O error']
@@ -57,8 +56,7 @@ class Sensors(Test):
         s_mg = SoftwareManager()
         d_distro = distro.detect()
         if d_distro.arch in ["ppc64", "ppc64le"]:
-            if not cpu._list_matches(open('/proc/cpuinfo').readlines(),
-                                     'platform\t: PowerNV\n'):
+            if 'PowerNV' not in cpu._get_cpu_info():
                 self.cancel(
                     'sensors test is applicable to bare-metal environment.')
         if d_distro.name == "Ubuntu":

--- a/generic/service_check.py
+++ b/generic/service_check.py
@@ -21,9 +21,8 @@ import os
 import ConfigParser
 from avocado import Test
 from avocado import main
-from avocado.utils import process
+from avocado.utils import process, cpu, distro
 from avocado.utils.service import SpecificServiceManager
-from avocado.utils import distro
 from avocado.utils.wait import wait_for
 from avocado.utils.software_manager import SoftwareManager
 
@@ -54,7 +53,7 @@ class service_check(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel(' %s is needed for the test to be run' % package)
 
-        if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
+        if 'PowerNV' in cpu._get_cpu_info():
             services_list.extend(['opal_errd', 'opal-prd'])
             if os.path.exists('/proc/device-tree/bmc'):
                 services_list.remove('opal_errd')

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -20,7 +20,7 @@ import platform
 import multiprocessing
 from avocado import Test
 from avocado import main
-from avocado.utils import process, memory, build, archive
+from avocado.utils import process, memory, build, archive, cpu
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -188,7 +188,7 @@ class MemStress(Test):
         self.__error_check()
 
     def test_dlpar_mem_hotplug(self):
-        if 'ppc' in platform.processor() and 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
+        if 'ppc' in platform.processor() and 'PowerNV' not in cpu._get_cpu_info():
             if b"mem_dlpar=yes" in process.system_output("drmgr -C", ignore_status=True, shell=True):
                 self.log.info("\nDLPAR remove memory operation\n")
                 for _ in range(len(self.blocks_hotpluggable) // 2):

--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -24,8 +24,8 @@ from avocado.utils import process, distro, cpu, genio
 from avocado.utils.software_manager import SoftwareManager
 from avocado import skipIf
 
-IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')
-IS_KVM_GUEST = 'qemu' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')
+IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
+IS_KVM_GUEST = 'qemu' in cpu._get_cpu_info()
 
 
 class EliminateDomainSuffix(Test):

--- a/perf/perf_nest_events.py
+++ b/perf/perf_nest_events.py
@@ -49,7 +49,7 @@ class nestEvents(Test):
         if cpu.get_cpu_arch().lower() == 'power8':
             self.cancel('This test not applies to Power8')
 
-        if 'PowerNV' not in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0'):
+        if 'PowerNV' not in cpu._get_cpu_info():
             self.cancel('This test applies only to PowerNV')
 
         deps = ['gcc', 'make']

--- a/ras/diag_encl.py
+++ b/ras/diag_encl.py
@@ -19,7 +19,7 @@ import glob
 import xml.etree.ElementTree
 from avocado import Test
 from avocado import main
-from avocado.utils import process, distro
+from avocado.utils import process, distro, cpu
 from avocado.utils import genio
 from avocado.utils.software_manager import SoftwareManager
 
@@ -78,7 +78,7 @@ class DiagEncl(Test):
             product_path = '/proc/device-tree/model'
             serial_path = '/proc/device-tree/system-id'
         product_name = genio.read_one_line(product_path).rstrip(' \t\r\n\0')
-        if 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
+        if 'PowerNV' not in cpu._get_cpu_info():
             product_name = product_name.split(',')[1]
         serial_num = genio.read_one_line(serial_path).rstrip(' \t\r\n\0')
         product_name_xml = "-".join((machine_type, machine_model))

--- a/ras/packages.py
+++ b/ras/packages.py
@@ -17,7 +17,7 @@
 from avocado import Test
 from avocado import main
 from avocado.utils import process
-from avocado.utils import distro
+from avocado.utils import distro, cpu
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -30,7 +30,7 @@ class Package_check(Test):
         self.sm = SoftwareManager()
         self.packages = self.params.get(
             'packages', default=['powerpc-utils', 'ppc64-diag', 'lsvpd'])
-        if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
+        if 'PowerNV' in cpu._get_cpu_info():
             self.packages.extend(['opal-prd'])
 
     def test(self):

--- a/ras/ras.py
+++ b/ras/ras.py
@@ -18,12 +18,12 @@ import os
 from shutil import copyfile
 from avocado import Test
 from avocado import main
-from avocado.utils import process, distro
+from avocado.utils import process, distro, cpu
 from avocado import skipIf, skipUnless
 from avocado.utils.software_manager import SoftwareManager
 
-IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
-IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()
+IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
+IS_KVM_GUEST = 'qemu' in cpu._get_cpu_info()
 
 
 class RASTools(Test):

--- a/ras/ras_extended.py
+++ b/ras/ras_extended.py
@@ -18,12 +18,12 @@ import os
 import shutil
 from avocado import Test
 from avocado import main
-from avocado.utils import process, distro
+from avocado.utils import process, distro, cpu
 from avocado import skipIf
 from avocado.utils.software_manager import SoftwareManager
 
-IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
-IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()
+IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
+IS_KVM_GUEST = 'qemu' in cpu._get_cpu_info()
 
 
 class RASTools(Test):

--- a/ras/servicelog.py
+++ b/ras/servicelog.py
@@ -19,7 +19,7 @@
 import os
 from avocado import Test
 from avocado import main
-from avocado.utils import process
+from avocado.utils import process, cpu
 from avocado.utils.service import ServiceManager
 from avocado.utils.software_manager import SoftwareManager
 
@@ -43,7 +43,7 @@ class servicelog(Test):
     def setUp(self):
         if "ppc" not in os.uname()[4]:
             self.cancel("supported only on Power platform")
-        if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
+        if 'PowerNV' in cpu._get_cpu_info():
             self.cancel("servicelog: is not supported on the PowerNV platform")
         smm = SoftwareManager()
         for package in ("servicelog", "ppc64-diag"):


### PR DESCRIPTION
Instead of reading from proc fs reading the required data
from cpu._get_cpu_info

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>