### PR TITLE
Adding multiple yamls for specific usecases

### DIFF
--- a/io/net/network_test.py.data/network_test_one_variant.yaml
+++ b/io/net/network_test.py.data/network_test_one_variant.yaml
@@ -1,0 +1,2 @@
+interface:
+peer_ip:

--- a/io/net/virt-net/lpm.py.data/lpm_5_iterations.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_5_iterations.yaml
@@ -1,0 +1,18 @@
+hmc_pwd:
+hmc_username:
+slot_num:
+vios_names:
+remote_server:
+remote_vios_names:
+sriov_adapters:
+sriov_ports:
+remote_sriov_adapters:
+remote_sriov_ports:
+bandwidth:
+iteration: !mux
+    default: !mux
+        1:
+        2:
+        3:
+        4:
+        5:


### PR DESCRIPTION
Adding network_test yaml to try for one mtu size.
Adding lpm yaml to try multiple iterations.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>