### PR TITLE
Fix issue in fs:pjdfstest test case

### DIFF
--- a/fs/pjdfstest.py
+++ b/fs/pjdfstest.py
@@ -41,7 +41,7 @@ class Pjdfstest(Test):
         # Check for basic utilities
         smm = SoftwareManager()
 
-        for package in ['autoconf', 'automake', 'gcc', 'make', 'perl']:
+        for package in ['autoconf', 'automake', 'gcc', 'make', 'perl', 'openssl']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
         locations = ['https://github.com/pjd/pjdfstest/archive/master.zip']


### PR DESCRIPTION
added openssl package as dependency package as without that test run stuck

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>