### PR TITLE
 [python3] Enable libhugetlbfs test to run with python3

### DIFF
--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -108,7 +108,7 @@ class LibHugetlbfs(Test):
                             % (pages_available, pages_requested))
 
         git.get_repo('https://github.com/libhugetlbfs/libhugetlbfs.git',
-                     destination_dir=self.workdir)
+                     branch='next', destination_dir=self.workdir)
         os.chdir(self.workdir)
         patch = self.params.get('patch', default='elflink.patch')
         process.run('patch -p1 < %s' % self.get_data(patch), shell=True)
@@ -176,7 +176,8 @@ class LibHugetlbfs(Test):
         os.chdir(self.workdir)
 
         run_log = build.run_make(
-            self.workdir, extra_args='BUILDTYPE=NATIVEONLY check').stdout
+            self.workdir, extra_args='BUILDTYPE=NATIVEONLY check',
+            process_kwargs={'ignore_status': True}).stdout.decode('utf-8')
         parsed_results = []
         error = ""
         for idx, hp_size in enumerate(self.page_sizes):

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -46,7 +46,6 @@ class LibHugetlbfs(Test):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         deps = ['gcc', 'make', 'patch']
-        cpuinfo = genio.read_file("/proc/cpuinfo").strip()
         if detected_distro.name == "Ubuntu":
             deps += ['libpthread-stubs0-dev', 'git']
         elif detected_distro.name == "SuSE":


### PR DESCRIPTION
*  [python3] Enable libhugetlbfs test to run with python3
Patch changes python3-enabled branch of libhugetlbfs and few other
fixes to run test with python3.

* Fix: Removed unused variable
Patch removes an unnecessary line from the test

Signed-off-by: Harish <harish@linux.ibm.com>