### PR TITLE
Changing network tests from python2 to python3

### DIFF
--- a/io/net/Network_config.py
+++ b/io/net/Network_config.py
@@ -45,7 +45,8 @@ class NetworkconfigTest(Test):
         if self.iface not in interfaces:
             self.cancel("%s interface is not available" % self.iface)
         cmd = "ethtool -i %s" % self.iface
-        for line in process.system_output(cmd, shell=True).splitlines():
+        for line in process.system_output(cmd, shell=True).decode("utf-8") \
+                                                          .splitlines():
             if 'bus-info' in line:
                 self.businfo = line.split()[-1]
         self.log.info(self.businfo)
@@ -56,7 +57,8 @@ class NetworkconfigTest(Test):
         driver match check using lspci and ethtool
         '''
         cmd = "ethtool -i %s" % self.iface
-        for line in process.system_output(cmd, shell=True).splitlines():
+        for line in process.system_output(cmd, shell=True).decode("utf-8") \
+                                                          .splitlines():
             if 'driver' in line:
                 driver = line.split()[-1]
         self.log.info(driver)
@@ -69,7 +71,7 @@ class NetworkconfigTest(Test):
         '''
         cmd = r"cat /sys/module/%s/drivers/pci\:%s/%s/net/%s/%s" %\
               (self.driver, self.driver, self.businfo, self.iface, param)
-        return process.system_output(cmd, shell=True).strip()
+        return process.system_output(cmd, shell=True).decode("utf-8").strip()
 
     def test_mtu_check(self):
         '''
@@ -78,7 +80,7 @@ class NetworkconfigTest(Test):
         mtu = self.get_network_sysfs_param("mtu")
         self.log.info("mtu value is %s" % mtu)
         mtuval = process.system_output("ip link show %s" % self.iface,
-                                       shell=True).split()[4]
+                                       shell=True).decode("utf-8").split()[4]
         self.log.info("through ip link show, mtu value is %s" % mtuval)
         if mtu != mtuval:
             self.fail("mismatch in mtu")
@@ -89,7 +91,8 @@ class NetworkconfigTest(Test):
         '''
         speed = self.get_network_sysfs_param("speed")
         cmd = "ethtool %s" % self.iface
-        for line in process.system_output(cmd, shell=True).splitlines():
+        for line in process.system_output(cmd, shell=True).decode("utf-8") \
+                                                          .splitlines():
             if 'Speed' in line:
                 eth_speed = line.split()[-1].strip('Mb/s')
         if speed != eth_speed:
@@ -113,7 +116,8 @@ class NetworkconfigTest(Test):
         duplex = self.get_network_sysfs_param("duplex")
         self.log.info("transmission mode is %s" % duplex)
         cmd = "ethtool %s" % self.iface
-        for line in process.system_output(cmd, shell=True).splitlines():
+        for line in process.system_output(cmd, shell=True).decode("utf-8") \
+                                                          .splitlines():
             if 'Duplex' in line:
                 eth_duplex = line.split()[-1]
         if str(duplex).capitalize() != eth_duplex:

--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -104,7 +104,7 @@ class Bonding(Test):
         '''
         SSH Login method for remote peer server
         '''
-        pxh = pxssh.pxssh()
+        pxh = pxssh.pxssh(encoding='utf-8')
         # Work-around for old pxssh not having options= parameter
         pxh.SSH_OPTS = "%s  -o 'StrictHostKeyChecking=no'" % pxh.SSH_OPTS
         pxh.SSH_OPTS = "%s  -o 'UserKnownHostsFile /dev/null' " % pxh.SSH_OPTS
@@ -160,11 +160,11 @@ class Bonding(Test):
         self.peer_interfaces.insert(0, self.peer_first_interface)
         self.net_mask = []
         stf = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        for val1, val2 in map(None, [interface], [self.local_ip]):
+        for val1, val2 in zip([interface], [self.local_ip]):
             mask = ""
             if val2:
-                tmp = fcntl.ioctl(stf.fileno(), 0x891b, struct.pack('256s',
-                                                                    val1))
+                tmp = fcntl.ioctl(stf.fileno(), 0x891b,
+                                  struct.pack('256s', val1.encode()))
                 mask = socket.inet_ntoa(tmp[20:24]).strip('\n')
             self.net_mask.append(mask)
         cmd = "route -n | grep %s | grep -w UG | awk "\
@@ -305,7 +305,7 @@ class Bonding(Test):
             process.system(cmd, shell=True, ignore_status=True)
             for _ in range(0, 600, 60):
                 if 'state UP' in process.system_output("ip link \
-                     show %s" % self.bond_name, shell=True):
+                     show %s" % self.bond_name, shell=True).decode("utf-8"):
                     self.log.info("Bonding setup is successful on\
                                   local machine")
                     break
@@ -380,7 +380,7 @@ class Bonding(Test):
             process.system(cmd, shell=True, ignore_status=True)
             for _ in range(0, 600, 60):
                 if 'state UP' in process.system_output("ip link \
-                     show %s" % val, shell=True):
+                     show %s" % val, shell=True).decode("utf-8"):
                     self.log.info("Interface %s is up", val)
                     break
                 time.sleep(60)

--- a/io/net/bridge.py
+++ b/io/net/bridge.py
@@ -48,15 +48,15 @@ class Bridging(Test):
         cmd = "ip addr show %s | sed -nr 's/.*inet ([^ ]+)."\
             "*/\\1/p'" % self.host_interface
         self.cidr = process.system_output(
-            '%s' % cmd, shell=True)
+            '%s' % cmd, shell=True).decode("utf-8")
         cmd = "route -n | grep %s | grep -w UG | awk "\
             "'{ print $2 }'" % self.host_interface
         self.gateway = process.system_output(
-            '%s' % cmd, shell=True)
+            '%s' % cmd, shell=True).decode("utf-8")
         cmd = "ip addr show %s | grep inet | grep brd | "\
             "awk '{ print $4 }'" % self.host_interface
         self.broadcast = process.system_output(
-            '%s' % cmd, shell=True)
+            '%s' % cmd, shell=True).decode("utf-8")
 
     def test(self):
         '''
@@ -65,8 +65,8 @@ class Bridging(Test):
         '''
         self.check_failure('ip link add dev br0 type bridge')
         check_flag = False
-        check_br = process.system_output(
-            'ip -d link show br0', verbose=True, ignore_status=True)
+        check_br = process.system_output('ip -d link show br0', verbose=True,
+                                         ignore_status=True).decode("utf-8")
         for line in check_br.splitlines():
             if line.find('bridge'):
                 check_flag = True
@@ -82,7 +82,7 @@ class Bridging(Test):
             self.check_failure('ip route add default via %s' %
                                self.gateway)
         if process.system('ping %s -I br0 -c 4' % self.peer_ip,
-           shell=True, ignore_status=True):
+                          shell=True, ignore_status=True):
             self.fail('Ping using bridge failed')
 
     def tearDown(self):
@@ -98,7 +98,7 @@ class Bridging(Test):
             self.check_failure('ip route add default via %s' %
                                self.gateway)
         if process.system('ping %s -c 4' % self.peer_ip,
-           shell=True, ignore_status=True):
+                          shell=True, ignore_status=True):
             self.fail('Ping failed when restoring back to provided interface')
 
 

--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -80,7 +80,8 @@ class Ethtool(Test):
         '''
         cmd = "ethtool %s" % interface
         for line in process.system_output(cmd, shell=True,
-                                          ignore_status=True).splitlines():
+                                          ignore_status=True).decode("utf-8") \
+                                                             .splitlines():
             if 'Link detected' in line:
                 return line.split()[-1]
         return ''

--- a/io/net/htx_nic_devices.py
+++ b/io/net/htx_nic_devices.py
@@ -67,7 +67,8 @@ class HtxNicTest(Test):
         Set up
         """
         if 'ppc64' not in process.system_output('uname -a', ignore_status=True,
-                                                shell=True, sudo=True):
+                                                shell=True,
+                                                sudo=True).decode("utf-8"):
             self.cancel("Platform does not support HTX tests")
 
         self.parameters()
@@ -158,7 +159,7 @@ class HtxNicTest(Test):
         '''
         SSH Login method for remote server
         '''
-        pxh = pxssh.pxssh()
+        pxh = pxssh.pxssh(encoding='utf-8')
         # Work-around for old pxssh not having options= parameter
         pxh.SSH_OPTS = "%s  -o 'StrictHostKeyChecking=no'" % pxh.SSH_OPTS
         pxh.SSH_OPTS = "%s  -o 'UserKnownHostsFile /dev/null' " % pxh.SSH_OPTS
@@ -201,7 +202,7 @@ class HtxNicTest(Test):
             cmd = "ip addr list %s |grep 'inet ' |cut -d' ' -f6| \
                   cut -d/ -f1" % intf
             ip = process.system_output(cmd, ignore_status=True,
-                                       shell=True, sudo=True)
+                                       shell=True, sudo=True).decode("utf-8")
             self.host_ips[intf] = ip
         self.peer_ips = {}
         for intf in self.peer_intfs:
@@ -473,7 +474,8 @@ class HtxNicTest(Test):
         '''
         self.log.info("Checking host_interfaces presence in %s",
                       self.mdt_file)
-        output = process.system_output(self.query_cmd, shell=True, sudo=True)
+        output = process.system_output(self.query_cmd, shell=True,
+                                       sudo=True).decode("utf-8")
         absent_devices = []
         for intf in self.host_intfs:
             if intf not in output:
@@ -612,7 +614,8 @@ class HtxNicTest(Test):
         self.log.info("Checking whether all net_devices are active or \
                       not in host ")
         output = process.system_output(self.query_cmd, ignore_status=True,
-                                       shell=True, sudo=True).split('\n')
+                                       shell=True,
+                                       sudo=True).decode("utf-8").split('\n')
         active_devices = []
         for line in output:
             for intf in self.host_intfs:
@@ -651,7 +654,8 @@ class HtxNicTest(Test):
         status_cmd = '/etc/init.d/htx.d status'
         shutdown_cmd = '/usr/lpp/htx/etc/scripts/htxd_shutdown'
         daemon_state = process.system_output(status_cmd, ignore_status=True,
-                                             shell=True, sudo=True)
+                                             shell=True,
+                                             sudo=True).decode("utf-8")
         if daemon_state.split(" ")[-1] == 'running':
             process.system(shutdown_cmd, ignore_status=True,
                            shell=True, sudo=True)
@@ -704,7 +708,7 @@ class HtxNicTest(Test):
 
         list = ["rhel", "fedora", "centos", "redhat", "SuSE"]
         if self.host_distro.name in list:
-            for intf, ip in self.host_ips.iteritems():
+            for intf, ip in self.host_ips.items():
                 file_name = "%s%s" % (base_name, intf)
                 with open(file_name, 'r') as file:
                     filedata = file.read()
@@ -728,7 +732,7 @@ class HtxNicTest(Test):
 
         list = ["rhel", "fedora", "centos", "redhat", "SuSE"]
         if self.peer_distro in list:
-            for intf, ip in self.peer_ips.iteritems():
+            for intf, ip in self.peer_ips.items():
                 file_name = "%s%s" % (base_name, intf)
                 filedata = self.run_command("cat %s" % file_name)
                 search_str = "IPADDR=.*"

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -95,7 +95,7 @@ class Iperf(Test):
         '''
         SSH Login method for remote peer server
         '''
-        pxh = pxssh.pxssh()
+        pxh = pxssh.pxssh(encoding='utf-8')
         # Work-around for old pxssh not having options= parameter
         pxh.SSH_OPTS = "%s  -o 'StrictHostKeyChecking=no'" % pxh.SSH_OPTS
         pxh.SSH_OPTS = "%s  -o 'UserKnownHostsFile /dev/null' " % pxh.SSH_OPTS
@@ -145,7 +145,7 @@ class Iperf(Test):
         result = process.run(cmd, shell=True, ignore_status=True)
         if result.exit_status:
             self.fail("FAIL: Iperf Run failed")
-        for line in result.stdout.splitlines():
+        for line in result.stdout.deocde("utf-8").splitlines():
             if 'sender' in line:
                 tput = int(line.split()[6].split('.')[0])
                 if tput < (int(self.expected_tp) * speed) / 100:

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -81,7 +81,7 @@ class ReceiveMulticastTest(Test):
         '''
         SSH Login method for remote server
         '''
-        pxh = pxssh.pxssh()
+        pxh = pxssh.pxssh(encoding='utf-8')
         # Work-around for old pxssh not having options= parameter
         pxh.SSH_OPTS = "%s  -o 'StrictHostKeyChecking=no'" % pxh.SSH_OPTS
         pxh.SSH_OPTS = "%s  -o 'UserKnownHostsFile /dev/null' " % pxh.SSH_OPTS

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -55,7 +55,7 @@ class MultiportStress(Test):
         Ping to multiple peers parallely
         '''
         parallel_procs = []
-        for host, peer in map(None, self.host_interfaces, self.peer_ips):
+        for host, peer in zip(self.host_interfaces, self.peer_ips):
             self.log.info('Starting Ping test')
             cmd = "ping -I %s %s -c %s %s" % (host, peer, self.count,
                                               ping_option)
@@ -70,7 +70,7 @@ class MultiportStress(Test):
         for proc in parallel_procs:
             out_buf = proc.get_stdout()
             out_buf += proc.get_stderr()
-            for val in out_buf.splitlines():
+            for val in out_buf.decode("utf-8").splitlines():
                 if 'packet loss' in val and ', 0% packet loss,' not in val:
                     errors.append(out_buf)
                     break

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -109,7 +109,7 @@ class Netperf(Test):
         '''
         SSH Login method for remote peer server
         '''
-        pxh = pxssh.pxssh()
+        pxh = pxssh.pxssh(encoding='utf-8')
         # Work-around for old pxssh not having options= parameter
         pxh.SSH_OPTS = "%s  -o 'StrictHostKeyChecking=no'" % pxh.SSH_OPTS
         pxh.SSH_OPTS = "%s  -o 'UserKnownHostsFile /dev/null' " % pxh.SSH_OPTS
@@ -170,16 +170,17 @@ class Netperf(Test):
         result = process.run(cmd, shell=True, ignore_status=True)
         if result.exit_status != 0:
             self.fail("FAIL: Run failed")
-        for line in result.stdout.splitlines():
+        for line in result.stdout.decode("utf-8").splitlines():
             if line and 'Throughput' in line.split()[-1]:
-                tput = int(result.stdout.split()[-1].split('.')[0])
+                tput = int(result.stdout.decode("utf-8").split()[-1].
+                           split('.')[0])
                 if tput < (int(self.expected_tp) * speed) / 100:
                     self.fail("FAIL: Throughput Actual - %s%%, Expected - %s%%"
                               ", Throughput Actual value - %s "
                               % ((tput*100)/speed, self.expected_tp,
                                  str(tput)+'Mb/sec'))
 
-        if 'WARNING' in result.stdout:
+        if 'WARNING' in result.stdout.decode("utf-8"):
             self.log.warn('Test completed with warning')
 
     def tearDown(self):

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -194,7 +194,9 @@ class NetworkTest(Test):
         cmd = "ssh %s \"ip addr show\"" % self.peer
         peer_interface = ""
         try:
-            for line in process.system_output(cmd, shell=True).splitlines():
+            for line in process.system_output(cmd,
+                                              shell=True).decode("utf-8") \
+                                                         .splitlines():
                 if self.peer in line:
                     peer_interface = line.split()[-1]
         except process.CmdError:
@@ -256,7 +258,8 @@ class NetworkTest(Test):
         If any other error, we return ''.
         '''
         cmd = "ethtool -k %s" % self.iface
-        output = process.system_output(cmd, shell=True, ignore_status=True)
+        output = process.system_output(cmd, shell=True,
+                                       ignore_status=True).decode("utf-8")
         for line in output.splitlines():
             if ro_type_full in line:
                 if 'fixed' in line.split()[-1]:

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -62,7 +62,8 @@ class TcpdumpTest(Test):
         cmd = "tcpdump -i %s -n -c %s -w '%s'" % (self.iface, self.count,
                                                   output_file)
         for line in process.run(cmd, shell=True,
-                                ignore_status=True).stderr.splitlines():
+                                ignore_status=True).stderr.decode("utf-8") \
+                                                   .splitlines():
             if "packets dropped by interface" in line:
                 self.log.info(line)
                 if int(line[0]) >= (int(self.drop) * int(self.count) / 100):

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -102,7 +102,7 @@ class Uperf(Test):
         '''
         SSH Login method for remote peer server
         '''
-        pxh = pxssh.pxssh()
+        pxh = pxssh.pxssh(encoding='utf-8')
         # Work-around for old pxssh not having options= parameter
         pxh.SSH_OPTS = "%s  -o 'StrictHostKeyChecking=no'" % pxh.SSH_OPTS
         pxh.SSH_OPTS = "%s  -o 'UserKnownHostsFile /dev/null' " % pxh.SSH_OPTS
@@ -152,7 +152,7 @@ class Uperf(Test):
         result = process.run(cmd, shell=True, ignore_status=True)
         if result.exit_status:
             self.fail("FAIL: Uperf Run failed")
-        for line in result.stdout.splitlines():
+        for line in result.stdout.decode("utf-8").splitlines():
             if self.peer_ip in line:
                 if 'Mb/s' in line:
                     tput = int(line.split()[3].split('.')[0])
@@ -164,7 +164,7 @@ class Uperf(Test):
                               ", Throughput Actual value - %s "
                               % ((tput*100)/speed, self.expected_tp,
                                  str(tput)+'Mb/sec'))
-        if 'WARNING' in result.stdout:
+        if 'WARNING' in result.stdout.decode("utf-8"):
             self.log.warn('Test completed with warning')
 
     def tearDown(self):


### PR DESCRIPTION
changing all network test form python2 to python3 except pktgen.py,
port_bounce.py, vlan_test.py, net_tools.py.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>