### PR TITLE
Add: option to optionally maintain virt-net config

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -72,6 +72,7 @@ class LPM(Test):
             self.cancel("HMC IP not got from lsrsrc command")
         self.hmc_user = self.params.get("hmc_username", default='hscroot')
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='abc123')
+        self.options = self.params.get("options", default='')
 
         self.lpar = self.get_mcp_component("NodeNameList").split('.')[0]
         if not self.lpar:
@@ -238,6 +239,8 @@ class LPM(Test):
         cmd = "migrlpar -o m -m %s -t %s -p %s %s" % (server,
                                                       remote_server,
                                                       lpar, params)
+        if self.options:
+            cmd = "%s %s" % (cmd, self.options)
         self.log.debug("\n".join(self.run_command(cmd)))
         time.sleep(10)
         if not self.is_lpar_in_server(remote_server, lpar):

--- a/io/net/virt-net/lpm.py.data/lpm.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm.yaml
@@ -9,3 +9,4 @@ sriov_ports:
 remote_sriov_adapters:
 remote_sriov_ports:
 bandwidth:
+options: "--vniccfg 2"

--- a/io/net/virt-net/lpm.py.data/lpm_5_iterations.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_5_iterations.yaml
@@ -9,6 +9,7 @@ sriov_ports:
 remote_sriov_adapters:
 remote_sriov_ports:
 bandwidth:
+options: "--vniccfg 2"
 iteration: !mux
     default: !mux
         1:


### PR DESCRIPTION
For LPM, there are different options to use along with the command,
which specifies what configuration to maintain and what not to.
To start with, we are enabling --vniccfg option with a value of 2,
which means "maintain virtual network configuration if possible".

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>