### PR TITLE
Fix for issue #1262

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -21,6 +21,7 @@
 import os
 import re
 import platform
+import subprocess
 
 from avocado import Test
 from avocado import main
@@ -38,7 +39,11 @@ class Kernbench(Test):
     and compile it as per the configuration file. Performance figures will be
     shown in the log file.
     """
-
+    subprocess.call("cp /boot/config* /tmp", shell=True)
+    subprocess.call("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYS/#&/g' /boot/config*", shell=True)
+    subprocess.call("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYRING/#&/g' /boot/config*", shell=True)
+    subprocess.call("sed -i 's/^.*CONFIG_MODULE_SIG_KEY/#&/g' /boot/config*", shell=True)
+    
     def time_build(self, threads=None, timefile=None, make_opts=None):
         """
         Time the building of the kernel
@@ -144,6 +149,7 @@ class Kernbench(Test):
         self.log.info("User      : %s", user_time)
         self.log.info("System    : %s", system_time)
         self.log.info("Elapsed   : %s", elapsed_time)
+        subprocess.call("mv -f /tmp/config* /boot/", shell=True)
 
 
 if __name__ == "__main__":

--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -21,7 +21,6 @@
 import os
 import re
 import platform
-import subprocess
 
 from avocado import Test
 from avocado import main
@@ -39,10 +38,10 @@ class Kernbench(Test):
     and compile it as per the configuration file. Performance figures will be
     shown in the log file.
     """
-    subprocess.call("cp /boot/config* /tmp", shell=True)
-    subprocess.call("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYS/#&/g' /boot/config*", shell=True)
-    subprocess.call("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYRING/#&/g' /boot/config*", shell=True)
-    subprocess.call("sed -i 's/^.*CONFIG_MODULE_SIG_KEY/#&/g' /boot/config*", shell=True)
+    process.system("cp /boot/config* /tmp", shell=True, sudo=True)
+    process.system("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYS/#&/g' /boot/config*", shell=True, sudo=True)
+    process.system("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYRING/#&/g' /boot/config*", shell=True, sudo=True)
+    process.system("sed -i 's/^.*CONFIG_MODULE_SIG_KEY/#&/g' /boot/config*", shell=True, sudo=True)
     def time_build(self, threads=None, timefile=None, make_opts=None):
         """
         Time the building of the kernel
@@ -148,7 +147,8 @@ class Kernbench(Test):
         self.log.info("User      : %s", user_time)
         self.log.info("System    : %s", system_time)
         self.log.info("Elapsed   : %s", elapsed_time)
-        subprocess.call("mv -f /tmp/config* /boot/", shell=True)
+        
+        process.system("mv -f /tmp/config* /boot/", shell=True, sudo=True)
 
 
 if __name__ == "__main__":

--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -42,6 +42,7 @@ class Kernbench(Test):
     process.system("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYS/#&/g' /boot/config*", shell=True, sudo=True)
     process.system("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYRING/#&/g' /boot/config*", shell=True, sudo=True)
     process.system("sed -i 's/^.*CONFIG_MODULE_SIG_KEY/#&/g' /boot/config*", shell=True, sudo=True)
+
     def time_build(self, threads=None, timefile=None, make_opts=None):
         """
         Time the building of the kernel

--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -147,7 +147,6 @@ class Kernbench(Test):
         self.log.info("User      : %s", user_time)
         self.log.info("System    : %s", system_time)
         self.log.info("Elapsed   : %s", elapsed_time)
-        
         process.system("mv -f /tmp/config* /boot/", shell=True, sudo=True)
 
 

--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -43,7 +43,6 @@ class Kernbench(Test):
     subprocess.call("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYS/#&/g' /boot/config*", shell=True)
     subprocess.call("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYRING/#&/g' /boot/config*", shell=True)
     subprocess.call("sed -i 's/^.*CONFIG_MODULE_SIG_KEY/#&/g' /boot/config*", shell=True)
-    
     def time_build(self, threads=None, timefile=None, make_opts=None):
         """
         Time the building of the kernel


### PR DESCRIPTION
While running the test case kernel/kernbench.py, there is an error occurred during the process of building a vmlinux kernel.

The error message is as follows :
make[1]: *** No rule to make target 'certs/rhel.pem' , needed by 'certs/x509_certificate_list' . Stop.

This fix is to comment out the lines CONFIG_SYSTEM_TRUSTED_KEY and CONFIG_MODULE_SIG_KEY in boot/config during the test.

So the process "make olddefconfig" would copy the config that already comments out certification sections and building kernel without errors.