### PR TITLE
Added new link for downloading Stress-1.0.4.tar.gz

### DIFF
--- a/perf/stress.py
+++ b/perf/stress.py
@@ -43,10 +43,10 @@ class Stress(Test):
         """
         Build 'stress'.
         Source:
-         http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz
+         https://fossies.org/linux/privat/stress-1.0.4.tar.gz
         """
         tarball = self.fetch_asset(
-            'http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz',
+            'https://fossies.org/linux/privat/stress-1.0.4.tar.gz',
             expire='7d')
         archive.extract(tarball, self.workdir)
         stress_version = os.path.basename(tarball.split('.tar.')[0])


### PR DESCRIPTION
tar file has been removed from people.seas.harvard.edu
And now downloading tar file from fossies.org.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>