### PR TITLE
Using the function interfacewait() in this test. [Waiting for avocado util]

### DIFF
--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -28,6 +28,7 @@ from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
 from avocado.utils import distro
+from avocado.utils import configure_network
 
 
 class Ethtool(Test):
@@ -67,11 +68,13 @@ class Ethtool(Test):
         Set the interface state specified, and return True if done.
         Returns False otherwise.
         '''
+        conf_net = configure_network.interfacewait(interface)
         cmd = "ip link set dev %s %s" % (interface, state)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             return False
-        if status != self.interface_link_status(interface):
-            return False
+        if state == "up" and conf_net is True:
+            if status != self.interface_link_status(interface):
+                return False
         return True
 
     def interface_link_status(self, interface):


### PR DESCRIPTION
Use the function interfacewait to wait for the interface's
link to be up before proceeding with ethtool tests.

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>