### PR TITLE
htx_test.ymal:Adding time_unit(m,h) for time_limit

### DIFF
--- a/generic/htx_test.py.data/htx_test.yaml
+++ b/generic/htx_test.py.data/htx_test.yaml
@@ -1,2 +1,3 @@
-time_limit: 2 # in minutes
+time_limit: 2
+time_unit: 'm' # m-minutes h-hours
 mdt_file: 'mdt.all'


### PR DESCRIPTION
to specify run-time in time_unit as m-minutes h-hours

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>