### PR TITLE
Handling teardown better in network_test

### DIFF
--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -284,9 +284,10 @@ class NetworkTest(Test):
         '''
         Remove the files created
         '''
-        process.run("rm -rf /tmp/tempfile")
-        cmd = "timeout 600 ssh %s \" rm -rf /tmp/tempfile\"" % self.peer
-        ret = process.system(cmd, shell=True, verbose=True, ignore_status=True)
+        if 'scp' in str(self.name.name):
+            process.run("rm -rf /tmp/tempfile")
+            cmd = "timeout 600 ssh %s \" rm -rf /tmp/tempfile\"" % self.peer
+            process.system(cmd, shell=True, verbose=True, ignore_status=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
network_test had been removing remote files created as part of
scp test. This failed in other tests, which did not create those
remote files at all. So, handling teardown only for scp test.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>