### PR TITLE
removed extra space from grep command which was making test fail

### DIFF
--- a/toolchain/gsl.py
+++ b/toolchain/gsl.py
@@ -46,9 +46,9 @@ class GSL(Test):
     def test(self):
         process.run("make -k check", ignore_status=True, sudo=True)
         logfile = os.path.join(self.logdir, "stdout")
-        if process.system_output("grep -Eai 'FAIL:  [1-9]' %s" %
+        if process.system_output("grep -Eai 'FAIL: [1-9]' %s" %
                                  logfile, shell=True, ignore_status=True):
-            process.run("grep -Eai 'Making check in|FAIL:  [1-9]' %s" % logfile,
+            process.run("grep -Eai 'Making check in|FAIL: [1-9]' %s" % logfile,
                         ignore_status=True, sudo=True)
             self.fail("test failed, Please check debug log for failed test cases")
 


### PR DESCRIPTION
attaching logs

[root@ltc-zz189-lp6 toolchain]# avocado run gsl.py
JOB ID     : 4acaef6f0934fb4ed23da44fd5f5492574db4632
JOB LOG    : /root/avocado/job-results/job-2019-09-26T00.28-4acaef6/job.log
 (1/1) gsl.py:GSL.test: PASS (423.09 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 423.53 s


Signed-off-by: Preeti Thakur <preeti.thakur@in.ibm.com>