### PR TITLE
fixed test case power_time_base_bug.py libpfm.py

### DIFF
--- a/toolchain/libpfm.py
+++ b/toolchain/libpfm.py
@@ -69,7 +69,7 @@ class Libpfm(Test):
                              shell=True, ignore_status=True)
         fail = False
         # Display the failed tests
-        for line in result.stdout.splitlines():
+        for line in result.stdout.decode("utf-8").splitlines():
             if 'Failed' in line:
                 self.log.error("Failed: %s", line)
                 fail = True

--- a/toolchain/power_time_base_bug.py
+++ b/toolchain/power_time_base_bug.py
@@ -66,7 +66,7 @@ class PowerTimeBaseBug(Test):
         os.chdir(self.teststmpdir)
         for cmd in ['./print_power_time_base', 'valgrind ./print_power_time_base']:
             self.log.info("Running %s", cmd)
-            cmd_output = process.system_output(cmd)
+            cmd_output = process.system_output(cmd).decode('utf-8')
             self.log.info("Output of command %s=%s", cmd, cmd_output)
             for line in cmd_output.splitlines():
                 if 'timebase' in line:


### PR DESCRIPTION
fixed test case to run in python3

Signed-off-by: Preeti Thakur <preeti.thakur@in.ibm.com>

fixed power_time_base_bug.py libpfm.py

logs
[root@ltc-zz189-lp6 toolchain]# avocado run power_time_base_bug.py
JOB ID     : 6bb2cc2f939f844045c1822c9fc45083f1474c9f
JOB LOG    : /root/avocado/job-results/job-2019-09-30T04.18-6bb2cc2/job.log
 (1/1) power_time_base_bug.py:PowerTimeBaseBug.test: PASS (31.25 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 31.52 s

[root@ltc-zz189-lp6 toolchain]# avocado run libpfm.py
JOB ID     : 59bfb96066fce8b22073aee9c0bf1e048f7563aa
JOB LOG    : /root/avocado/job-results/job-2019-09-30T04.23-59bfb96/job.log
 (1/1) libpfm.py:Libpfm.test: PASS (2.66 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 3.01 s
