### PR TITLE
In Python3, ConfigParser has been renamed to configparser

### DIFF
--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -16,7 +16,7 @@
 # Author: Shriya Kulkarni <shriyak@linux.vnet.ibm.com>
 
 import os
-import ConfigParser
+import configparser
 from avocado import Test
 from avocado import main
 
@@ -31,7 +31,7 @@ class test_generic_events(Test):
     """
 
     def read_generic_events(self):
-        parser = ConfigParser.ConfigParser()
+        parser = configparser.ConfigParser()
         parser.optionxform = str
         parser.read(self.get_data('raw_code.cfg'))
         cpu_info = open('/proc/cpuinfo', 'r').read()


### PR DESCRIPTION
Changed the module name according to python3

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>