### PR TITLE
[Back-port] Rename generic disk variable in lsi9361 scripts

### DIFF
--- a/io/disk/Avago_storage_adapter/avago9361_vd.py
+++ b/io/disk/Avago_storage_adapter/avago9361_vd.py
@@ -38,14 +38,14 @@ class Avago9361(Test):
         """
         self.controller = int(self.params.get('controller', default='0'))
         self.tool = str(self.params.get('tool_location'))
-        self.disk = str(self.params.get('disk')).split(" ")
+        self.disk = str(self.params.get('vd_disk')).split(" ")
         self.raid_level = str(self.params.get('raid_level', default='0'))
         self.size = str(self.params.get('size', default='all'))
         self.on_off = str(self.params.get('on_off'))
         self.hotspare = str(self.params.get('hotspare'))
         self.copyback = self.on_off.replace("e", "").replace("s", "").replace(
             "/", ":")
-        self.add_disk = str(self.params.get('add_disk')).split(" ")
+        self.add_disk = str(self.params.get('add_vd_disk')).split(" ")
         if not self.hotspare:
             self.cancel("Hotspare test needs a drive to create/test hotspare")
         if not self.on_off:

--- a/io/disk/Avago_storage_adapter/avago9361_vd.py.data/Readme
+++ b/io/disk/Avago_storage_adapter/avago9361_vd.py.data/Readme
@@ -9,7 +9,7 @@ Values to be provided in yaml file:
 controller ID: Specify the controller ID for which you want
 run this script
 raid_level: Specify the raid level that you want run test cases.
-disk: specify the disk on which tests need to be run.
+vd_disk: specify the disk on which tests need to be run.
 size: size of the raid array you want create
 on_off: Format should be in ex/sx.
 hotspare: Format should be in ex/sx

--- a/io/disk/Avago_storage_adapter/avago9361_vd.py.data/avago9361_vd.yaml
+++ b/io/disk/Avago_storage_adapter/avago9361_vd.py.data/avago9361_vd.yaml
@@ -1,11 +1,11 @@
 cenario:
     controller: 0
     tool_location: /root/storcli64
-    disk: 16:5 16:6 16:7
+    vd_disk: 16:5 16:6 16:7
     size : 10000 
     on_off: e16/s6
     hotspare: e16/s3
-    add_disk: 16:2 16:3 16:4
+    add_vd_disk: 16:2 16:3 16:4
 raid_level: !mux
     r0:
         raid_level: r0


### PR DESCRIPTION
Rename generic disk variable in lsi9361 to disk_vd so that the input file in test suite can cover all the disk related tests.
Backport of fix to py2-lts.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>