### PR TITLE
[Back-port] Fixing timeout issue with tg3 driver specific to rhel7.6

### DIFF
--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -23,6 +23,7 @@ This test needs to be run as root.
 """
 
 import netifaces
+import time
 from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
@@ -70,6 +71,7 @@ class Ethtool(Test):
         cmd = "ip link set dev %s %s" % (interface, state)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             return False
+        time.sleep(60)
         if status != self.interface_link_status(interface):
             return False
         return True


### PR DESCRIPTION
Fixing timeout issue with tg3 driver specific to RHEl7.6/py2-lts branch. Driver takes around 60 seconds to come up.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>