### PR TITLE
[Back-port] Removing btrfs specific tests from py2-lts branch

### DIFF
--- a/io/disk/bonnie.py.data/bonnie.yaml
+++ b/io/disk/bonnie.py.data/bonnie.yaml
@@ -17,5 +17,5 @@ filesystem: !mux
         fs: 'ext4'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'

--- a/io/disk/disk_info.py.data/disk_info.yaml
+++ b/io/disk/disk_info.py.data/disk_info.yaml
@@ -5,5 +5,5 @@ filesystem: !mux
         fs: 'ext4'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'

--- a/io/disk/disktest.py.data/disktest.yaml
+++ b/io/disk/disktest.py.data/disktest.yaml
@@ -5,5 +5,5 @@ filesystem: !mux
         fs: 'ext4'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'

--- a/io/disk/fiotest.py.data/fio.yaml
+++ b/io/disk/fiotest.py.data/fio.yaml
@@ -7,5 +7,5 @@ filesystem: !mux
         fs: 'ext4'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'

--- a/io/disk/fs_mark.py.data/fs_mark.yaml
+++ b/io/disk/fs_mark.py.data/fs_mark.yaml
@@ -7,5 +7,5 @@ filesystem: !mux
         fs: 'ext4'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'

--- a/io/disk/ltp_fs.py.data/ltp_fs.yaml
+++ b/io/disk/ltp_fs.py.data/ltp_fs.yaml
@@ -19,5 +19,5 @@ fs: !mux
         fs: 'ext2'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'

--- a/io/disk/lvsetup.py.data/lvsetup.yaml
+++ b/io/disk/lvsetup.py.data/lvsetup.yaml
@@ -10,5 +10,5 @@ filesystem: !mux
         fs: ext4
     xfs:
         fs: xfs
-    btrfs:
-        fs: btrfs
+#   btrfs:
+#       fs: btrfs

--- a/io/disk/parallel_dd.py.data/parallel_dd.yaml
+++ b/io/disk/parallel_dd.py.data/parallel_dd.yaml
@@ -13,8 +13,8 @@ file_system_type: !mux
        fs: 'ext4'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'
 seqread: !mux
     yes:
        seq_read: True

--- a/io/disk/tiobench.py.data/tiobench.yaml
+++ b/io/disk/tiobench.py.data/tiobench.yaml
@@ -5,8 +5,8 @@ filesystem: !mux
         fs: 'ext4'
     xfs:
         fs: 'xfs'
-    btrfs:
-        fs: 'btrfs'
+#   btrfs:
+#       fs: 'btrfs'
 block: !mux
     4096:
         blocks: 4096


### PR DESCRIPTION
Commenting out old btrfs specific tests from py2-lts branch to reduce the number of invalid tests.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>