### PR TITLE
Fix: xfstests python3 string decode

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -362,7 +362,7 @@ class Xfstests(Test):
         na_detail_re = re.compile(r'(\d{3})\s*(\[not run\])\s*(.*)')
         failed_re = re.compile(r'Failed \d+ of \d+ tests')
 
-        lines = output.split('\n')
+        lines = output.decode("utf-8").split('\n')
         result_line = lines[-3]
 
         error_msg = None

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -78,13 +78,15 @@ class Xfstests(Test):
                              'libattr-devel', 'libaio-devel', 'libuuid-devel',
                              'openssl-devel', 'xfsprogs-devel'])
 
-            if self.detected_distro.name == 'rhel' and\
-                    self.detected_distro.version.startswith('8'):
-                packages.remove('indent')
             if self.detected_distro.name == 'SuSE':
                 packages.extend(['libbtrfs-devel', 'libcap-progs'])
             else:
                 packages.extend(['btrfs-progs-devel'])
+
+            if self.detected_distro.name == 'rhel' and\
+                    self.detected_distro.version.startswith('8'):
+                packages.remove('indent')
+                packages.remove('btrfs-progs-devel')
 
             if self.detected_distro.name in ['centos', 'fedora']:
                 packages.extend(['fio', 'dbench'])


### PR DESCRIPTION
The result being parsed requires a string to be split, patch fixes the error

Signed-off-by: Harish <harish@linux.ibm.com>