### PR TITLE
Kern fix

### DIFF
--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -98,6 +98,10 @@ class Kernbench(Test):
             deps.extend(['popt', 'glibc', 'glibc-devel', 'libcap-ng',
                          'libcap', 'libcap-devel', 'elfutils-libelf',
                          'elfutils-libelf-devel', 'openssl-devel'])
+            process.system("cp /boot/config* /tmp", shell=True, sudo=True)
+            process.system("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYS/#&/g' /boot/config*", shell=True, sudo=True)
+            process.system("sed -i 's/^.*CONFIG_SYSTEM_TRUSTED_KEYRING/#&/g' /boot/config*", shell=True, sudo=True)
+            process.system("sed -i 's/^.*CONFIG_MODULE_SIG_KEY/#&/g' /boot/config*", shell=True, sudo=True)
 
         for package in deps:
             if not smg.check_installed(package) and not smg.install(package):
@@ -144,6 +148,9 @@ class Kernbench(Test):
         self.log.info("User      : %s", user_time)
         self.log.info("System    : %s", system_time)
         self.log.info("Elapsed   : %s", elapsed_time)
+        detected_distro = distro.detect()
+        if detected_distro.name in ['centos', 'fedora', 'rhel']:
+            process.system("mv -f /tmp/config* /boot/", shell=True, sudo=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1-change the fix to be specific to rhel and rhel origin distro 
command out the certificate section in the /boot/config*,
in order to prevent build errors in rhel or rhel origin distros.
2-address review comments as well fixed pep8 issue
in Test

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>
Signed-off-by: Chih Yuan Hsi <gofar.hsi@gmail.com>
