### PR TITLE
[Backport]htx.py:Adding time_units m-minutes h-hours.

### DIFF
--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -48,8 +48,15 @@ class HtxTest(Test):
             self.cancel("Supported only on Power Architecture")
 
         self.mdt_file = self.params.get('mdt_file', default='mdt.mem')
-        self.time_limit = int(self.params.get('time_limit', default=2)) * 60
+        self.time_limit = int(self.params.get('time_limit', default=2))
+        self.time_unit = self.params.get('time_unit', default='m')
         self.failed = False
+        if self.time_unit == 'm':
+            self.time_limit = self.time_limit * 60
+        elif self.time_unit == 'h':
+            self.time_limit = self.time_limit * 3600
+        else:
+            self.cancel("running time unit is not proper, please pass as 'm' or 'h' ")
         if str(self.name.name).endswith('test_start'):
             # Build HTX only at the start phase of test
             self.setup_htx()

--- a/generic/htx_test.py.data/htx_test.yaml
+++ b/generic/htx_test.py.data/htx_test.yaml
@@ -1,2 +1,3 @@
-time_limit: 2 # in minutes
+time_limit: 2
+time_unit: 'm' # m-minutes h-hours
 mdt_file: 'mdt.all'


### PR DESCRIPTION
time_units m,h are added to time_limit
for specifying run-time.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>