### PR TITLE
Removing btrfs specific tests from py2-lts branch from LVM script - v5

### DIFF
--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -57,6 +57,11 @@ class Lvsetup(Test):
         if self.fs_name == 'xfs':
             pkg = 'xfsprogs'
         if self.fs_name == 'btrfs':
+            if distro.detect().name == 'rhel':
+                if (int(distro.detect().version) == 7 and \
+                   int(distro.detect().release) >= 4) or \
+                   int(distro.detect().version) > 7:
+                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro.detect().name == 'SuSE':
                 pkg = 'btrfsprogs'
             else:


### PR DESCRIPTION
Removing btrfs specific tests from py2-lts branch from LVM script.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>