### PR TITLE
Changed attribute name a/c to py3(process.py)

### DIFF
--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -81,13 +81,13 @@ class hv_24x7_all_events(Test):
         # Check if its enabled
         result_perf = process.run("%s,domain=2,core=1/ sleep 1"
                                   % self.perf_stat, ignore_status=True)
-        if "not supported" in result_perf.stderr:
+        if "not supported" in result_perf.stderr.decode("utf-8"):
             self.cancel("Please enable LPAR to allow collecting"
                         " the 24x7 counters info")
 
         # Getting the number of cores
         output = process.run("lscpu")
-        for line in output.stdout.split('\n'):
+        for line in output.stdout.decode("utf-8").split('\n'):
             if 'Core(s) per socket:' in line:
                 self.cores = int(line.split(':')[1].strip())
 
@@ -96,7 +96,7 @@ class hv_24x7_all_events(Test):
 
         # Collect all hv_24x7 events
         self.list_of_hv_24x7_events = []
-        for line in process.get_perf_events('hv_24x7'):
+        for line in process.get_command_output_matching('perf list', 'hv_24x7'):
             line = line.split(',')[0].split('/')[1]
             self.list_of_hv_24x7_events.append(line)
 

--- a/perf/perf_hv_gpci.py
+++ b/perf/perf_hv_gpci.py
@@ -61,7 +61,7 @@ class perf_hv_gpci(Test):
 
         # Collect all hv_gpci events
         self.list_of_hv_gpci_events = []
-        for line in process.get_perf_events('hv_gpci'):
+        for line in process.get_command_output_matching('perf list', 'hv_gpci'):
             line = line.split(',')[0].split('/')[1]
             self.list_of_hv_gpci_events.append(line)
 


### PR DESCRIPTION
To get rid of 'module' object has no attribute
'get_perf_events'.

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>