### PR TITLE
Changed attr name a/c to process.py

### DIFF
--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -26,7 +26,6 @@ class hv_24x7_all_events(Test):
 
     """
     This tests all hv_24x7 events
-    :avocado: tags=perf,24x7,events
     """
     # Initializing fail command list
     fail_cmd = list()
@@ -96,7 +95,7 @@ class hv_24x7_all_events(Test):
 
         # Collect all hv_24x7 events
         self.list_of_hv_24x7_events = []
-        for line in process.get_perf_events('hv_24x7'):
+        for line in process.get_command_output_matching('perf list', 'hv_24x7'):
             line = line.split(',')[0].split('/')[1]
             self.list_of_hv_24x7_events.append(line)
 

--- a/perf/perf_hv_gpci.py
+++ b/perf/perf_hv_gpci.py
@@ -25,7 +25,6 @@ class perf_hv_gpci(Test):
 
     """
     Tests hv_gpci events
-    :avocado: tags=perf,hv_gpci,events
     """
     # Initializing fail command list
     fail_cmd = list()
@@ -61,7 +60,7 @@ class perf_hv_gpci(Test):
 
         # Collect all hv_gpci events
         self.list_of_hv_gpci_events = []
-        for line in process.get_perf_events('hv_gpci'):
+        for line in process.get_command_output_matching('perf list', 'hv_gpci'):
             line = line.split(',')[0].split('/')[1]
             self.list_of_hv_gpci_events.append(line)
 


### PR DESCRIPTION
To get rid of 'module' object has no attribute
'get_perf_events'.

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>