### PR TITLE
Remove nvme_format for nvme-cli selftest

### DIFF
--- a/io/disk/ssd/nvme_cli_selftests.py.data/nvme_cli_selftests.yaml
+++ b/io/disk/ssd/nvme_cli_selftests.py.data/nvme_cli_selftests.yaml
@@ -31,5 +31,3 @@ test: !mux
         test: nvme_smart_log_test
     nvme_test:
         test: nvme_test
-    nvme_format_test:
-        test: nvme_format_test


### PR DESCRIPTION
nvme_format_test covers formatting namespace, and deleting and
creating namespace. These are already taken care in nvmetest.py.
So, removing the test.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>