### PR TITLE
Fix emtest

### DIFF
--- a/cpu/em_quad_level_frequency_transitions.py
+++ b/cpu/em_quad_level_frequency_transitions.py
@@ -85,7 +85,8 @@ class freq_transitions(Test):
 
     def run_cmd(self, cmdline):
         try:
-            return process.run(cmdline, ignore_status=True, sudo=True, shell=True)
+            return process.run(cmdline, ignore_status=True,
+                               sudo=True, shell=True)
         except process.CmdError as details:
             self.fail("test  failed: %s" % details)
 

--- a/cpu/em_quad_level_frequency_transitions.py
+++ b/cpu/em_quad_level_frequency_transitions.py
@@ -129,9 +129,9 @@ class freq_transitions(Test):
                     freq_max = self.max_freq_dict[chip][quad]
                     diff = float(freq_max) - float(freq_get)
                     if diff > self.threshold:
-                        self.cancel("Quad level max frequency %s is not set on"
-                                    "this cpu %s"
-                                    % (self.max_freq_dict[chip][quad], cpu))
+                        self.fail("Quad level max frequency %s is not set on"
+                                  "this cpu %s"
+                                  % (self.max_freq_dict[chip][quad], cpu))
             self.log.info("Quad level max frequency %s is set on this quad"
                           "%s" % (self.max_freq_dict[chip][quad], quad))
 

--- a/cpu/em_quad_level_frequency_transitions.py
+++ b/cpu/em_quad_level_frequency_transitions.py
@@ -19,6 +19,8 @@ import time
 import os
 import random
 import platform
+import re
+
 from avocado import Test
 from avocado import main
 from avocado.utils import process, distro, cpu, genio
@@ -49,7 +51,6 @@ class freq_transitions(Test):
 
         smm = SoftwareManager()
         detected_distro = distro.detect()
-        self.threshold = int(self.params.get("threshold", default=300000))
         if 'Ubuntu' in detected_distro.name:
             deps = ['linux-tools-common', 'linux-tools-%s'
                     % platform.uname()[2]]
@@ -61,6 +62,20 @@ class freq_transitions(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
 
+        fre_min = 0
+        fre_max = 0
+        freq_info = process.system_output(
+            "cpupower frequency-info", shell=True).decode("utf-8")
+        for line in str(freq_info).splitlines():
+            if re.search('hardware limits:', line, re.IGNORECASE):
+                frq = line.split(":")[1]
+                frq_init = frq.split('-')[0]
+                frq_last = frq.split('-')[1]
+                fre_min = float(frq_init.split('GHz')[0])
+                fre_max = float(frq_last.split('GHz')[0])
+                break
+        threshold = (fre_max - fre_min) * (10 ** 6)
+        self.threshold = int(self.params.get("threshold", default=threshold))
         self.cpus = cpu.total_cpus_count()
         self.cpu_num = 0
         self.max_freq = 0


### PR DESCRIPTION
1-added functionality as script able to calculate system frequency threshold
so automated run  works well
2-change test cancel to fail as if frequency scaling if not fit
in the threshold, test should fail
3- fix pep8 issue in em_quad_level_frequency_transitions 

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>