### PR TITLE
kselftest.yaml:Removing powerpc component from kselftests.

### DIFF
--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -2,8 +2,8 @@ setup:
     component: !mux
         vm:
             comp: "vm"
-        power:
-            comp: "powerpc"
+#        power:
+#            comp: "powerpc"
         mem_plug:
             comp: "memory-hotplug"
     run_type: !mux


### PR DESCRIPTION
sigfuz from powerpc is blocking test flow
so removing it from kselftests.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>