### PR TITLE
Configure networkscripts differently for IB and RoCE [Waiitng for Avocado util - configure_network.py ]

### DIFF
--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -53,8 +53,12 @@ class PingPong(Test):
                                              default="None")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
-                                 interface_type='infiniband')
+        if self.iface[0:2] == 'ib':
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Infiniband')
+        else:
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Ethernet')
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
         if self.iface not in interfaces:

--- a/io/net/infiniband/mckey.py
+++ b/io/net/infiniband/mckey.py
@@ -71,8 +71,12 @@ class Mckey(Test):
                                              default="None")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
-                                 interface_type='infiniband')
+        if self.iface[0:2] == 'ib':
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Infiniband')
+        else:
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Ethernet')
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
         if self.iface not in interfaces:

--- a/io/net/infiniband/ping6.py
+++ b/io/net/infiniband/ping6.py
@@ -73,8 +73,12 @@ class Ping6(Test):
                                              default="None")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
-                                 interface_type='infiniband')
+        if self.iface[0:2] == 'ib':
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Infiniband')
+        else:
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Ethernet')
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
         if self.iface not in interfaces:

--- a/io/net/infiniband/rdma_tests.py
+++ b/io/net/infiniband/rdma_tests.py
@@ -60,8 +60,12 @@ class RDMA(Test):
                                              default="None")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
-                                 interface_type='infiniband')
+        if self.iface[0:2] == 'ib':
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Infiniband')
+        else:
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Ethernet')
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
         if self.iface not in interfaces:

--- a/io/net/infiniband/rping.py
+++ b/io/net/infiniband/rping.py
@@ -73,8 +73,12 @@ class Rping(Test):
             self.cancel("%s peer machine is not available" % self.peer_ip)
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
-                                 interface_type='infiniband')
+        if self.iface[0:2] == 'ib':
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Infiniband')
+        else:
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Ethernet')
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
         self.option = self.option.replace("peer_ipv6", self.ipv6_peer)

--- a/io/net/infiniband/ucmatose.py
+++ b/io/net/infiniband/ucmatose.py
@@ -72,8 +72,12 @@ class Ucmatose(Test):
                                              default="None")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
-                                 interface_type='infiniband')
+        if self.iface[0:2] == 'ib':
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Infiniband')
+        else:
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Ethernet')
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
         if self.iface not in interfaces:

--- a/io/net/infiniband/udaddy.py
+++ b/io/net/infiniband/udaddy.py
@@ -71,8 +71,12 @@ class Udady(Test):
                                              default="None")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
-                                 interface_type='infiniband')
+        if self.iface[0:2] == 'ib':
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Infiniband')
+        else:
+            configure_network.set_ip(self.ipaddr, self.netmask, self.iface,
+                                 interface_type='Ethernet')
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
         if self.iface not in interfaces:


### PR DESCRIPTION
Configure networkscripts differently for IB and RoCE

Signed-off-by: Manvanthara Puttashankar <manvanth@linux.vnet.ibm.com>