### PR TITLE
[Back-port] Removing btrfs specific tests from all disk tests.

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -61,6 +61,11 @@ class Bonnie(Test):
                 else:
                     deps.extend(['gcc-c++'])
                 if fstype == 'btrfs':
+                    if distro.detect().name == 'rhel':
+                        if (int(distro.detect().version) == 7 and \
+                           int(distro.detect().release) >= 4) or \
+                           int(distro.detect().version) > 7:
+                            self.cancel("btrfs is not supported with RHEL 7.4 onwards")
                     if distro.detect().name == 'Ubuntu':
                         deps.extend(['btrfs-tools'])
 

--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -61,11 +61,12 @@ class Bonnie(Test):
                 else:
                     deps.extend(['gcc-c++'])
                 if fstype == 'btrfs':
+                    ver = int(distro.detect().version)
+                    rel = int(distro.detect().release)
                     if distro.detect().name == 'rhel':
-                        if (int(distro.detect().version) == 7 and \
-                           int(distro.detect().release) >= 4) or \
-                           int(distro.detect().version) > 7:
-                            self.cancel("btrfs is not supported with RHEL 7.4 onwards")
+                        if (ver == 7 and rel >= 4) or ver > 7:
+                            self.cancel("btrfs is not supported with \
+                                        RHEL 7.4 onwards")
                     if distro.detect().name == 'Ubuntu':
                         deps.extend(['btrfs-tools'])
 

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -73,11 +73,12 @@ class DiskInfo(Test):
         if self.fstype == 'xfs':
             pkg_list.append('xfsprogs')
         if self.fstype == 'btrfs':
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
-                if (int(distro.detect().version) == 7 and \
-                   int(distro.detect().release) >= 4) or \
-                   int(distro.detect().version) > 7:
-                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
+                if (ver == 7 and rel >= 4) or ver > 7:
+                    self.cancel("btrfs is not supported with \
+                                RHEL 7.4 onwards")
             if self.distro == 'Ubuntu':
                 pkg_list.append("btrfs-tools")
         for pkg in pkg_list:

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -73,6 +73,11 @@ class DiskInfo(Test):
         if self.fstype == 'xfs':
             pkg_list.append('xfsprogs')
         if self.fstype == 'btrfs':
+            if distro.detect().name == 'rhel':
+                if (int(distro.detect().version) == 7 and \
+                   int(distro.detect().release) >= 4) or \
+                   int(distro.detect().version) > 7:
+                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if self.distro == 'Ubuntu':
                 pkg_list.append("btrfs-tools")
         for pkg in pkg_list:

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -29,7 +29,7 @@ from avocado import Test
 from avocado import main
 from avocado.utils import build
 from avocado.utils import memory
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils import lv_utils
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager import SoftwareManager
@@ -74,11 +74,12 @@ class Disktest(Test):
         self.dirs = self.params.get('dir', default=self.workdir)
         self.fstype = self.params.get('fs', default='ext4')
         if self.fstype == 'btrfs':
-	    if distro.detect().name == 'rhel':
-	        if (int(distro.detect().version) == 7 and \
-		    int(distro.detect().release) >= 4) or \
-		    int(distro.detect().version) > 7:
-		     self.cancel("btrfs is not supported with RHEL7.4 onwards")
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
+            if distro.detect().name == 'rhel':
+                if (ver == 7 and rel >= 4) or ver > 7:
+                    self.cancel("btrfs is not supported with \
+                                RHEL 7.4 onwards")
         gigabytes = int(lv_utils.get_diskspace(self.disk)) // 1073741824
         memory_mb = memory.meminfo.MemTotal.m
         self.chunk_mb = gigabytes * 950

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -73,7 +73,12 @@ class Disktest(Test):
         self.disk = self.params.get('disk', default=None)
         self.dirs = self.params.get('dir', default=self.workdir)
         self.fstype = self.params.get('fs', default='ext4')
-
+        if self.fstype == 'btrfs':
+	    if distro.detect().name == 'rhel':
+	        if (int(distro.detect().version) == 7 and \
+		    int(distro.detect().release) >= 4) or \
+		    int(distro.detect().version) > 7:
+		     self.cancel("btrfs is not supported with RHEL7.4 onwards")
         gigabytes = int(lv_utils.get_diskspace(self.disk)) // 1073741824
         memory_mb = memory.meminfo.MemTotal.m
         self.chunk_mb = gigabytes * 950

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -64,6 +64,11 @@ class FioTest(Test):
         pkg_list = ['libaio', 'libaio-devel']
         smm = SoftwareManager()
         if fstype == 'btrfs':
+            if distro.detect().name == 'rhel':
+                if (int(distro.detect().version) == 7 and \
+                   int(distro.detect().release) >= 4) or \
+                   int(distro.detect().version) > 7:
+                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
                 pkg_list.append('btrfs-tools')
 

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -64,11 +64,12 @@ class FioTest(Test):
         pkg_list = ['libaio', 'libaio-devel']
         smm = SoftwareManager()
         if fstype == 'btrfs':
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
-                if (int(distro.detect().version) == 7 and \
-                   int(distro.detect().release) >= 4) or \
-                   int(distro.detect().version) > 7:
-                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
+                if (ver == 7 and rel >= 4) or ver > 7:
+                    self.cancel("btrfs is not supported with \
+                                RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
                 pkg_list.append('btrfs-tools')
 

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -61,11 +61,12 @@ class FSMark(Test):
         self.fstype = self.params.get('fs', default='ext4')
 
         if self.fstype == 'btrfs':
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
-                if (int(distro.detect().version) == 7 and \
-                   int(distro.detect().release) >= 4) or \
-                   int(distro.detect().version) > 7:
-                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
+                if (ver == 7 and rel >= 4) or ver > 7:
+                    self.cancel("btrfs is not supported with \
+                                RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
                 if not smm.check_installed("btrfs-tools") and not \
                         smm.install("btrfs-tools"):

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -61,6 +61,11 @@ class FSMark(Test):
         self.fstype = self.params.get('fs', default='ext4')
 
         if self.fstype == 'btrfs':
+            if distro.detect().name == 'rhel':
+                if (int(distro.detect().version) == 7 and \
+                   int(distro.detect().release) >= 4) or \
+                   int(distro.detect().version) > 7:
+                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
                 if not smm.check_installed("btrfs-tools") and not \
                         smm.install("btrfs-tools"):

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -53,6 +53,13 @@ class LtpFs(Test):
         fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
 
+        if fstype == 'btrfs':
+	    if distro.detect().name == 'rhel':
+	        if (int(distro.detect().version) == 7 and \
+		    int(distro.detect().release) >= 4) or \
+		    int(distro.detect().version) > 7:
+		     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
+
         if self.disk is not None:
             self.part_obj = Partition(self.disk, mountpoint=self.mount_point)
             self.log.info("Unmounting the disk/dir if it is already mounted")

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -26,7 +26,7 @@ LTP Filesystem tests
 import os
 from avocado import Test
 from avocado import main
-from avocado.utils import build
+from avocado.utils import build, distro
 from avocado.utils import process, archive
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.partition import Partition
@@ -54,12 +54,12 @@ class LtpFs(Test):
         self.args = self.params.get('args', default='')
 
         if fstype == 'btrfs':
-	    if distro.detect().name == 'rhel':
-	        if (int(distro.detect().version) == 7 and \
-		    int(distro.detect().release) >= 4) or \
-		    int(distro.detect().version) > 7:
-		     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
-
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
+            if distro.detect().name == 'rhel':
+                if (ver == 7 and rel >= 4) or ver > 7:
+                    self.cancel("btrfs is not supported with \
+                                RHEL 7.4 onwards")
         if self.disk is not None:
             self.part_obj = Partition(self.disk, mountpoint=self.mount_point)
             self.log.info("Unmounting the disk/dir if it is already mounted")

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -57,10 +57,10 @@ class Lvsetup(Test):
         if self.fs_name == 'xfs':
             pkg = 'xfsprogs'
         if self.fs_name == 'btrfs':
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
-                if (int(distro.detect().version) == 7 and \
-                   int(distro.detect().release) >= 4) or \
-                   int(distro.detect().version) > 7:
+                if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro.detect().name == 'SuSE':
                 pkg = 'btrfsprogs'

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -57,6 +57,11 @@ class Lvsetup(Test):
         if self.fs_name == 'xfs':
             pkg = 'xfsprogs'
         if self.fs_name == 'btrfs':
+            if distro.detect().name == 'rhel':
+                if (int(distro.detect().version) == 7 and \
+                   int(distro.detect().release) >= 4) or \
+                   int(distro.detect().version) > 7:
+                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro.detect().name == 'SuSE':
                 pkg = 'btrfsprogs'
             else:

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -30,7 +30,7 @@ import sys
 import json
 from avocado import Test
 from avocado import main
-from avocado.utils import process
+from avocado.utils import process, distro
 from avocado.utils import partition as partition_lib
 
 
@@ -71,11 +71,11 @@ class ParallelDd(Test):
         self.fs_dd_woptions = self.params.get('fs_dd_woptions', default='')
         self.fs_dd_roptions = self.params.get('fs_dd_roptions', default='')
         if self.fstype == 'btrfs':
-	    if distro.detect().name == 'rhel':
-                if (int(distro.detect().version) == 7 and \
-		    int(distro.detect().release) >= 4) or \
-		    int(distro.detect().version) > 7:
-		     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
+            if distro.detect().name == 'rhel':
+                if (ver == 7 and rel >= 4) or ver > 7:
+                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
 
         if not self.blocks:
             self.blocks = self.megabytes * 256

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -70,6 +70,13 @@ class ParallelDd(Test):
         self.dd_roptions = self.params.get('dd_roptions', default='')
         self.fs_dd_woptions = self.params.get('fs_dd_woptions', default='')
         self.fs_dd_roptions = self.params.get('fs_dd_roptions', default='')
+        if self.fstype == 'btrfs':
+	    if distro.detect().name == 'rhel':
+                if (int(distro.detect().version) == 7 and \
+		    int(distro.detect().release) >= 4) or \
+		    int(distro.detect().version) > 7:
+		     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
+
         if not self.blocks:
             self.blocks = self.megabytes * 256
 

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -49,6 +49,11 @@ class Tiobench(Test):
         smm = SoftwareManager()
         packages = ['gcc']
         if self.fstype == 'btrfs':
+            if distro.detect().name == 'rhel':
+                if (int(distro.detect().version) == 7 and \
+                   int(distro.detect().release) >= 4) or \
+                   int(distro.detect().version) > 7:
+                    self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
                 packages.extend(['btrfs-tools'])
         for package in packages:

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -49,10 +49,10 @@ class Tiobench(Test):
         smm = SoftwareManager()
         packages = ['gcc']
         if self.fstype == 'btrfs':
+            ver = int(distro.detect().version)
+            rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
-                if (int(distro.detect().version) == 7 and \
-                   int(distro.detect().release) >= 4) or \
-                   int(distro.detect().version) > 7:
+                if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
                 packages.extend(['btrfs-tools'])


### PR DESCRIPTION
Removing btrfs specific tests from all disk tests.

Signed-off-by: Manvanthara B Puttashankar <manvanth@linux.vnet.ibm.com>