### PR TITLE
changes made to bonding.py to read different mtu sizes

### DIFF
--- a/io/net/bonding.py.data/bonding_mode0.yaml
+++ b/io/net/bonding.py.data/bonding_mode0.yaml
@@ -1,0 +1,28 @@
+bonding_mode: "0"
+bond_interfaces: ""
+peer_ip: ""
+peer_interfaces: ""
+bond_name: "bondtest"
+user_name: "root"
+peer_bond_needed: False 
+peer_wait_time: "10"
+sleep_time: "5"
+mtu: !mux
+    1500:
+        mtu: "1500"
+    2000:
+        mtu: "2000"
+    3000:
+        mtu: "3000"
+    4000:
+        mtu: "4000"
+    5000:
+        mtu: "5000"
+    6000:
+        mtu: "6000"
+    7000:
+        mtu: "7000"
+    8000:
+        mtu: "8000"
+    9000:
+        mtu: "9000"

--- a/io/net/bonding.py.data/bonding_mode1.yaml
+++ b/io/net/bonding.py.data/bonding_mode1.yaml
@@ -1,0 +1,28 @@
+bonding_mode: "1"
+bond_interfaces: ""
+peer_ip: ""
+peer_interfaces: ""
+bond_name: "bondtest"
+user_name: "root"
+peer_bond_needed: False 
+peer_wait_time: "10"
+sleep_time: "5"
+mtu: !mux
+    1500:
+        mtu: "1500"
+    2000:
+        mtu: "2000"
+    3000:
+        mtu: "3000"
+    4000:
+        mtu: "4000"
+    5000:
+        mtu: "5000"
+    6000:
+        mtu: "6000"
+    7000:
+        mtu: "7000"
+    8000:
+        mtu: "8000"
+    9000:
+        mtu: "9000"

--- a/io/net/bonding.py.data/bonding_mode4.yaml
+++ b/io/net/bonding.py.data/bonding_mode4.yaml
@@ -1,0 +1,28 @@
+bonding_mode: "4"
+bond_interfaces: ""
+peer_ip: ""
+peer_interfaces: ""
+bond_name: "bondtest"
+user_name: "root"
+peer_bond_needed: False 
+peer_wait_time: "10"
+sleep_time: "5"
+mtu: !mux
+    1500:
+        mtu: "1500"
+    2000:
+        mtu: "2000"
+    3000:
+        mtu: "3000"
+    4000:
+        mtu: "4000"
+    5000:
+        mtu: "5000"
+    6000:
+        mtu: "6000"
+    7000:
+        mtu: "7000"
+    8000:
+        mtu: "8000"
+    9000:
+        mtu: "9000"


### PR DESCRIPTION
differnt yaml files are also added to the list to address
different scenario based testing for mode 0,1, and 4
Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>