### PR TITLE
Enable ndctl selftest from source

### DIFF
--- a/memory/ndctl_selftest.py
+++ b/memory/ndctl_selftest.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2019 IBM
+# Author: Harish <harish@linux.vnet.ibm.com>
+#
+#
+
+import os
+import json
+
+from avocado import Test
+from avocado import main
+from avocado.utils import process, build, distro, git
+from avocado.utils.software_manager import SoftwareManager
+
+
+class NdctlTest(Test):
+    """
+    Ndctl is a user space tool to manage persistent memory devices
+    This test uses the selftests of the userspace tool to sanity check the
+    persistent memory
+    """
+
+    def get_bus_ids(self):
+        """
+        Get the provider IDs for each pmem device
+        """
+        bus_ids = []
+        os.chdir(self.sourcedir)
+        json_op = json.loads(process.system_output(
+            './ndctl/ndctl list -B', shell=True))
+        for nid in json_op:
+            for key, value in nid.items():
+                if key == 'provider':
+                    bus_ids.append(value)
+        return bus_ids
+
+    def setUp(self):
+        """
+        Prequisite for ndctl selftest on non-NFIT devices
+        """
+        smg = SoftwareManager()
+        self.url = self.params.get(
+            'url', default="https://github.com/pmem/ndctl.git")
+        self.branch = self.params.get('branch', default='master')
+        deps = ['gcc', 'make', 'automake', 'autoconf', 'patch']
+        detected_distro = distro.detect()
+        if 'SuSE' in detected_distro.name:
+            deps.extend(['ruby2.5-rubygem-asciidoctor', 'libtool',
+                         'libkmod-devel', 'libudev-devel', 'keyutils-devel',
+                         'libuuid-devel-static', 'libjson-c-devel',
+                         'systemd-devel', 'kmod-bash-completion'])
+        else:
+            # TODO: Add RHEL when support arrives
+            self.cancel('Unsupported OS %s' % detected_distro.name)
+
+        for package in deps:
+            if not smg.check_installed(package) and not smg.install(package):
+                self.cancel(
+                    "Fail to install %s required for this test." % (package))
+
+        git.get_repo(self.url, branch=self.branch,
+                     destination_dir=self.teststmpdir)
+
+        self.sourcedir = self.teststmpdir
+        os.chdir(self.sourcedir)
+
+        # TODO: remove patches once merged upstream
+        upstream_patch = self.fetch_asset("upstream.patch", locations=[
+            "https://patchwork.kernel.org/series/177255/mbox/"], expire='7d')
+
+        process.run('patch -p1 < %s' % upstream_patch, shell=True)
+        if detected_distro.arch in ["ppc64", "ppc64le"]:
+            process.run('patch -p1 < %s' %
+                        self.get_data('ppc.patch'), shell=True)
+
+        process.run('./autogen.sh', sudo=True, shell=True)
+        process.run(
+            "./configure CFLAGS='-g -O2' --prefix=/usr "
+            "--sysconfdir=/etc --libdir=/usr/lib64 "
+            "--enable-destructive", shell=True, sudo=True)
+
+        build.make(self.sourcedir)
+
+        bus_ids = self.get_bus_ids()
+        os.environ['WITHOUT_NFIT'] = "y"
+        os.environ['BUS_PROVIDER0'] = bus_ids[0]
+        if len(bus_ids) > 1:
+            os.environ['BUS_PROVIDER1'] = bus_ids[1]
+
+    def test(self):
+        """
+        Selftests for non-NFIT devices
+        """
+        self.log.info("Running NDCTL selftests")
+        failed_tests = []
+        output = build.run_make(
+            self.sourcedir, extra_args='check -j 1', process_kwargs={"ignore_status": True})
+        for line in output.stdout.decode('utf-8').splitlines():
+            if "Testsuite summary" in line:
+                break
+            if "PASS" in line:
+                self.log.info("Passed test %s", line)
+            if "FAIL" in line:
+                failed_tests.append(line)
+        if failed_tests:
+            self.fail("%s" % failed_tests)
+
+
+if __name__ == "__main__":
+    main()

--- a/memory/ndctl_selftest.py.data/ndctl_selftest.yaml
+++ b/memory/ndctl_selftest.py.data/ndctl_selftest.yaml
@@ -1,0 +1,3 @@
+config:
+    url:
+    branch:

--- a/memory/ndctl_selftest.py.data/ppc.patch
+++ b/memory/ndctl_selftest.py.data/ppc.patch
@@ -1,0 +1,153 @@
+diff --git a/test/btt-check.sh b/test/btt-check.sh
+index c91a5ad..f601412 100755
+--- a/test/btt-check.sh
++++ b/test/btt-check.sh
+@@ -33,11 +33,11 @@ trap 'err $LINENO' ERR
+ #   "blockdev":"pmem5s"
+ # }
+ 
+-check_min_kver "4.14" || do_skip "may not support badblocks clearing on pmem via btt"
++check_min_kver "4.12" || do_skip "may not support badblocks clearing on pmem via btt"
+ 
+ create()
+ {
+-	json=$($NDCTL create-namespace -b $TEST_BUS0 -t pmem -m sector)
++	json=$($NDCTL create-namespace -b $TEST_BUS0 -t pmem -m sector -s 1G)
+ 	rc=2
+ 	eval "$(echo "$json" | json2var)"
+ 	[ -n "$dev" ] || err "$LINENO"
+@@ -166,7 +166,10 @@ do_tests()
+ }
+ 
+ # setup (reset nfit_test dimms, create the BTT namespace)
+-modprobe nfit_test
++if [ -z "$WITHOUT_NFIT" ]; then
++    modprobe nfit_test
++fi
++
+ rc=1
+ reset && create
+ do_tests
+diff --git a/test/create.sh b/test/create.sh
+index afc34ac..a5133b2 100755
+--- a/test/create.sh
++++ b/test/create.sh
+@@ -38,6 +38,10 @@ dev="x"
+ json=$($NDCTL create-namespace -b $TEST_BUS0 -t pmem -m raw)
+ eval $(echo $json | json2var )
+ [ $dev = "x" ] && echo "fail: $LINENO" && exit 1
++echo 1 > /sys/bus/nd/devices/$dev/force_raw
++cat /sys/bus/nd/devices/$dev/force_raw
++json=$($NDCTL list -n $dev)
++eval $(echo $json | json2var )
+ [ $mode != "raw" ] && echo "fail: $LINENO" &&  exit 1
+ 
+ # convert pmem to fsdax mode
+@@ -56,9 +60,12 @@ $NDCTL destroy-namespace -f $dev
+ 
+ # create blk
+ dev="x"
+-json=$($NDCTL create-namespace -b $TEST_BUS0 -t blk -m raw -v)
++json=$($NDCTL create-namespace -b $TEST_BUS0 -t pmem -m raw -v)
+ eval $(echo $json | json2var)
+ [ $dev = "x" ] && echo "fail: $LINENO" && exit 1
++echo 1 > /sys/bus/nd/devices/$dev/force_raw
++json=$($NDCTL list -n $dev)
++eval $(echo $json | json2var )
+ [ $mode != "raw" ] && echo "fail: $LINENO" &&  exit 1
+ 
+ # convert blk to sector mode
+diff --git a/test/max_available_extent_ns.sh b/test/max_available_extent_ns.sh
+index 5701195..b18571c 100755
+--- a/test/max_available_extent_ns.sh
++++ b/test/max_available_extent_ns.sh
+@@ -9,7 +9,7 @@ rc=77
+ 
+ trap 'err $LINENO' ERR
+ 
+-check_min_kver "4.19" || do_skip "kernel $KVER may not support max_available_size"
++check_min_kver "4.12" || do_skip "kernel $KVER may not support max_available_size"
+ 
+ init()
+ {
+@@ -28,7 +28,7 @@ do_test()
+ 	NS=()
+ 	for ((i=0; i<3; i++))
+ 	do
+-		NS[$i]=$($NDCTL create-namespace -r $region -t pmem -s $size | jq -r .dev)
++		NS[$i]=$($NDCTL create-namespace -r $region -t pmem -s $size -a 64k | jq -r .dev)
+ 		[[ -n ${NS[$i]} ]]
+ 	done
+ 
+@@ -38,7 +38,10 @@ do_test()
+ 	$NDCTL create-namespace -r $region -t pmem
+ }
+ 
+-modprobe nfit_test
++if [ -z "$WITHOUT_NFIT" ]; then
++    modprobe nfit_test
++fi
++
+ rc=1
+ init
+ do_test
+diff --git a/test/multi-dax.sh b/test/multi-dax.sh
+index 1dca352..f77f992 100755
+--- a/test/multi-dax.sh
++++ b/test/multi-dax.sh
+@@ -17,12 +17,15 @@ rc=77
+ 
+ . ./common
+ 
+-check_min_kver "4.13" || do_skip "may lack multi-dax support"
++check_min_kver "4.12" || do_skip "may lack multi-dax support"
+ 
+ trap 'err $LINENO' ERR
+ 
+ # setup (reset nfit_test dimms)
+-modprobe nfit_test
++if [ -z "$WITHOUT_NFIT" ]; then
++    modprobe nfit_test
++fi
++
+ $NDCTL disable-region -b $TEST_BUS0 all
+ $NDCTL zero-labels -b $TEST_BUS0 all
+ $NDCTL enable-region -b $TEST_BUS0 all
+@@ -31,9 +34,9 @@ rc=1
+ query=". | sort_by(.available_size) | reverse | .[0].dev"
+ region=$($NDCTL list -b $TEST_BUS0 -t pmem -Ri | jq -r "$query")
+ 
+-json=$($NDCTL create-namespace -b $TEST_BUS0 -r $region -t pmem -m devdax -a 4096 -s 16M)
++json=$($NDCTL create-namespace -b $TEST_BUS0 -r $region -t pmem -m devdax -a 65536 -s 64M)
+ chardev1=$(echo $json | jq ". | select(.mode == \"devdax\") | .daxregion.devices[0].chardev")
+-json=$($NDCTL create-namespace -b $TEST_BUS0 -r $region -t pmem -m devdax -a 4096 -s 16M)
++json=$($NDCTL create-namespace -b $TEST_BUS0 -r $region -t pmem -m devdax -a 65536 -s 64M)
+ chardev2=$(echo $json | jq ". | select(.mode == \"devdax\") | .daxregion.devices[0].chardev")
+ 
+ _cleanup
+diff --git a/test/rescan-partitions.sh b/test/rescan-partitions.sh
+index 5e01665..b880e1b 100755
+--- a/test/rescan-partitions.sh
++++ b/test/rescan-partitions.sh
+@@ -20,7 +20,7 @@ trap 'err $LINENO' ERR
+ #  "blockdev":"pmem5s",
+ #}
+ 
+-check_min_kver "4.16" || do_skip "may not contain fixes for partition rescanning"
++check_min_kver "4.12" || do_skip "may not contain fixes for partition rescanning"
+ 
+ check_prereq "parted"
+ check_prereq "blockdev"
+@@ -72,7 +72,11 @@ test_mode()
+ 	$NDCTL destroy-namespace $dev
+ }
+ 
+-modprobe nfit_test
++# setup (reset nfit_test dimms)
++if [ -z "$WITHOUT_NFIT" ]; then
++    modprobe nfit_test
++fi
++
+ rc=1
+ reset
+ test_mode "raw"


### PR DESCRIPTION
Patch enables functional verification test for non-NFIT NVDIMM devices from ndctl source. This patch internally patches source with yet-to-be-upstream accepted proposal to run on non-NFIT devices. Once accepted the patching process would be removed from the test.

Signed-off-by: Harish <harish@linux.ibm.com>