### PR TITLE
[Backport]lshw.py : Corrected indentation error for lshw_options

### DIFF
--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -211,7 +211,7 @@ class Lshwrun(Test):
             if not self.run_cmd_out("lshw"
                                     " -numeric | grep HCI | cut -d':' -f3"):
                 self.is_fail += 1
-            self.fail_cmd.append("lshw -numeric | grep HCI | cut -d':' -f3")
+                self.fail_cmd.append("lshw -numeric | grep HCI | cut -d':' -f3")
         self.error_check()
 
     @skipIf(process.system("lshw --help 2>&1 |grep notime",


### PR DESCRIPTION
lshw -numeric command returns fail even it completes
succesfully, that is because of indentation error in loop.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>