### PR TITLE
enabled Travis for py2-lts as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 branches:
     only:
         - master
+        - py2-lts
 
 cache:
     directories:


### PR DESCRIPTION
as ealier travis not enabled for py2-lts this patch enable same
as well run against python2.7

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>