### PR TITLE
[Backport] Correct memtester yaml file

### DIFF
--- a/memory/memtester.py.data/memtester.yaml
+++ b/memory/memtester.py.data/memtester.yaml
@@ -1,7 +1,8 @@
 test_memster:
     memtest_opt:
         runs: 1
-        memory: '1G'
+        # NOTE: Specify in MB
+        memory: 1024
         # NOTE: Provide page boundary address
-        physaddr: 0x100000
-        device: '/dev/mem'
+        physaddr:
+        device:


### PR DESCRIPTION
Patch fixes a minor issue with yaml default inputs '1G' which is a string compared with an integer value. Hence making the input an integer, adding a NOTE explicitly and emptying other inputs to
be used on need basis.

Signed-off-by: Harish <harish@linux.ibm.com>