### PR TITLE
Multiple enhancements to DLPAR, LPM and virt-net tests

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -155,7 +155,8 @@ class LPM(Test):
         '''
         for line in process.system_output('lsrsrc IBM.MCP %s' % component,
                                           ignore_status=True, shell=True,
-                                          sudo=True).splitlines():
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
         return ''
@@ -167,7 +168,9 @@ class LPM(Test):
         '''
 
         for line in process.system_output('lparstat -i', ignore_status=True,
-                                          shell=True, sudo=True).splitlines():
+                                          shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
             if component in line:
                 return line.split(':')[-1].strip()
         return ''
@@ -176,7 +179,7 @@ class LPM(Test):
         '''
         SSH Login method for remote server
         '''
-        pxh = pxssh.pxssh()
+        pxh = pxssh.pxssh(encoding='utf-8')
         # Work-around for old pxssh not having options= parameter
         pxh.SSH_OPTS = pxh.SSH_OPTS + " -o 'StrictHostKeyChecking=no'"
         pxh.SSH_OPTS = pxh.SSH_OPTS + " -o 'UserKnownHostsFile /dev/null' "
@@ -219,7 +222,7 @@ class LPM(Test):
             self.fail("Starting service %s failed", svc)
 
         output = process.system_output("lssrc -a", ignore_status=True,
-                                       shell=True, sudo=True)
+                                       shell=True, sudo=True).decode("utf-8")
         if "inoperative" in output:
             self.fail("Failed to start the rsct and rsct_rm services")
 

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -74,9 +74,9 @@ class LPM(Test):
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
         self.options = self.params.get("options", default='')
 
-        self.lpar = self.get_mcp_component("NodeNameList").split('.')[0]
+        self.lpar = self.get_partition_name("Partition Name")
         if not self.lpar:
-            self.cancel("LPAR Name not got from lsrsrc command")
+            self.cancel("LPAR Name not got from lparstat command")
 
         self.login(self.hmc_ip, self.hmc_user, self.hmc_pwd)
         cmd = 'lssyscfg -r sys -F name'
@@ -158,6 +158,18 @@ class LPM(Test):
                                           sudo=True).splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_partition_name(component):
+        '''
+        get partition name from lparstat -i
+        '''
+
+        for line in process.system_output('lparstat -i', ignore_status=True,
+                                          shell=True, sudo=True).splitlines():
+            if component in line:
+                return line.split(':')[-1].strip()
         return ''
 
     def login(self, ipaddr, username, password):

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -184,7 +184,9 @@ class NetworkVirtualization(Test):
         '''
 
         for line in process.system_output('lparstat -i', ignore_status=True,
-                                          shell=True, sudo=True).splitlines():
+                                          shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
             if component in line:
                 return line.split(':')[-1].strip()
         return ''

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -81,9 +81,9 @@ class NetworkVirtualization(Test):
             self.cancel("HMC IP not got")
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default=None)
         self.hmc_username = self.params.get("hmc_username", '*', default=None)
-        self.lpar = self.get_mcp_component("NodeNameList").split('.')[0]
+        self.lpar = self.get_partition_name("Partition Name")
         if not self.lpar:
-            self.cancel("LPAR Name not got from lsrsrc command")
+            self.cancel("LPAR Name not got from lparstat command")
         self.login(self.hmc_ip, self.hmc_username, self.hmc_pwd)
         cmd = 'lssyscfg -r sys  -F name'
         output = self.run_command(cmd)
@@ -175,6 +175,18 @@ class NetworkVirtualization(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_partition_name(component):
+        '''
+        get partition name from lparstat -i
+        '''
+
+        for line in process.system_output('lparstat -i', ignore_status=True,
+                                          shell=True, sudo=True).splitlines():
+            if component in line:
+                return line.split(':')[-1].strip()
         return ''
 
     def login(self, ipaddr, username, password):

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -296,6 +296,11 @@ class NetworkVirtualization(Test):
                 self.log.debug(output)
                 self.fail("lshwres fails to list Network virtualized device \
                            after add operation")
+            if mac not in str(output):
+                self.log.debug(output)
+                self.fail("MAC address in HMC differs")
+            if not self.find_device(mac):
+                self.fail("MAC address differs in linux")
             self.configure_device(device_ip, netmask, mac)
 
     def test_backingdevadd(self):
@@ -621,6 +626,7 @@ class NetworkVirtualization(Test):
         for device in devices:
             if mac in netifaces.ifaddresses(device)[17][0]['addr']:
                 return device
+        return ''
 
     def interfacewait(self, mac):
         """

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -68,9 +68,9 @@ class DlparPci(Test):
             self.cancel("HMC IP not got")
         self.hmc_user = self.params.get("hmc_username", default='hscroot')
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
-        self.lpar_1 = self.get_mcp_component("NodeNameList")
+        self.lpar_1 = self.get_partition_name("Partition Name")
         if not self.lpar_1:
-            self.cancel("LPAR Name not got")
+            self.cancel("LPAR Name not got from lparstat command")
         self.login(self.hmc_ip, self.hmc_user, self.hmc_pwd)
         cmd = 'lssyscfg -r sys  -F name'
         output = self.run_command(cmd)
@@ -118,6 +118,18 @@ class DlparPci(Test):
                                           sudo=True).decode("utf-8").splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_partition_name(component):
+        '''
+        get partition name from lparstat -i
+        '''
+
+        for line in process.system_output('lparstat -i', ignore_status=True,
+                                          shell=True, sudo=True).splitlines():
+            if component in line:
+                return line.split(':')[-1].strip()
         return ''
 
     def login(self, ip_addr, username, password):


### PR DESCRIPTION
Handling lpar name via lparstat command since it is better.
The previous method of lsrsrc had a prerequisite of hostname to
be set properly, which was not consistent.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>