### PR TITLE
dynamic SMT value and Hugepage memory tests

### DIFF
--- a/cpu/em_cpuhotplug.py
+++ b/cpu/em_cpuhotplug.py
@@ -51,12 +51,10 @@ class Cpuhotplug_Test(Test):
                       % (self.T_CORES, self.THREADS))
 
         genio.write_one_line('/proc/sys/kernel/printk', "8")
-        self.max_smt = 4
-        if cpu.get_cpu_arch().lower() == 'power8':
-            self.max_smt = 8
-        if cpu.get_cpu_arch().lower() == 'power6':
-            self.max_smt = 2
-        process.system("ppc64_cpu --smt=%s" % self.max_smt, shell=True)
+        # Set SMT to max SMT value (restricted at boot time) and get its value
+        process.system("ppc64_cpu --smt=%s" % "on", shell=True)
+        self.max_smt_s=process.system_output("ppc64_cpu --smt", shell=True).decode()
+        self.max_smt = int(self.max_smt_s[4:])
         self.path = "/sys/devices/system/cpu"
 
     def clear_dmesg(self):

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -45,7 +45,10 @@ class PPC64Test(Test):
         if SoftwareManager().check_installed("powerpc-utils") is False:
             if SoftwareManager().install("powerpc-utils") is False:
                 self.cancel("powerpc-utils is not installing")
-        self.smt_str = "ppc64_cpu --smt"
+        self.smt_str = "ppc64_cpu --smt
+        # Dynamically set max SMT specified at boot time
+        process.system("%s=on" % self.smt_str, shell=True)
+        # and get its value
         smt_op = process.system_output(self.smt_str, shell=True).decode()
         if "is not SMT capable" in smt_op:
             self.cancel("Machine is not SMT capable")
@@ -61,14 +64,7 @@ class PPC64Test(Test):
         self.smt_values = {1: "off"}
         self.key = 0
         self.value = ""
-        self.max_smt_value = 4
-        if cpu.get_cpu_arch().lower() == 'power9':
-            if 'Hash' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0'):
-                self.max_smt_value = 8
-        if cpu.get_cpu_arch().lower() == 'power8':
-            self.max_smt_value = 8
-        if cpu.get_cpu_arch().lower() == 'power6':
-            self.max_smt_value = 2
+        self.max_smt_value =  int(self.curr_smt)
 
     def equality_check(self, test_name, cmd1, cmd2):
         """
@@ -89,7 +85,7 @@ class PPC64Test(Test):
         """
         Sets the SMT value, and calls each of the test, for each value.
         """
-        for i in range(2, self.max_smt_value + 1):
+        for i in range(2, self.max_smt_value):
             self.smt_values[i] = str(i)
         for self.key, self.value in self.smt_values.items():
             process.system_output("%s=%s" % (self.smt_str,

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -21,7 +21,7 @@ import os
 import glob
 
 from avocado import Test
-from avocado import main
+from avocado import main, skipUnless
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import kernel
@@ -40,6 +40,8 @@ class LibHugetlbfs(Test):
     :avocado: tags=memory,privileged,hugepage
     '''
 
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                "Hugepagesize not defined in kernel.")
     def setUp(self):
 
         # Check for basic utilities

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -18,7 +18,7 @@
 import os
 from avocado import Test
 from avocado import main
-from avocado import skipIf
+from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.core import data_dir
@@ -38,6 +38,9 @@ class Thp(Test):
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                "Hugepagesize not defined in kernel.")
+        
     def setUp(self):
         '''
         Sets all the reqd parameter and also

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -21,7 +21,7 @@ import mmap
 import avocado
 from avocado import Test
 from avocado import main
-from avocado import skipIf
+from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.utils import disk
@@ -42,6 +42,9 @@ class ThpDefrag(Test):
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                      "Hugepagesize not defined in kernel.")
+    
     def setUp(self):
         '''
         Sets required params for dd workload and mounts the tmpfs

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -19,7 +19,7 @@
 import os
 from avocado import Test
 from avocado import main
-from avocado import skipIf
+from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.core import data_dir
@@ -38,6 +38,9 @@ class ThpSwapping(Test):
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                      "Hugepagesize not defined in kernel.")
+    
     def setUp(self):
         '''
         Sets the Required params for dd and mounts the tmpfs dir


### PR DESCRIPTION
Default arch SMT is not necessary the on defined at boot time
So we need to dynamically set the SMT to its max with ppc64_cpu --smt=on and retrieve its values
Memory Hugepage tests must be skipped if not defined in kernel

Signed-off-by: Thierry  tfauck@free.fr