### PR TITLE
SMT can be restricted at boot time

### DIFF
--- a/cpu/em_cpuhotplug.py
+++ b/cpu/em_cpuhotplug.py
@@ -53,7 +53,7 @@ class Cpuhotplug_Test(Test):
         genio.write_one_line('/proc/sys/kernel/printk', "8")
         # Set SMT to max SMT value (restricted at boot time) and get its value
         process.system("ppc64_cpu --smt=%s" % "on", shell=True)
-        self.max_smt_s=process.system_output("ppc64_cpu --smt", shell=True).decode()
+        self.max_smt_s = process.system_output("ppc64_cpu --smt", shell=True).decode()
         self.max_smt = int(self.max_smt_s[4:])
         self.path = "/sys/devices/system/cpu"
 

--- a/cpu/em_cpuhotplug.py
+++ b/cpu/em_cpuhotplug.py
@@ -51,12 +51,10 @@ class Cpuhotplug_Test(Test):
                       % (self.T_CORES, self.THREADS))
 
         genio.write_one_line('/proc/sys/kernel/printk', "8")
-        self.max_smt = 4
-        if cpu.get_cpu_arch().lower() == 'power8':
-            self.max_smt = 8
-        if cpu.get_cpu_arch().lower() == 'power6':
-            self.max_smt = 2
-        process.system("ppc64_cpu --smt=%s" % self.max_smt, shell=True)
+        # Set SMT to max SMT value (restricted at boot time) and get its value
+        process.system("ppc64_cpu --smt=%s" % "on", shell=True)
+        self.max_smt_s=process.system_output("ppc64_cpu --smt", shell=True).decode()
+        self.max_smt = int(self.max_smt_s[4:])
         self.path = "/sys/devices/system/cpu"
 
     def clear_dmesg(self):

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -46,6 +46,9 @@ class PPC64Test(Test):
             if SoftwareManager().install("powerpc-utils") is False:
                 self.cancel("powerpc-utils is not installing")
         self.smt_str = "ppc64_cpu --smt"
+        # Dynamically set max SMT specified at boot time
+        process.system("%s=on" % self.smt_str, shell=True)
+        # and get its value
         smt_op = process.system_output(self.smt_str, shell=True).decode()
         if "is not SMT capable" in smt_op:
             self.cancel("Machine is not SMT capable")
@@ -61,14 +64,7 @@ class PPC64Test(Test):
         self.smt_values = {1: "off"}
         self.key = 0
         self.value = ""
-        self.max_smt_value = 4
-        if cpu.get_cpu_arch().lower() == 'power9':
-            if 'Hash' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0'):
-                self.max_smt_value = 8
-        if cpu.get_cpu_arch().lower() == 'power8':
-            self.max_smt_value = 8
-        if cpu.get_cpu_arch().lower() == 'power6':
-            self.max_smt_value = 2
+        self.max_smt_value = int(self.curr_smt)
 
     def equality_check(self, test_name, cmd1, cmd2):
         """


### PR DESCRIPTION
As SMT can be restricted at boot time test must retrieve that max_smt value dynamically.
So using ppc64_cpu --smt=on to get the max value

Signed-off-by: Thierry tfauck@free.fr