### PR TITLE
Hugepage may not be defined in kernel

### DIFF
--- a/memory/hugepage_sanity.py
+++ b/memory/hugepage_sanity.py
@@ -19,7 +19,7 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main
+from avocado import main, skipUnless
 from avocado.utils import process, build, memory
 from avocado.utils.software_manager import SoftwareManager
 
@@ -36,6 +36,8 @@ class HugepageSanity(Test):
         shutil.copyfile(self.get_data(file_name),
                         os.path.join(self.teststmpdir, file_name))
 
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                "Hugepagesize not defined in kernel.")
     def setUp(self):
         smm = SoftwareManager()
         self.hpagesize = int(self.params.get('hpagesize', default=memory.get_huge_page_size()/1024))

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -21,7 +21,7 @@ import os
 import glob
 
 from avocado import Test
-from avocado import main
+from avocado import main, skipUnless
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import kernel
@@ -40,6 +40,8 @@ class LibHugetlbfs(Test):
     :avocado: tags=memory,privileged,hugepage
     '''
 
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                "Hugepagesize not defined in kernel.")
     def setUp(self):
 
         # Check for basic utilities

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -18,7 +18,7 @@
 import os
 from avocado import Test
 from avocado import main
-from avocado import skipIf
+from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.core import data_dir
@@ -38,6 +38,8 @@ class Thp(Test):
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                "Hugepagesize not defined in kernel.")
     def setUp(self):
         '''
         Sets all the reqd parameter and also

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -21,7 +21,7 @@ import mmap
 import avocado
 from avocado import Test
 from avocado import main
-from avocado import skipIf
+from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.utils import disk
@@ -42,6 +42,8 @@ class ThpDefrag(Test):
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                "Hugepagesize not defined in kernel.")
     def setUp(self):
         '''
         Sets required params for dd workload and mounts the tmpfs

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -19,7 +19,7 @@
 import os
 from avocado import Test
 from avocado import main
-from avocado import skipIf
+from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.core import data_dir
@@ -38,6 +38,8 @@ class ThpSwapping(Test):
     '''
 
     @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipUnless('Hugepagesize' in dict(memory.meminfo),
+                "Hugepagesize not defined in kernel.")
     def setUp(self):
         '''
         Sets the Required params for dd and mounts the tmpfs dir


### PR DESCRIPTION
When Hugepage is not defined in kernel, memory.hugepage() is not defined -
Skipping test on that platform

Signed-off-by: thierry <tfauck@free.fr>