### PR TITLE
lvsetup: moving fs creation out of lv_create

### DIFF
--- a/io/disk/lvsetup.py.data/lvsetup_single.yaml
+++ b/io/disk/lvsetup.py.data/lvsetup_single.yaml
@@ -1,5 +1,6 @@
 # btrfs needs minimum LV size of 641M
 lv_disks:
 lv_size:
+vg_name:
 lv_name:
 fs: xfs


### PR DESCRIPTION
Moving filesystem creation out of lv_create, so that only the
tests that need filesystem creates it.
Some variable name changes go along with it as enhancements.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>