### PR TITLE
Allow 2.7 failure in travis as this repo will hold good for python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+matrix:
+  allow_failures:
+        - python: "2.7"
+
 python:
     - "2.7" #will remove when whole repo moved to python3
     - "3.4"


### PR DESCRIPTION
Allow 2.7 failure as this repo will hold good for python3

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>