### PR TITLE
Add pre-req for some distro

### DIFF
--- a/generic/connectathon.py
+++ b/generic/connectathon.py
@@ -56,7 +56,8 @@ class Connectathon(Test):
 
         if detected_distro.name == "SuSE":
             packages.extend(['git-core'])
-
+        elif detected_distro.name == "centos":
+            packages.extend(['libtirpc-devel'])
         else:
             packages.extend(['git'])
 

--- a/generic/openblas.py
+++ b/generic/openblas.py
@@ -34,7 +34,7 @@ class Openblas(Test):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         packages = ['make', 'gcc']
-        if detected_distro.name == "Ubuntu":
+        if detected_distro.name in ["Ubuntu", 'debian']:
             packages.append("gfortran")
         elif detected_distro.name == "SuSE":
             packages.extend(["gcc-fortran", "libgfortran4"])


### PR DESCRIPTION
Missing pre-req libtirpc for centos and fedora prevented compiling

Signed-off-by: Thierry <tfauck@free.fr>