### PR TITLE
   Fix some lshw powerpc behaviour

### DIFF
--- a/ras/kprobe.py
+++ b/ras/kprobe.py
@@ -62,7 +62,7 @@ class Kprobe(Test):
         smg = SoftwareManager()
         detected_distro = distro.detect()
         deps = ['gcc', 'make', 'automake', 'autoconf', 'time', 'bison', 'flex']
-        if 'Ubuntu' in detected_distro.name:
+        if detected_distro.name in ['Ubuntu', 'debian']:
             linux_headers = 'linux-headers-%s' % os.uname()[2]
             deps.extend(['libpopt0', 'libc6', 'libc6-dev', 'libpopt-dev',
                          'libcap-ng0', 'libcap-ng-dev', 'elfutils', 'libelf1',

--- a/ras/kretprobe.py
+++ b/ras/kretprobe.py
@@ -55,7 +55,7 @@ class Kretprobe(Test):
         smg = SoftwareManager()
         detected_distro = distro.detect()
         deps = ['gcc', 'make', 'automake', 'autoconf', 'time', 'bison', 'flex']
-        if 'Ubuntu' in detected_distro.name:
+        if detected_distro.name in ['Ubuntu', 'debian']:
             linux_headers = 'linux-headers-%s' % os.uname()[2]
             deps.extend(['libpopt0', 'libc6', 'libc6-dev', 'libpopt-dev',
                          'libcap-ng0', 'libcap-ng-dev', 'elfutils', 'libelf1',


### PR DESCRIPTION
    lshw --numeric |grep HCI make sense only if USB enabled
    lshw --class network doesn't get the ip name
    add check on ppc64el and ppc64le

Signed-off-by: Thierry <tfauck@free.fr>