### PR TITLE
ndctl.py: Fixes and enhancements

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -444,20 +444,22 @@ class NdctlTest(Test):
         self.disable_namespace()
         self.destroy_namespace()
         for val in regions:
+            ns_size = None
             region = self.get_json_val(val, 'dev')
             self.log.info("Using %s for muliple namespaces", region)
             self.log.info("Creating %s namespaces", self.cnt)
             if not self.size:
-                self.size = self.get_json_val(self.get_json(
+                ns_size = self.get_json_val(self.get_json(
                     '-r %s' % region)[0], 'size')
-                ch_cnt = self.get_aligned_count(self.size)
-                self.size = self.size // ch_cnt
+                ch_cnt = self.get_aligned_count(ns_size)
+                ns_size = ns_size // ch_cnt
             else:
                 # Assuming size is aligned
+                ns_size = self.size
                 ch_cnt = self.cnt
             for nid in range(0, ch_cnt):
                 self.create_namespace(
-                    region=region, mode=self.mode_to_use, size=self.size)
+                    region=region, mode=self.mode_to_use, size=ns_size)
                 self.log.info("Namespace %s created", nid + 1)
 
     def test_nslot_namespace(self):

--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -258,6 +258,7 @@ class NdctlTest(Test):
         if not self.check_buses():
             self.cancel("Test needs atleast one region")
 
+        self.smm = SoftwareManager()
         if self.package == 'upstream':
             deps.extend(['gcc', 'make', 'automake', 'autoconf'])
             if self.dist.name == 'SuSE':
@@ -265,6 +266,10 @@ class NdctlTest(Test):
                              'libkmod-devel', 'libudev-devel',
                              'libuuid-devel-static', 'libjson-c-devel',
                              'systemd-devel', 'kmod-bash-completion'])
+            for pkg in deps:
+                if not self.smm.check_installed(pkg) and not \
+                        self.smm.install(pkg):
+                    self.cancel('%s is needed for the test to be run' % pkg)
 
             locations = ["https://github.com/pmem/ndctl/archive/master.zip"]
             tarball = self.fetch_asset("ndctl.zip", locations=locations,
@@ -279,15 +284,13 @@ class NdctlTest(Test):
             self.binary = './ndctl/ndctl'
             self.daxctl = './daxctl/daxctl'
         else:
-            deps.extend(['ndctl', 'daxctl'])
+            for pkg in ['ndctl', 'daxctl']:
+                if not self.smm.check_installed(pkg) and not \
+                        self.smm.install(pkg):
+                    self.cancel('%s is needed for the test to be run' % pkg)
             self.binary = 'ndctl'
             self.daxctl = 'daxctl'
 
-        self.smm = SoftwareManager()
-        for pkg in deps:
-            if not self.smm.check_installed(pkg) and not \
-                    self.smm.install(pkg):
-                self.cancel('%s is needed for the test to be run' % pkg)
         self.opt_dict = {'-B': 'provider',
                          '-D': 'dev', '-R': 'dev', '-N': 'dev'}
         self.modes = ['raw', 'sector', 'fsdax', 'devdax']

--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -279,7 +279,7 @@ class NdctlTest(Test):
             self.binary = './ndctl/ndctl'
             self.daxctl = './daxctl/daxctl'
         else:
-            deps.extend(['ndctl'])
+            deps.extend(['ndctl', 'daxctl'])
             self.binary = 'ndctl'
             self.daxctl = 'daxctl'
 


### PR DESCRIPTION
1) Add daxctl package for running DAX test
Patch adds daxctl package for running DAX test

2) Fix: Install packages before configuring ndctl
Patch fixes packages installation before configuring ndctl repo

3) Add support to run test on RHEL distribution
Add support to run ndctl test on RHEL distribution

4) Fix: namespace creation size with multiple regions
Current implementation overwrites size on first iteration and uses the same for all regions. hence replacing the variable with a proper persistence.

Signed-off-by: Harish <harish@linux.ibm.com>