### PR TITLE
bug fix for tcpdump.py by including nmap package 

### DIFF
--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -70,7 +70,7 @@ class TcpdumpTest(Test):
         # Install needed packages
         smm = SoftwareManager()
         detected_distro = distro.detect()
-        pkgs = ['tcpdump', 'flex', 'bison', 'gcc', 'gcc-c++']
+        pkgs = ['tcpdump', 'flex', 'bison', 'gcc', 'gcc-c++', 'nmap']
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel("%s package Can not install" % pkg)


### PR DESCRIPTION
tcpdump requires nmap package to be istalled to run
nping

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>