### PR TITLE
Enable libhugetlbfs test to run with available pages

### DIFF
--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -190,8 +190,12 @@ class LibHugetlbfs(Test):
     def test(self):
         os.chdir(self.workdir)
 
+        functional_test = self.params.get('functional_test', default=False)
+        test_type = 'check'
+        if functional_test:
+            test_type = 'func'
         run_log = build.run_make(
-            self.workdir, extra_args='BUILDTYPE=NATIVEONLY check',
+            self.workdir, extra_args='BUILDTYPE=NATIVEONLY %s' % test_type,
             process_kwargs={'ignore_status': True}).stdout.decode('utf-8')
         parsed_results = []
         error = ""

--- a/memory/libhugetlbfs.py.data/libhugetlbfs.yaml
+++ b/memory/libhugetlbfs.py.data/libhugetlbfs.yaml
@@ -1,4 +1,5 @@
 setup:
+    functional_test: True
     mount_dir: !mux
         default:
             hugetlbfs_dir: null


### PR DESCRIPTION
Patch enables test to run even with fewer available pages, which would be helpful with system with lesser memory/larger page size.

Signed-off-by: Harish <harish@linux.ibm.com>