### PR TITLE
action_lapse option is invalid for -g with vnic

### DIFF
--- a/io/net/ethtool_test.py.data/ethtool_vnic_test.yaml
+++ b/io/net/ethtool_test.py.data/ethtool_vnic_test.yaml
@@ -9,7 +9,6 @@ args: !mux
         arg: -i
     RingParameter:
         arg: -g
-        action_elapse: 3
     ShowOffloadProtocolFeature:
         arg: -k
     Statistics:


### PR DESCRIPTION
removed action_lapse option from vnic yaml file, the argument
is not applicable for virtual interface

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>