### PR TITLE
uname for machine name

### DIFF
--- a/perf/unixbench.py
+++ b/perf/unixbench.py
@@ -35,7 +35,7 @@ class Unixbench(Test):
         self.tmpdir = data_dir.get_tmp_dir()
         self.report_data = self.err = None
         self.build_dir = self.params.get('build_dir', default=self.tmpdir)
-        for package in ['gcc', 'make']:
+        for package in ['gcc', 'make', 'patch']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
         url = 'https://github.com/kdlucas/byte-unixbench/archive/master.zip'
@@ -45,6 +45,8 @@ class Unixbench(Test):
         self.sourcedir = os.path.join(self.workdir,
                                       "byte-unixbench-master/UnixBench")
         os.chdir(self.sourcedir)
+        makefile_patch = 'patch -p0 < %s' % self.get_data('make1.patch')
+        process.run(makefile_patch, shell=True)
         build.make(self.sourcedir)
 
     def test(self):

--- a/perf/unixbench.py.data/make1.patch
+++ b/perf/unixbench.py.data/make1.patch
@@ -1,0 +1,11 @@
+--- Makefile.orig   2020-01-09 18:35:13.509293580 +0100
++++ Makefile    2020-01-09 18:33:49.723976623 +0100
+@@ -89,7 +89,7 @@
+ 
+   ## OS detection.  Comment out if gmake syntax not supported by other 'make'. 
+   OSNAME:=$(shell uname -s)
+-  ARCH := $(shell uname -p)
++  ARCH := $(shell uname -m)
+   ifeq ($(OSNAME),Linux)
+     # Not all CPU architectures support "-march" or "-march=native".
+     #   - Supported    : x86, x86_64, ARM, AARCH64, etc..


### PR DESCRIPTION
Add debian as distro
decode() added when necessary
test on null string fixed
upgrade valgrind release to current one

Signed-off-by: Thierry <tfauck@free.fr>