### PR TITLE
multipath_test.py fails with  bytes-like object is required, not 'str'

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -72,6 +72,8 @@ class MultipathTest(Test):
         # Check if given multipath devices are present in system
         self.wwids = self.params.get('wwids', default='').split(',')
         system_wwids = multipath.get_multipath_wwids()
+        if self.wwids == ['']:
+            self.cancel("No System Multipath Devices available")
         wwids_to_remove = []
         for wwid in self.wwids:
             if wwid not in system_wwids:

--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -72,7 +72,7 @@ class MultipathTest(Test):
         # Check if given multipath devices are present in system
         self.wwids = self.params.get('wwids', default='').split(',')
         system_wwids = multipath.get_multipath_wwids()
-        if self.wwids == ['']:
+        if system_wwids == ['']:
             self.cancel("No System Multipath Devices available")
         wwids_to_remove = []
         for wwid in self.wwids:


### PR DESCRIPTION
if self.wwids is empty call to get_multipath_wwids() fails. Check for
empty string before that call.

Signed-off-by: Thierry <tfauck@free.fr>