### PR TITLE
Fix: Memory API test to induce error through yaml

### DIFF
--- a/memory/memory_api.py
+++ b/memory/memory_api.py
@@ -43,7 +43,7 @@ class MemorySyscall(Test):
     def setUp(self):
         smm = SoftwareManager()
         self.memsize = int(self.params.get(
-            'memory_size', default=memory.meminfo.MemFree.m) * 1048576 * 0.5)
+            'memory_size', default=(memory.meminfo.MemFree.m * 0.5)) * 1048576)
         self.induce_err = self.params.get('induce_err', default=0)
 
         for package in ['gcc', 'make']:
@@ -54,7 +54,7 @@ class MemorySyscall(Test):
 
         build.make(self.teststmpdir)
 
-    def test(self):
+    def test_memapi(self):
         os.chdir(self.teststmpdir)
         proc = process.SubProcess('./memory_api %s %s' % (self.memsize, self.induce_err),
                                   shell=True, allow_output_check='both')
@@ -62,12 +62,7 @@ class MemorySyscall(Test):
         while proc.poll() is None:
             pass
 
-        ret = process.system('./memory_api %s 1' % self.memsize,
-                             shell=True, ignore_status=True)
-        if ret == 255:
-            self.log.info("Error obtained as expected")
-
-        if proc.poll() != 0:
+        if proc.poll() not in [0, 255]:
             self.fail("Unexpected application abort, check for possible issues")
 
     def test_mremap(self):

--- a/memory/memory_api.py.data/memory_api.yaml
+++ b/memory/memory_api.py.data/memory_api.yaml
@@ -1,3 +1,7 @@
 setup:
- memory_size: 10 # in MB
- induce_err: 1
+ memory_size: 100 # in MB
+ error: !mux
+     wo_err:
+         induce_err: 0
+     with_err:
+         induce_err: 1


### PR DESCRIPTION
Patch fixes memory API test to induce error through yaml and handle the same in test

Signed-off-by: Harish <harish@linux.ibm.com>