### PR TITLE
removing the static data of lpar name and made it generic.

### DIFF
--- a/io/disk/vfc-tests/vfc_dlpar.py
+++ b/io/disk/vfc-tests/vfc_dlpar.py
@@ -82,7 +82,7 @@ class VirtualFC(Test):
         output = self.run_command(cmd)
         self.server = ''
         for line in output:
-            if line in "ltcfleet2-lp10-Naresh":
+            if line in self.lpar:
                 self.server = line
         if not self.server:
             self.cancel("Managed System not got")


### PR DESCRIPTION
there was a hardcoded data in the test script, changing it
to generic thing.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>