### PR TITLE
Added decode("utf-8") for tlbflush.py and em_quad_level_frequency_tra…

### DIFF
--- a/cpu/em_quad_level_frequency_transitions.py
+++ b/cpu/em_quad_level_frequency_transitions.py
@@ -177,7 +177,7 @@ class freq_transitions(Test):
                 %s yes>/dev/null" % cpu
         output = self.run_cmd(cmd)
         self.log.info("output : %s" % output.stderr)
-        output = output.stderr.splitlines()[3].split('#')[
+        output = output.stderr.decode("utf-8").splitlines()[3].split('#')[
             1].strip().split(' ')[0]
         output = float(output) * (10 ** 6)
         return output

--- a/kernel/tlbflush.py
+++ b/kernel/tlbflush.py
@@ -84,7 +84,7 @@ class Tlbflush(Test):
 
         cmd = '%s -n %s -t %s' % (tlbflush, self.nr_entries, self.nr_threads)
 
-        out = process.system_output(cmd)
+        out = process.system_output(cmd).decode("utf-8")
 
         return out
 


### PR DESCRIPTION
…nsitions.py

Added decode("utf-8") to avoid string pattern error.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>