### PR TITLE
fixed iperf and uperf for running background command

### DIFF
--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -31,6 +31,7 @@ from avocado.utils.genio import read_file
 from avocado.utils.configure_network import PeerInfo
 from avocado.utils import configure_network
 from avocado.utils.ssh import Session
+from avocado.utils.process import SubProcess
 
 
 class Iperf(Test):
@@ -93,7 +94,9 @@ class Iperf(Test):
         self.iperf_run = str(self.params.get("IPERF_SERVER_RUN", default=0))
         if self.iperf_run == '1':
             cmd = "/tmp/%s/src/iperf -s" % self.version
-            self.session.cmd(cmd)
+            cmd = self.session.get_raw_ssh_command(cmd)
+            self.obj = SubProcess(cmd)
+            self.obj.start()
         os.chdir(self.iperf_dir)
         process.system('./configure', shell=True)
         build.make(self.iperf_dir)
@@ -125,6 +128,7 @@ class Iperf(Test):
         """
         Killing Iperf process in peer machine
         """
+        self.obj.stop()
         cmd = "pkill iperf; rm -rf /tmp/%s" % self.version
         output = self.session.cmd(cmd)
         if not output.exit_status == 0:

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -33,6 +33,7 @@ from avocado.utils.ssh import Session
 from avocado.utils.genio import read_file
 from avocado.utils.configure_network import PeerInfo
 from avocado.utils import configure_network
+from avocado.utils.process import SubProcess
 
 
 class Uperf(Test):
@@ -100,9 +101,9 @@ class Uperf(Test):
         self.uperf_run = str(self.params.get("UPERF_SERVER_RUN", default=0))
         if self.uperf_run == '1':
             cmd = "/tmp/uperf-master/src/uperf -s &"
-            output = self.session.cmd(cmd)
-            if not output.exit_status == 0:
-                self.log.debug("Command %s failed %s", cmd, output)
+            cmd = self.session.get_raw_ssh_command(cmd)
+            self.obj = SubProcess(cmd)
+            self.obj.start()
         os.chdir(self.uperf_dir)
         process.system('autoreconf -fi', shell=True)
         process.system('./configure ppc64le', shell=True)
@@ -140,6 +141,7 @@ class Uperf(Test):
         """
         Killing Uperf process in peer machine
         """
+        self.obj.stop()
         cmd = "pkill uperf; rm -rf /tmp/uperf-master"
         output = self.session.cmd(cmd)
         if not output.exit_status == 0:


### PR DESCRIPTION
fixed iperf and uperf test for running the subprocess in background.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>