### PR TITLE
multiport : add yaml file for virtual interface

### DIFF
--- a/io/net/multiport_stress.py.data/multiport_stress_virt.yaml
+++ b/io/net/multiport_stress.py.data/multiport_stress_virt.yaml
@@ -1,0 +1,12 @@
+host_interfaces: "enP4p1s0f1,enP4p1s0f2"
+peer_ips: ""
+peer_user: ""
+peer_password: ""
+count: "1100"
+host_ips: ""
+netmask: ""
+mtu: !mux
+    1500:
+        mtu: "1500"
+    9000:
+        mtu: "9000"


### PR DESCRIPTION
in case of vnic only mtu 1500 and 9000 size is supported, so added
the yaml specific to virutal interface

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>