### PR TITLE
Use pmem library to create pmem devices and run xfstests

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -270,11 +270,15 @@ class Xfstests(Test):
                     self._create_test_list(self.share_exclude, "shared",
                                            dangerous=False)
         if self.detected_distro.name is not 'SuSE':
-            process.run('useradd 123456-fsgqa', sudo=True)
-            process.run('useradd fsgqa', sudo=True)
+            if process.system('useradd 123456-fsgqa', sudo=True, ignore_status=True):
+                self.log.warn('useradd 123456-fsgqa failed')
+            if process.system('useradd fsgqa', sudo=True, ignore_status=True):
+                self.log.warn('useradd fsgqa failed')
         else:
-            process.run('useradd -m -U fsgqa', sudo=True)
-            process.run('groupadd sys', sudo=True)
+            if process.system('useradd -m -U fsgqa', sudo=True, ignore_status=True):
+                self.log.warn('useradd fsgqa failed')
+            if process.system('groupadd sys', sudo=True, ignore_status=True):
+                self.log.warn('groupadd sys failed')
         if not os.path.exists(self.scratch_mnt):
             os.makedirs(self.scratch_mnt)
         if not os.path.exists(self.test_mnt):
@@ -324,9 +328,9 @@ class Xfstests(Test):
         process.system('umount %s %s' % (self.scratch_mnt, self.test_mnt),
                        sudo=True, ignore_status=True)
         if os.path.exists(self.scratch_mnt):
-            os.rmdir(self.scratch_mnt)
+            shutil.rmtree(self.scratch_mnt)
         if os.path.exists(self.test_mnt):
-            os.rmdir(self.test_mnt)
+            shutil.rmtree(self.test_mnt)
         if self.dev_type == 'loop':
             for dev in self.devices:
                 process.system('losetup -d %s' % dev, shell=True,

--- a/fs/xfstests.py.data/nvdimm.yaml
+++ b/fs/xfstests.py.data/nvdimm.yaml
@@ -13,8 +13,10 @@ setup:
             #share_exclude: '1-600'
         fs_xfs:
             fs: 'xfs'
-            mkfs_opt: '-b size=65536 -s size=4096'
-    disk_type: !mux
-        type: 'disk'
-        disk_test: /dev/pmem0
-        disk_scratch: /dev/pmem0.1
+            mkfs_opt: '-b size=65536 -s size=4096 -m reflink=0'
+            exclude:
+            gen_exclude:
+    disk_type:
+        type: 'nvdimm'
+        disk_test:
+        disk_scratch:

--- a/fs/xfstests.py.data/nvdimm_log.yaml
+++ b/fs/xfstests.py.data/nvdimm_log.yaml
@@ -3,6 +3,7 @@ setup:
     scratch_mnt: '/mnt/scratch_pmem'
     test_mnt: '/mnt/test_pmem'
     mount_opt: '-o dax'
+    logdev: true
     fs_type: !mux
         fs_ext4:
             fs: 'ext4'
@@ -12,12 +13,13 @@ setup:
             #share_exclude: '1-300'
         fs_xfs:
             fs: 'xfs'
-            mkfs_opt: '-b size=65536 -s size=4096'
+            mkfs_opt: '-b size=65536 -s size=512 -m reflink=0'
             logdev_opt: '-l logdev'
-            #gen_exclude: '388'
-    disk_type: !mux
-        type: 'disk'
-        disk_test: /dev/pmem0
-        disk_scratch: /dev/pmem0.1
-        log_test: /dev/pmem1s
-        log_scratch: /dev/pmem1.1s
+            exclude:
+            gen_exclude:
+    disk_type:
+        type: 'nvdimm'
+        disk_test:
+        disk_scratch:
+        log_test:
+        log_scratch:


### PR DESCRIPTION
Patch uses pmem library to create pmem devices and run xfstests suite

Signed-off-by: Harish <harish@linux.ibm.com>