### PR TITLE
Skip lro test for vNIC interface

### DIFF
--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -25,6 +25,7 @@ import hashlib
 import netifaces
 from avocado import main
 from avocado import Test
+from avocado import skipIf
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
 from avocado.utils import distro
@@ -32,6 +33,8 @@ from avocado.utils import genio
 from avocado.utils.configure_network import PeerInfo
 from avocado.utils import configure_network
 from avocado.utils import wait
+
+IS_VNIC = 'vnic' in open('/sys/class/net/eth1/device/name', 'r').read()
 
 
 class NetworkTest(Test):
@@ -117,6 +120,7 @@ class NetworkTest(Test):
             self.fail("Can not change the state of %s" % ro_type)
         self.offload_toggle_test(ro_type, ro_type_full)
 
+    @skipIf(IS_VNIC, "Test not supported for vNIC")
     def test_lro(self):
         '''
         Test LRO


### PR DESCRIPTION
vNIC do not support enabling lro option, so check and skip for vnic
interface

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>