### PR TITLE
numa_test: Fix error condition

### DIFF
--- a/memory/numa_test.py.data/bench_movepages.c
+++ b/memory/numa_test.py.data/bench_movepages.c
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 	thp_time = test_migration(hp, "THP migration");
 	bp_time = test_migration(p, "Base migration");
 
-	if (bp_time >= thp_time)
-		errmsg("Base page migration took more time\n");
+	if (bp_time < thp_time)
+		errmsg("THP page migration took more time\n");
 	return 0;
 }

--- a/memory/numa_test.py.data/bench_movepages.c
+++ b/memory/numa_test.py.data/bench_movepages.c
@@ -30,7 +30,7 @@
 #define errmsg(x, ...) fprintf(stderr, x, ##__VA_ARGS__),exit(1)
 
 extern int is_thp(unsigned long pfn);
-extern unsigned long get_pfn(void *addr);
+extern int get_pfn(void *addr, unsigned long *);
 extern unsigned long get_first_mem_node(void);
 extern unsigned long get_next_mem_node(unsigned long node);
 
@@ -44,7 +44,8 @@ int *status, *nodes;
 
 double test_migration(void *p, char *msg)
 {
-	int non_thp = 0;
+	int thp_pages = 0;
+	int non_thp_pages = 0;
 	int i, thp, ret;
 	unsigned long pfn;
 	double time;
@@ -56,10 +57,14 @@ double test_migration(void *p, char *msg)
 		addrs[i] = p + (i * page_size);
 		nodes[i] = dest_node;
 		status[i] = 0;
-		pfn =  get_pfn(p + (i* page_size));
+		ret =  get_pfn(p + (i* page_size), &pfn);
+		if (ret)
+			continue;
 		if (pfn) {
-			if (!non_thp && !is_thp(pfn))
-				non_thp = 1;
+			if (is_thp(pfn))
+				thp_pages++;
+			else
+				non_thp_pages++;
 			if (verbose)
 				fprintf(stderr, "pfn before move_pages 0x%lx is_thp %d\n",
 					pfn, is_thp(pfn));
@@ -73,12 +78,15 @@ double test_migration(void *p, char *msg)
 	clock_gettime(CLOCK_MONOTONIC, &ts_end);
 
 	for (i = 0; i < nr_pages; i++) {
-		pfn = get_pfn(p + (i* page_size));
+		ret = get_pfn(p + (i* page_size), &pfn);
+		if (ret)
+			continue;
 		if (pfn && verbose)
 			fprintf(stderr, "pfn after move_pages 0x%lx is_thp %d\n", pfn, is_thp(pfn));
 	}
 	time = ts_end.tv_sec - ts_start.tv_sec + (ts_end.tv_nsec - ts_start.tv_nsec) / 1e9;
-	printf("%s time(seconds) (Non THP = %d) = %.6f\n", msg, non_thp, time);
+	printf("%s time(seconds) (thp_pages %d non_thp_pages = %d) = %.6f\n",
+	       msg, thp_pages, non_thp_pages, time);
 	return time;
 }
 
@@ -123,7 +131,8 @@ int main(int argc, char *argv[])
 	old_nodes = numa_bitmask_alloc(nr_nodes);
         src_node = get_first_mem_node();
         dest_node = get_next_mem_node(src_node);
-	printf("src node = %ld and dest node = %ld\n", src_node, dest_node);
+	printf("src node = %ld and dest node = %ld pages %d\n",
+	       src_node, dest_node, nr_pages);
 
         numa_bitmask_setbit(all_nodes, src_node);
 	numa_bitmask_setbit(all_nodes, dest_node);

--- a/memory/numa_test.py.data/numa_test.c
+++ b/memory/numa_test.py.data/numa_test.c
@@ -31,7 +31,7 @@
 #define PROTFLAG PROT_READ|PROT_WRITE
 
 extern int *get_numa_nodes_to_use(int max_node, unsigned long size);
-extern unsigned long get_pfn(void *addr);
+extern int get_pfn(void *addr, unsigned long *);
 unsigned long i;
 
 struct testcase {
@@ -102,7 +102,7 @@ int test_func(unsigned long nr_nodes, int mapflag, unsigned long nr_pages, unsig
 			nodes[i] = node_list[1];
 			status[i] = 0;
 		}
-		old_pfn[i] = get_pfn(p + i* page_size);
+		get_pfn(p + i* page_size, &old_pfn[i]);
 	}
 	printf("Executing %s\n", msg);
 	if (id == 1)
@@ -122,8 +122,10 @@ int test_func(unsigned long nr_nodes, int mapflag, unsigned long nr_pages, unsig
 	printf("Checking PFN's\n");
 
 	for (i = 0; i < nr_pages; i++) {
-		if(old_pfn[i]!=0){
-			if(old_pfn[i] == get_pfn(p + i* page_size)){
+		unsigned long pfn;
+		if(old_pfn[i] != 0) {
+			get_pfn(p + i* page_size, &pfn);
+			if(old_pfn[i] == pfn) {
 				same_pfn++;
 			}
 		}

--- a/memory/numa_test.py.data/softoffline.c
+++ b/memory/numa_test.py.data/softoffline.c
@@ -32,7 +32,7 @@
 
 #define errmsg(x, ...) fprintf(stderr, x, ##__VA_ARGS__),exit(1)
 
-extern unsigned long get_pfn(void *addr);
+extern int get_pfn(void *addr, unsigned long *);
 int main(int argc, char *argv[])
 {
 	char *p;
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 	/* fault in */
 	memset(p, 'a', nr_pages * page_size);
 	for (i = 0; i < nr_pages; i++){
-		old_pfn[i] = get_pfn(p + (i * page_size));
+		get_pfn(p + (i * page_size), &old_pfn[i]);
 		printf("pfn before soft offline 0x%lx\n", old_pfn[i]);
 	}
 
@@ -89,11 +89,13 @@ int main(int argc, char *argv[])
 
 	memset(p, 'a', nr_pages * page_size);
 	for (i = 0; i < nr_pages; i++){
-		new_pfn[i] = get_pfn(p + (i * page_size));
+		get_pfn(p + (i * page_size), &new_pfn[i]);
 		printf("pfn after soft offline 0x%lx\n", new_pfn[i]);
 	}
 
 	for (i = 0; i < nr_pages; i++){
+		if (!old_pfn[i] || !new_pfn[i])
+			continue;
 		if (old_pfn[i] == new_pfn[i]){
 			printf("pfn matches, softoffline failed\n");
 			return -1;


### PR DESCRIPTION
THP migration should take less time.

Should fix the below erros

 (09/12) memory/numa_test.py:NumaTest.test_thp_compare;s_type-wo_huge-f08a: FAIL: Please check the logs for failure (1.63 s)
 (10/12) memory/numa_test.py:NumaTest.test_thp_compare;s_type-with_huge-e569: FAIL: Please check the logs for failure (1.68 s)
 (11/12) memory/numa_test.py:NumaTest.test_thp_compare;p_type-wo_huge-526a: FAIL: Please check the logs for failure (1.62 s)
 (12/12) memory/numa_test.py:NumaTest.test_thp_compare;p_type-with_huge-6cd4: FAIL: Please check the logs for failure (1.65 s)

Signed-off-by: Aneesh Kumar K.V <aneesh.kumar@linux.ibm.com>