### PR TITLE
network_stress: re-arange mtu settings serially

### DIFF
--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -223,10 +223,10 @@ class NetworkTest(Test):
         '''
         Test set mtu back to 1500
         '''
-        if self.peer_networkinterface.set_mtu('1500') is not None:
+        if not self.peerinfo.set_mtu_peer(self.peer_interface, '1500'):
             self.cancel("Failed to set mtu in peer")
-        if self.networkinterface.set_mtu('1500') is not None:
-            self.cancel("Failed to set mtu in peer")
+        if not configure_network.set_mtu_host(self.iface, '1500'):
+            self.cancel("Failed to set mtu in host")
 
     def offload_toggle_test(self, ro_type, ro_type_full):
         '''


### PR DESCRIPTION
for every test the script is setting mtu to 1500 for peer and host
interface at start of the test and also resetting mtu for peer and host
this patch make sure the mtu reset happens serially i.e

test start : set mtu in host and set mtu in peer
test end   : reset mtu in of peer first and than set back host

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>