### PR TITLE
Adding pciutils package to dependencies

### DIFF
--- a/io/disk/scsi_add_remove.py
+++ b/io/disk/scsi_add_remove.py
@@ -40,8 +40,9 @@ class ScsiAddRemove(Test):
         self.err_paths = []
         self.device_list = []
         smm = SoftwareManager()
-        if not smm.check_installed("lsscsi") and not smm.install("lsscsi"):
-            self.cancel("lsscsi is not installed")
+        for pkg in ["lsscsi", "pciutils"]:
+            if not smm.check_installed(pkg) and not smm.install(pkg):
+                self.cancel("%s is not installed" % pkg)
         self.wwids = self.params.get('wwids', default='')
         self.pci_device = self.params.get("pci_device", default='')
         self.count = int(self.params.get("count", default=1))

--- a/io/driver/driver_bind_test.py
+++ b/io/driver/driver_bind_test.py
@@ -25,6 +25,7 @@ from avocado import Test
 from avocado import main
 from avocado.utils import process
 from avocado.utils import pci
+from avocado.utils.software_manager import SoftwareManager
 
 
 class DriverBindTest(Test):
@@ -45,6 +46,9 @@ class DriverBindTest(Test):
         self.count = int(self.params.get('count', default=1))
         if not self.pci_devices:
             self.cancel("No pci_adresses Given")
+        smm = SoftwareManager()
+        if not smm.check_installed("pciutils") and not smm.install("pciutils"):
+            self.cancel("pciutils package is need to test")
 
     def test(self):
         """

--- a/io/driver/module_unload_load.py
+++ b/io/driver/module_unload_load.py
@@ -20,6 +20,7 @@ import os
 from avocado import main
 from avocado.utils import process
 from avocado.utils import linux_modules, genio
+from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import pci
 from avocado import Test
 
@@ -43,6 +44,9 @@ class ModuleLoadUnload(Test):
         self.error_modules = []
         self.mod_list = []
         self.uname = linux_modules.platform.uname()[2]
+        smm = SoftwareManager()
+        if not smm.check_installed("pciutils") and not smm.install("pciutils"):
+            self.cancel("pciutils package is need to test")
 
     def built_in_module(self, module):
         """

--- a/io/pci/PowerNVEEH.py
+++ b/io/pci/PowerNVEEH.py
@@ -26,6 +26,7 @@ from avocado.utils import process
 from avocado.utils import pci
 from avocado.utils import genio
 from avocado.utils import distro
+from avocado.utils.software_manager import SoftwareManager
 
 EEH_HIT = 0
 EEH_MISS = 1
@@ -74,6 +75,9 @@ class PowerNVEEH(Test):
                                     "eeh_pe_config_addr" % self.pci_device)
         self.addr = str(self.addr).rstrip()
         self.err = 0
+        smm = SoftwareManager()
+        if not smm.check_installed("pciutils") and not smm.install("pciutils"):
+            self.cancel("pciutils package is need to test")
         for line in process.system_output('lspci -vs %s' % self.pci_device,
                                           ignore_status=True,
                                           shell=True).decode("utf-8\

--- a/io/pci/PowerVMEEH.py
+++ b/io/pci/PowerVMEEH.py
@@ -26,6 +26,7 @@ from avocado.utils import process
 from avocado.utils import pci
 from avocado.utils import genio
 from avocado.utils import distro
+from avocado.utils.software_manager import SoftwareManager
 
 EEH_HIT = 0
 EEH_MISS = 1
@@ -73,6 +74,9 @@ class PowerVMEEH(Test):
             % self.max_freeze
         process.system(cmd, ignore_status=True, shell=True)
         self.function = str(self.params.get('function')).split(" ")
+        smm = SoftwareManager()
+        if not smm.check_installed("pciutils") and not smm.install("pciutils"):
+            self.cancel("pciutils package is need to test")
         self.log.info("===============Testing EEH Frozen PE==================")
 
     def test_eeh_basic_pe(self):

--- a/io/pci/distro_tools.py
+++ b/io/pci/distro_tools.py
@@ -23,6 +23,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado import skipUnless
 from avocado.utils import pci
+from avocado.utils.software_manager import SoftwareManager
 
 IS_POWER_VM = 'pSeries' in open('/proc/cpuinfo', 'r').read()
 
@@ -39,6 +40,9 @@ class DisrtoTool(Test):
         self.option = self.params.get("test_opt", default='')
         self.tool = self.params.get("tool", default='')
         self.pci_device = self.params.get("pci_device", default='')
+        smm = SoftwareManager()
+        if not smm.check_installed("pciutils") and not smm.install("pciutils"):
+            self.cancel("pciutils package is need to test")
 
     @skipUnless(IS_POWER_VM,
                 "supported only on PowerVM platform")

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -180,7 +180,7 @@ class DlparPci(Test):
         '''
         smm = SoftwareManager()
         packages = ['ksh', 'src', 'rsct.basic', 'rsct.core.utils',
-                    'rsct.core', 'DynamicRM']
+                    'rsct.core', 'DynamicRM', 'pciutils']
         detected_distro = distro.detect()
         if detected_distro.name == "Ubuntu":
             packages.extend(['python-paramiko'])

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -27,6 +27,7 @@ from avocado import Test
 from avocado import main
 from avocado.utils import wait
 from avocado.utils import linux_modules, genio, pci, cpu
+from avocado.utils.software_manager import SoftwareManager
 
 
 class PCIHotPlugTest(Test):
@@ -61,6 +62,9 @@ class PCIHotPlugTest(Test):
         self.count = int(self.params.get('count', default='1'))
         if not self.device:
             self.cancel("PCI_address not given")
+        smm = SoftwareManager()
+        if not smm.check_installed("pciutils") and not smm.install("pciutils"):
+            self.cancel("pciutils package is need to test")
         for pci_addr in self.device:
             if not os.path.isdir('/sys/bus/pci/devices/%s' % pci_addr):
                 self.cancel("%s not present in device path" % pci_addr)

--- a/io/pci/pci_info_lsvpd.py
+++ b/io/pci/pci_info_lsvpd.py
@@ -36,7 +36,7 @@ class PciLsvpdInfo(Test):
         To check and install dependencies for the test
         '''
         smm = SoftwareManager()
-        for pkg in ["lsvpd"]:
+        for pkg in ["lsvpd", "pciutils"]:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel("%s package is need to test" % pkg)
         if process.system("vpdupdate", ignore_status=True, shell=True):


### PR DESCRIPTION
Adding pciutils package as part of dependenciy packages for all
pci related tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>