### PR TITLE
bootlist parameter input made space separted

### DIFF
--- a/io/common/bootlist_test.py
+++ b/io/common/bootlist_test.py
@@ -42,15 +42,15 @@ class BootlisTest(Test):
         if self.host_interfaces is not None:
             if not self.host_interfaces:
                 self.cancel("user should specify host interfaces")
-            self.names = self.host_interfaces.replace(',', ' ')
+            self.names = self.host_interfaces
             interfaces = netifaces.interfaces()
-            for host_interface in self.host_interfaces.split(","):
+            for host_interface in self.host_interfaces.split(" "):
                 if host_interface not in interfaces:
                     self.cancel("interface is not available")
         elif self.disk_names is not None:
             if not self.disk_names:
                 self.cancel("user should specify disk name")
-            self.names = self.disk_names.replace(',', ' ')
+            self.names = self.disk_names
 
     def bootlist_mode(self, param):
         '''

--- a/io/common/bootlist_test.py.data/README.txt
+++ b/io/common/bootlist_test.py.data/README.txt
@@ -12,6 +12,6 @@ converting in to the different mode.
 
 Input Needed (in yaml file)
 ---------------------------
-Interfaces - Specify the interfaces for which the test needs to be run.
-disks - specify the disks for which the test needs to be run.
+Interfaces - Specify the interfaces(space separated) for which the test needs to be run. like eth8 eth9
+disks - specify the disks (space separated) for which the test needs to be run .like /dev/sda /dev/sdb
 


### PR DESCRIPTION
bootlist test now expect the input disk/interface value to be
space separated as standard format and also updated Readme about the
input format

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>