### PR TITLE
doc: added software raid input example in readme

### DIFF
--- a/io/disk/softwareraid.py.data/Readme
+++ b/io/disk/softwareraid.py.data/Readme
@@ -2,7 +2,7 @@ mdadm - manage MD devices aka Linux Software RAID
 
 Values to be passed in yaml file:
 
-* Devices on which this scripts should be run.
+* Devices on which this scripts should be run. disks: "/dev/sdx /dev/sdy ..." (comman separated disks)
 
 * Raid Name to be created, optional parameter.
 


### PR DESCRIPTION
User needs an example to pass the input disks format, so added to
readme

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>