### PR TITLE
Rename pci_device to pci_devices

### DIFF
--- a/io/disk/scsi_add_remove.py
+++ b/io/disk/scsi_add_remove.py
@@ -43,7 +43,7 @@ class ScsiAddRemove(Test):
         if not smm.check_installed("lsscsi") and not smm.install("lsscsi"):
             self.cancel("lsscsi is not installed")
         self.wwids = self.params.get('wwids', default='')
-        self.pci_device = self.params.get("pci_device", default='')
+        self.pci_device = self.params.get("pci_devices", default='')
         self.count = int(self.params.get("count", default=1))
         system_pci_adress = pci.get_pci_addresses()
         system_wwids = multipath.get_multipath_wwids()

--- a/io/disk/scsi_add_remove.py.data/scsi_add_remove.yaml
+++ b/io/disk/scsi_add_remove.py.data/scsi_add_remove.yaml
@@ -1,3 +1,3 @@
 wwids: ''
-pci_device: ''
+pci_devices: ''
 count: 1

--- a/io/driver/driver_bind_test.py
+++ b/io/driver/driver_bind_test.py
@@ -41,7 +41,7 @@ class DriverBindTest(Test):
         Setup the device.
         """
         self.return_code = 0
-        self.pci_devices = self.params.get('pci_device', default=None)
+        self.pci_devices = self.params.get('pci_devices', default=None)
         self.count = int(self.params.get('count', default=1))
         if not self.pci_devices:
             self.cancel("No pci_adresses Given")

--- a/io/driver/driver_bind_test.py.data/README.txt
+++ b/io/driver/driver_bind_test.py.data/README.txt
@@ -3,5 +3,5 @@ This test needs to be run as root.
 
 Inputs Needed (in multiplexer file):
 ------------------------------------
-pci_device -      can be fetched from <lspci -nnD>  output. use comma(,) for multiple devices
+pci_devices -      can be fetched from <lspci -nnD>  output. use comma(,) for multiple devices 001b:62:00.0,001b:62:00.1
 count -      This is an interger value give for number of time the unbind and bind operation to run

--- a/io/driver/driver_bind_test.py.data/driver_bind_test.yaml
+++ b/io/driver/driver_bind_test.py.data/driver_bind_test.yaml
@@ -1,2 +1,2 @@
-pci_device: "001b:62:00.0,001b:62:00.1"
+pci_devices: ""
 count: 3

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -57,7 +57,7 @@ class PCIHotPlugTest(Test):
             if not linux_modules.module_is_loaded("pnv_php"):
                 linux_modules.load_module("pnv_php")
         self.dic = {}
-        self.device = self.params.get('pci_device', default=' ').split(",")
+        self.device = self.params.get('pci_devices', default=' ').split(",")
         self.count = int(self.params.get('count', default='1'))
         if not self.device:
             self.cancel("PCI_address not given")

--- a/io/pci/pci_hotplug.py.data/README.txt
+++ b/io/pci/pci_hotplug.py.data/README.txt
@@ -4,5 +4,5 @@ This test needs to be run as root.
 
 Inputs Needed (in multiplexer file):
 ------------------------------------
-pci_device -       PCI devices
+pci_devices -       PCI devices, pass comma separated pci devices 001b:62:00.0,001b:62:00.1
 num_of_hotplug -   Specify number of times hotplug to be performed

--- a/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
+++ b/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
@@ -1,2 +1,2 @@
-pci_device: "001b:62:00.0,001b:62:00.1"
+pci_devices: ""
 count: 10


### PR DESCRIPTION
To differentiate between a single device(other test) and multiple device
changed the param from pci_device to pci_devices

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>