### PR TITLE
Fixing the way lpar name is found

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -98,13 +98,6 @@ class LPM(Test):
         else:
             current_server = self.server
 
-        cmd = 'lssyscfg -r lpar -F name -m %s' % current_server
-        output = self.run_command(cmd)
-        for line in output:
-            if "%s-" % self.lpar in line:
-                self.lpar = line
-                break
-
         if not self.is_lpar_in_server(current_server, self.lpar):
             self.cancel("%s not in %s" % (self.lpar, current_server))
 

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -94,12 +94,6 @@ class NetworkVirtualization(Test):
                 break
         if not self.server:
             self.cancel("Managed System not got")
-        cmd = 'lssyscfg -r lpar -F name -m %s' % self.server
-        output = self.run_command(self.con_hmc, cmd)
-        for line in output:
-            if "%s-" % self.lpar in line:
-                self.lpar = line
-                break
         self.slot_num = self.params.get("slot_num", '*', default=None)
         self.slot_num = self.slot_num.split(',')
         for slot in self.slot_num:

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -79,12 +79,6 @@ class DlparPci(Test):
             if line in self.lpar_1:
                 self.server = line
                 break
-        cmd = 'lssyscfg -r lpar -F name -m %s' % self.server
-        output = self.run_command(cmd)
-        for line in output:
-            if "%s-" % self.lpar_1 in line:
-                self.lpar_1 = line
-                break
         if not self.server:
             self.cancel("Managed System not got")
         self.lpar_2 = self.params.get("lpar_2", '*', default=None)


### PR DESCRIPTION
Earlier, we were finding LPAR name by using lsrsrc to find LPAR
host name and then using that to find LPAR name from HMC. But
we came up with lsslot later which was a better way. So, removing
some leftover workarounds from the older method using this commit.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>