### PR TITLE
Added timeout value to runcommand function call in function changehwres

### DIFF
--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -351,7 +351,7 @@ class DlparPci(Test):
                    -o %s --id %s -l %s ' % (server, operation, lpar_id,
                                             drc_index)
         try:
-            cmd = self.run_command(cmd)
+            cmd = self.run_command(cmd, 3000)
         except CommandFailed as cmd_fail:
             self.log.debug(str(cmd_fail))
             self.fail("dlpar %s operation failed" % msg)


### PR DESCRIPTION
On large systems dlpar tests are failing due to timeout, as changehwres
takes more time to release the hardware. Hence added the timeout to
3000 secs. So that tests will pass even on large systems.

Signed-off-by: Hariharan T S <hari@linux.vnet.ibm.com>