### PR TITLE
Skip checking of mounted device

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -79,7 +79,8 @@ class LTP(Test):
             else:
                 self.device = Partition(
                     device="none", mountpoint=self.mount_dir)
-            self.device.mount(mountpoint=self.mount_dir, fstype="tmpfs")
+            self.device.mount(mountpoint=self.mount_dir,
+                              fstype="tmpfs", mnt_check=False)
 
     def setUp(self):
         smg = SoftwareManager()


### PR DESCRIPTION
Patch skips check of device mounted device through partition library

Signed-off-by: Harish <harish@linux.ibm.com>