### PR TITLE
memory: Use integer whenever required

### DIFF
--- a/memory/dma_memtest.py
+++ b/memory/dma_memtest.py
@@ -66,7 +66,7 @@ class DmaMemtest(Test):
         self.log.info('Downloading linux kernel tarball')
         self.tarball = self.fetch_asset(tarball_url, asset_hash=tarball_md5,
                                         algorithm='md5')
-        size_tarball = os.path.getsize(self.tarball) / 1024 / 1024
+        size_tarball = os.path.getsize(self.tarball) // 1024 // 1024
 
         # Estimation of the tarball size after uncompression
         compress_ratio = 5
@@ -80,7 +80,7 @@ class DmaMemtest(Test):
         self.log.info('Parallel: %s', parallel)
 
         # Verify if space is available in disk
-        disk_free_mb = (disk.freespace(self.tmpdir) / 1024) / 1024
+        disk_free_mb = (disk.freespace(self.tmpdir) // 1024) // 1024
         if disk_free_mb < (est_size * self.sim_cps):
             self.cancel("Space not available to extract the %s linux tars\n"
                         "Mount and Use other partitions in dir_to_extract arg "
@@ -97,12 +97,12 @@ class DmaMemtest(Test):
         mem_str = process.system_output('grep MemTotal /proc/meminfo')
         mem = int(re.search(r'\d+', mem_str.decode()).group(0))
         mem = int(mem / 1024)
-        sim_cps = (1.5 * mem) / est_size
+        sim_cps = (1.5 * mem) // est_size
 
-        if (mem % est_size) >= (est_size / 2):
+        if (mem % est_size) >= (est_size // 2):
             sim_cps += 1
 
-        if (mem / 32) < 1:
+        if (mem // 32) < 1:
             sim_cps += 1
 
         return int(sim_cps)

--- a/memory/eatmemory.py
+++ b/memory/eatmemory.py
@@ -71,7 +71,7 @@ class EatMemory(Test):
                 return None
             mem_in_bytes = value * multiplier[unit]
 
-        return mem_in_bytes / multiplier['m']
+        return mem_in_bytes // multiplier['m']
 
     def test(self):
         os.chdir(self.sourcedir)

--- a/memory/ksm_poison.py
+++ b/memory/ksm_poison.py
@@ -58,7 +58,7 @@ class KsmPoison(Test):
 
     def test(self):
         os.chdir(self.teststmpdir)
-        cmd = './ksm_poison -n %s' % str(self.nr_pages / 2)
+        cmd = './ksm_poison -n %s' % str(self.nr_pages // 2)
         if self.touch:
             cmd = '%s -t' % cmd
         if self.offline:

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -157,8 +157,8 @@ class MemStress(Test):
             self.fail('ERROR: Test failed, please check the dmesg logs')
 
     def run_stress(self):
-        mem_free = memory.meminfo.MemFree.m / 4
-        cpu_count = int(multiprocessing.cpu_count()) / 2
+        mem_free = memory.meminfo.MemFree.m // 4
+        cpu_count = int(multiprocessing.cpu_count()) // 2
         process.run("stress --cpu %s --io %s --vm %s --vm-bytes %sM --timeout %ss" %
                     (cpu_count, self.iocount, self.vmcount, mem_free, self.stresstime), ignore_status=True, sudo=True, shell=True)
 

--- a/memory/mprotect.py
+++ b/memory/mprotect.py
@@ -45,7 +45,7 @@ class Mprotect(Test):
 
         if not self.nr_pages:
             memsize = int(memory.meminfo.MemFree.b * 0.9)
-            self.nr_pages = memsize / memory.get_page_size()
+            self.nr_pages = memsize // memory.get_page_size()
 
         for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -42,7 +42,7 @@ class NumaTest(Test):
         dist = distro.detect()
         memsize = int(memory.meminfo.MemFree.b * 0.2)
         self.nr_pages = self.params.get(
-            'nr_pages', default=memsize / memory.get_page_size())
+            'nr_pages', default=memsize // memory.get_page_size())
         self.map_type = self.params.get('map_type', default='private')
         self.hpage = self.params.get('h_page', default=False)
 

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -85,8 +85,8 @@ class VATest(Test):
                 self.hsizes[0] * 1024)).rstrip("\n")
             n_pages2 = genio.read_file(self.hp_file % str(
                 self.hsizes[1] * 1024)).rstrip("\n")
-            self.n_chunks = (int(n_pages) * self.hsizes[0]) / 16384
-            self.n_chunks2 = (int(n_pages2) * self.hsizes[1]) / 16384
+            self.n_chunks = (int(n_pages) * self.hsizes[0]) // 16384
+            self.n_chunks2 = (int(n_pages2) * self.hsizes[1]) // 16384
         if self.scenario_arg not in [1, 2, 10, 11, 12]:
             max_hpages = int((0.9 * memory.meminfo.MemFree.m) / page_chunker)
             if self.scenario_arg in [3, 4, 5, 6]:
@@ -97,7 +97,7 @@ class VATest(Test):
                     page_chunker * 1024), str(max_hpages))
                 nr_pages = genio.read_file(self.hp_file % str(
                     page_chunker * 1024)).rstrip("\n")
-            self.n_chunks = (int(nr_pages) * page_chunker) / 16384
+            self.n_chunks = (int(nr_pages) * page_chunker) // 16384
 
         for packages in ['gcc', 'make']:
             if not smm.check_installed(packages) and not smm.install(packages):


### PR DESCRIPTION
Use integer whenever it is required in memory tests

Signed-off-by: Harish <harish@linux.ibm.com>