### PR TITLE
Removal of unnecessary condition in disktest

### DIFF
--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -83,9 +83,6 @@ class Disktest(Test):
         gigabytes = int(lv_utils.get_diskspace(self.disk)) // 1073741824
         memory_mb = memory.meminfo.MemTotal.m
         self.chunk_mb = gigabytes * 950
-        if memory_mb > self.chunk_mb:
-            self.cancel("Chunk size has to be greater or equal to RAM size. "
-                        "(%s > %s)" % (self.chunk_mb, memory_mb))
 
         self.no_chunks = 1024 * gigabytes // self.chunk_mb
         if self.no_chunks == 0:


### PR DESCRIPTION
disktest runs for any size of disk against any size of memory.
So, removed the unnecessary condition.

Co-authored-by: Naresh Bannoth <nbannoth@in.ibm.com>

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>