### PR TITLE
Fix issue in perf_nest_event test as adopted latest lib change

### DIFF
--- a/perf/perf_nest_events.py
+++ b/perf/perf_nest_events.py
@@ -67,13 +67,14 @@ class nestEvents(Test):
 
         # Collect nest events
         self.list_of_nest_events = []
-        for line in process.get_perf_events('nest_'):
+        for line in process.get_command_output_matching('perf list', 'nest_'):
             line = line.split(' ')[2]
             if 'pm_nest' in line:
                 continue
             self.list_of_nest_events.append(line)
 
-        # Clear the dmesg, by that we can capture the delta at the end of the test.
+        # Clear the dmesg, by that we can capture the delta at the end of the
+        # test.
         process.run("dmesg -c", sudo=True)
 
     def error_check(self):


### PR DESCRIPTION
this patch fix https://github.com/avocado-framework-tests/avocado-misc-tests/issues/1626

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>