### PR TITLE
perftool.py:Replacing package name 'gcc-g++' with 'gcc-c++'.

### DIFF
--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -48,7 +48,7 @@ class Perftool(Test):
         # enabler for older runners, but should be removed soon
         elif detected_distro.name in ['rhel', 'SuSE', 'fedora',
                                       'centos', 'redhat']:
-            deps.extend(['perf', 'gcc-g++'])
+            deps.extend(['perf', 'gcc-c++'])
         else:
             self.cancel("Install the package for perf supported\
                       by %s" % detected_distro.name)


### PR DESCRIPTION
Since gcc-g++ is not available replacing it with gcc-c++ which is needed for the test to be run.
Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>