### PR TITLE
pmqa.py:cpufreq feature only supported on PowerNV

### DIFF
--- a/cpu/pmqa.py
+++ b/cpu/pmqa.py
@@ -20,9 +20,11 @@ import os
 
 from avocado import Test
 from avocado import main
-from avocado.utils import process, git
+from avocado import skipIf
+from avocado.utils import process, git,cpu
 from avocado.utils.software_manager import SoftwareManager
 
+IS_POWER_NV = 'PowerNV' in cpu._get_cpu_info()
 
 class Pmqa(Test):
 
@@ -33,15 +35,13 @@ class Pmqa(Test):
 
     :avocado: tags=cpu,privileged
     """
-
+    @skipIf(not IS_POWER_NV, "This test is not supported on PowerVM platform")
     def setUp(self):
         '''
         Build Pmqa Test
         Source:
         git://git.linaro.org/power/pm-qa.git
         '''
-        if not os.path.exists('/sys/devices/system/cpu/cpu0/cpufreq'):
-            self.cancel('sysfs directory for cpufreq is unavailable.')
         # Check for basic utilities
         smm = SoftwareManager()
         for package in ['gcc', 'make']:


### PR DESCRIPTION
In PowerVM cpufreq is not supported
so changed the script that cpufreq supports only in PowerNV environment

Signed-off-by: shirisha Ganta <shiganta@in.ibm.com>