### PR TITLE
Fixes for kselftests

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -126,7 +126,7 @@ class kselftest(Test):
         Execute the kernel selftest
         """
         self.error = False
-        build.make(self.sourcedir, extra_args='%s run_tests' % self.comp)
+        build.make(self.sourcedir, extra_args='summary=1 %s run_tests' % self.comp)
         for line in open(os.path.join(self.logdir, 'debug.log')).readlines():
             self.find_match(r'not ok (.*) selftests:(.*)', line)
 

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -128,10 +128,7 @@ class kselftest(Test):
         self.error = False
         build.make(self.sourcedir, extra_args='%s run_tests' % self.comp)
         for line in open(os.path.join(self.logdir, 'debug.log')).readlines():
-            if self.run_type == 'upstream':
-                self.find_match(r'not ok (.*) selftests:(.*)', line)
-            elif self.run_type == 'distro':
-                self.find_match(r'selftests:(.*)\[FAIL\]', line)
+            self.find_match(r'not ok (.*) selftests:(.*)', line)
 
         if self.error:
             self.fail("Testcase failed during selftests")


### PR DESCRIPTION
1. Fix: Use same search string for result
The existing upstream string search matches both old, new result summary of selftest. So removing the old string for distro version
    ```
    >>> re.search(r'not ok (.*) selftests:(.*)', "not ok 15 selftests: powerpc/ptrace: ptrace-syscall # exit=1")
    <_sre.SRE_Match object; span=(0, 60), match='not ok 15 selftests: powerpc/ptrace: ptrace-sysca>

    >>> re.search(r'not ok (.*) selftests:(.*)', "not ok 1..13 selftests: ptrace: core-pkey [FAIL]")
    <_sre.SRE_Match object; span=(0, 48), match='not ok 1..13 selftests: ptrace: core-pkey [FAIL]'>
    ```

2. Add a summary option to kselftest
This allows the failed tests search to be faster as only summary lines are emitted to stdout

Signed-off-by: Harish <harish@linux.ibm.com>