### PR TITLE
uprobe.py: Adding "glibc-devel" package for SuSE.

### DIFF
--- a/ras/uprobe.py
+++ b/ras/uprobe.py
@@ -62,6 +62,8 @@ class Uprobe(Test):
         smg = SoftwareManager()
         if dist.name in ["Ubuntu", "unknown", 'debian']:
             deps = ['libc-bin']
+        elif 'SuSE' in dist.name:
+            deps = ['glibc-devel']
         else:
             deps = ['glibc-common']
         for package in deps:


### PR DESCRIPTION
glibc-devel package is required to run the test for Distro SuSE.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>