### PR TITLE
Fixing blocksize to be integer in nvmetest

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -267,7 +267,7 @@ class NVMeTest(Test):
         Creates one namespace, with the specified id, block size, controller
         """
         cmd = "%s create-ns %s --nsze=%s --ncap=%s --flbas=0 -dps=0" % (
-            self.binary, self.device, blocksize, blocksize)
+            self.binary, self.device, int(blocksize), int(blocksize))
         process.system(cmd, shell=True, ignore_status=True)
         cmd = "%s attach-ns %s --namespace-id=%s -controllers=%s" % (
             self.binary, self.device, ns_id, controller)


### PR DESCRIPTION
When creating nvme namespace, blocksize needs to be integer.
We compute that, but did not make it integer earlier. Fixed it.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>