### PR TITLE
added restore_from_backup() to network tests

### DIFF
--- a/io/net/Network_config.py
+++ b/io/net/Network_config.py
@@ -158,6 +158,7 @@ class NetworkconfigTest(Test):
         unset ip for host interface
         '''
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -180,6 +180,7 @@ class Ethtool(Test):
         '''
         self.interface_state_change(self.iface, "up", "yes")
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -155,6 +155,7 @@ class Iperf(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -128,6 +128,7 @@ class ReceiveMulticastTest(Test):
                           ignore_status=True) != 0:
             self.log.info("unable to unset all mulicast option")
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -137,6 +137,7 @@ class MultiportStress(Test):
         for ipaddr, interface in zip(self.ipaddr, self.host_interfaces):
             networkinterface = NetworkInterface(interface, self.local)
             networkinterface.remove_ipaddr(ipaddr, self.netmask)
+            networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -180,6 +180,7 @@ class Netperf(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -301,6 +301,7 @@ class NetworkTest(Test):
             cmd = "timeout 600 ssh %s \" rm -rf /tmp/tempfile\"" % self.peer
             process.system(cmd, shell=True, verbose=True, ignore_status=True)
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/switch_test.py
+++ b/io/net/switch_test.py
@@ -127,6 +127,7 @@ class SwitchTest(Test):
         unset ip address
         '''
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -159,6 +159,7 @@ class TcpdumpTest(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -168,6 +168,7 @@ class Uperf(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+        self.networkinterface.restore_from_backup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
to remove backup config files and to restore the old config
back.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>