### PR TITLE
change netmask to netmasks in yaml and test file

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -137,7 +137,7 @@ class NetworkVirtualization(Test):
         self.mac_id = self.params.get('mac_id',
                                       default="02:03:03:03:03:01").split(' ')
         self.mac_id = [mac.replace(':', '') for mac in self.mac_id]
-        self.netmask = self.params.get('netmask', '*', default=None).split(' ')
+        self.netmask = self.params.get('netmasks', '*', default=None).split(' ')
         self.peer_ip = self.params.get('peer_ip', default=None).split(' ')
         self.run_command(self.con_hmc, "uname -a")
         cmd = 'lssyscfg -m ' + self.server + \

--- a/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
@@ -13,7 +13,7 @@ priority:
 auto_failover:
 bandwidth:
 device_ip:
-netmask:
+netmasks:
 peer_ip:
 vnic_test_count:
 num_of_dlpar:


### PR DESCRIPTION
changing netmask to netmasks its because of scenario testing
with multiple vnic,in vnic test will pass multiple netmask.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>