### PR TITLE
fiotest: Fixing disk parameter name in create_lv

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -111,7 +111,7 @@ class FioTest(Test):
         vgname = 'avocado_vg'
         lvname = 'avocado_lv'
         lv_size = int(lv_utils.get_diskspace(l_disk)) / 2330168
-        lv_utils.vg_create(vgname, disk)
+        lv_utils.vg_create(vgname, l_disk)
         lv_utils.lv_create(vgname, lvname, lv_size)
         return '/dev/%s/%s' % (vgname, lvname)
 


### PR DESCRIPTION
Fixing disk parameter name, as it should have been l_disk.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>