### PR TITLE
Correcting the changed library function name in disk_info test 

### DIFF
--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -89,7 +89,7 @@ class DiskInfo(Test):
                             % pkg)
         self.disk_nodes = []
         self.disk_base = os.path.basename(self.disk)
-        if multipath.is_mpath(self.disk_base):
+        if multipath.is_mpath_dev(self.disk_base):
             self.mpath = True
             self.disk_abs = os.path.basename(os.readlink(self.disk))
             mwwid = multipath.get_multipath_wwid(self.disk_base)


### PR DESCRIPTION
Name of a multipath library function that used in disk_info.py
has changed. corrected it with new changed function name

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>