### PR TITLE
Add support to run FIO with pmem devices

### DIFF
--- a/io/disk/fiotest.py.data/fio-devdax.job
+++ b/io/disk/fiotest.py.data/fio-devdax.job
@@ -1,0 +1,44 @@
+[global]
+bs=16M
+ioengine=dev-dax
+norandommap
+time_based=1
+runtime=30
+group_reporting
+disable_lat=1
+disable_slat=1
+disable_clat=1
+clat_percentiles=0
+cpus_allowed_policy=split
+
+# For the dev-dax engine:
+#
+#   IOs always complete immediately
+#   IOs are always direct
+#
+iodepth=1
+direct=0
+thread=1
+numjobs=5
+#
+# The dev-dax engine does IO to DAX device that are special character
+# devices exported by the kernel (e.g. /dev/dax0.0). The device is
+# opened normally and then the region is accessible via mmap. We do
+# not use the O_DIRECT flag because the device is naturally direct
+# access. The O_DIRECT flags will result in failure. The engine
+# access the underlying NVDIMM directly once the mmapping is setup.
+#
+# Check the alignment requirement of your DAX device. Currently the default
+# should be 2M. Blocksize (bs) should meet alignment requirement.
+#
+# An example of creating a dev dax device node from pmem:
+# ndctl create-namespace --reconfig=namespace0.0 --mode=dax --force
+#
+
+[dev-dax-write]
+rw=randwrite
+stonewall
+
+[dev-dax-read]
+rw=randread
+stonewall

--- a/io/disk/fiotest.py.data/fio-libpmem.job
+++ b/io/disk/fiotest.py.data/fio-libpmem.job
@@ -1,0 +1,72 @@
+[global]
+bs=64k
+size=1g
+ioengine=libpmem
+norandommap
+time_based=1
+group_reporting
+invalidate=1
+disable_lat=1
+disable_slat=1
+disable_clat=1
+clat_percentiles=0
+
+iodepth=1
+iodepth_batch=1
+thread=1
+numjobs=5
+
+#
+# In case of 'scramble_buffers=1', the source buffer
+# is rewritten with a random value every write operations.
+#
+# But when 'scramble_buffers=0' is set, the source buffer isn't
+# rewritten. So it will be likely that the source buffer is in CPU
+# cache and it seems to be high performance.
+#
+scramble_buffers=1
+
+#
+# direct=0:
+#   Using pmem_memcpy_nodrain() for write operation
+#
+# direct=1:
+#   Using pmem_memcpy_persist() for write operation
+#
+direct=1
+
+#
+# Setting for fio process's CPU Node and Memory Node
+#
+numa_cpu_nodes=0
+numa_mem_policy=bind:0
+
+#
+# split means that each job will get a unique CPU from the CPU set
+#
+cpus_allowed_policy=split
+
+#
+# The pmemblk engine does IO to files in a DAX-mounted filesystem.
+# The filesystem should be created on an NVDIMM (e.g /dev/pmem0)
+# and then mounted with the '-o dax' option.  Note that the engine
+# accesses the underlying NVDIMM directly, bypassing the kernel block
+# layer, so the usual filesystem/disk performance monitoring tools such
+# as iostat will not provide useful data.
+#
+
+[libpmem-seqwrite]
+rw=write
+stonewall
+
+[libpmem-seqread]
+rw=read
+stonewall
+
+[libpmem-randwrite]
+rw=randwrite
+stonewall
+
+[libpmem-randread]
+rw=randread
+stonewall

--- a/io/disk/fiotest.py.data/fio-pmem.yaml
+++ b/io/disk/fiotest.py.data/fio-pmem.yaml
@@ -1,0 +1,18 @@
+setup:
+    pmdk_url: 'https://github.com/pmem/pmdk/releases/download/1.8/pmdk-1.8.tar.gz'
+    disk:
+    disk_type: 'nvdimm'
+    run_type: !mux
+        libpmem:
+            fio_job: 'fio-libpmem.job'
+            filesystem: !mux
+                xfs:
+                    fs: 'xfs'
+                    fs_args: '-f -b size=64k -s size=512 -m reflink=0'
+                    mnt_args: '-o dax'
+                ext4:
+                    fs: 'ext4'
+                    fs_args: '-b 64k -F'
+                    mnt_args: '-o dax'
+        devdax:
+            fio_job: 'fio-devdax.job'


### PR DESCRIPTION
Patch adds support to create and run pmem device type with both fsdax and devdax modes

Signed-off-by: Harish <harish@linux.ibm.com>