### PR TITLE
iperf2 file location has changed

### DIFF
--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -91,8 +91,8 @@ class Iperf(Test):
             self.cancel("Failed to set mtu in host")
         self.iperf = os.path.join(self.teststmpdir, 'iperf')
         iperf_download = self.params.get("iperf_download", default="https:"
-                                         "//excellmedia.dl.sourceforge.net/"
-                                         "project/iperf2/iperf-2.0.13.tar.gz")
+                                         "//sourceforge.net/projects/iperf2/"
+                                         "files/iperf-2.0.13.tar.gz")
         tarball = self.fetch_asset(iperf_download, expire='7d')
         archive.extract(tarball, self.iperf)
         self.version = os.path.basename(tarball.split('.tar')[0])

--- a/io/net/iperf_test.py.data/iperf_test.yaml
+++ b/io/net/iperf_test.py.data/iperf_test.yaml
@@ -7,6 +7,7 @@ peer_user_name: "root"
 peer_password: "********"
 EXPECTED_THROUGHPUT : 90
 IPERF_SERVER_RUN : 1
+iperf_download: "https://sourceforge.net/projects/iperf2/files/iperf-2.0.13.tar.gz"
 mtu: !mux
     1500:
         mtu: "1500"


### PR DESCRIPTION
iperf2 file location has changed and hence he default is not working
adding the param "iperf_download" to yaml file as this location
is not consistent and cannot rely on default always.

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>