### PR TITLE
pci_hotplug: cancel test if pci not given

### DIFF
--- a/io/pci/PowerNVEEH.py
+++ b/io/pci/PowerNVEEH.py
@@ -68,7 +68,9 @@ class PowerNVEEH(Test):
         process.system(cmd, ignore_status=True, shell=True)
         self.function = str(self.params.get('function', default='4'))
         self.err = str(self.params.get('err'))
-        self.pci_device = str(self.params.get('pci_device', default=' '))
+        self.pci_device = str(self.params.get('pci_device', default=""))
+        if not self.pci_device:
+            self.cancel("PCI bus id not given")
         self.phb = self.pci_device.split(":", 1)[0]
         self.addr = genio.read_file("/sys/bus/pci/devices/%s/"
                                     "eeh_pe_config_addr" % self.pci_device)

--- a/io/pci/PowerVMEEH.py
+++ b/io/pci/PowerVMEEH.py
@@ -65,7 +65,7 @@ class PowerVMEEH(Test):
         if '0x1' not in genio.read_file(eeh_enable_file).strip():
             self.cancel("EEH is not enabled, please enable via FSP")
         self.max_freeze = self.params.get('max_freeze', default=1)
-        self.pci_addr = [self.params.get('pci_device', default='')]
+        self.pci_addr = [self.params.get('pci_device', default="")]
         self.add_cmd = self.params.get('additional_command', default='')
         if not self.pci_addr:
             self.cancel("No PCI Device specified")

--- a/io/pci/PowerVMEEH.py.data/PowerVMEEH.yaml
+++ b/io/pci/PowerVMEEH.py.data/PowerVMEEH.yaml
@@ -1,4 +1,4 @@
 scenario:
     max_freeze: 1
     function: 4
-    pci_device:
+    pci_device: ""

--- a/io/pci/PowerVMEEH.py.data/PowerVMEEH_nvme.yaml
+++ b/io/pci/PowerVMEEH.py.data/PowerVMEEH_nvme.yaml
@@ -1,5 +1,5 @@
 scenario:
     max_freeze: 5
     function: 6
-    pci_device: 
+    pci_device: "" 
     additional_command: nvme list

--- a/io/pci/PowerVMEEH.py.data/Readme
+++ b/io/pci/PowerVMEEH.py.data/Readme
@@ -2,7 +2,7 @@ This script injects one EEH errors on all the adapters present in the machine.
 It takes two parameters. One is the value to set max_eeh_frezze bit, and other
 is the EEH function number, which user wishes to use.
 User can specify which pci address to use (output from lspci command), as a list
-separated by comma
+separated by space "0:20:0002"
 
 Function can take values from 0-17, each value indicates different type of error.
 e.g.,   # 0 : MMIO read

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -57,10 +57,11 @@ class PCIHotPlugTest(Test):
             if not linux_modules.module_is_loaded("pnv_php"):
                 linux_modules.load_module("pnv_php")
         self.dic = {}
-        self.device = self.params.get('pci_devices', default=' ').split(" ")
+        self.device = self.params.get('pci_devices', default="")
         self.count = int(self.params.get('count', default='1'))
         if not self.device:
             self.cancel("PCI_address not given")
+        self.device = self.device.split(" ")
         smm = SoftwareManager()
         if not smm.check_installed("pciutils") and not smm.install("pciutils"):
             self.cancel("pciutils package is need to test")


### PR DESCRIPTION
make sure the default value is porper and skip the test
for all non pci devices

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>