### PR TITLE
ethtool fix for unsupported operation

### DIFF
--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -137,7 +137,10 @@ class Ethtool(Test):
             ret = process.run(cmd, shell=True, verbose=True,
                               ignore_status=True)
             if ret.exit_status != 0:
-                self.fail("failed")
+                if "Operation not supported" in ret.stderr_text:
+                    self.log.warn("%s failed" % self.args)
+                else:
+                    self.fail("failed")
         if self.networkinterface.ping_check(self.peer, count=10000,
                                             options='-f') is not None:
             self.fail("flood ping test failed")


### PR DESCRIPTION
make changes for unsupported operation as warn
in place of failed.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>
Reported-by Abdul Haleem <abdhalee@linux.vnet.ibm.com>