### PR TITLE
fixed htx for ip restore in host and peer

### DIFF
--- a/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+++ b/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
@@ -3,10 +3,11 @@ host_public_ip: x.xx.xxx.xx
 peer_public_ip: x.xx.xxx.xy
 peer_password: "*******"
 peer_user: "root"
-host_interfaces: ""
+htx_host_interfaces: ""
 peer_interfaces: ""
 host_ips: ""
 netmask: ""
+peer_ips: ""
 net_ids: ""
 # time limit in minutes
 time_limit: 2


### PR DESCRIPTION
add a function for ip config to original ip address
for host and peer after htx run.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>
Reported-by Abdul Haleem abdhalee@linux.vnet.ibm.com