### PR TITLE
Using latest get_device_total_space function

### DIFF
--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -80,7 +80,7 @@ class Disktest(Test):
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
-        gigabytes = int(lv_utils.get_diskspace(self.disk)) // 1073741824
+        gigabytes = lv_utils.get_device_total_space(self.disk) // 1073741824
         memory_mb = memory.meminfo.MemTotal.m
         self.chunk_mb = gigabytes * 950
 

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -165,7 +165,7 @@ class FioTest(Test):
     def create_lv(self, l_disk):
         vgname = 'avocado_vg'
         lvname = 'avocado_lv'
-        lv_size = int(lv_utils.get_diskspace(l_disk)) / 2330168
+        lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
         lv_utils.vg_create(vgname, l_disk)
         lv_utils.lv_create(vgname, lvname, lv_size)
         return '/dev/%s/%s' % (vgname, lvname)

--- a/io/disk/ssd/blkdiscard.py
+++ b/io/disk/ssd/blkdiscard.py
@@ -61,7 +61,7 @@ class Blkdiscard(Test):
         """
         Sectors are dicarded for the different values of OFFSET and LENGTH.
         """
-        size = int(lv_utils.get_diskspace(self.disk))
+        size = lv_utils.get_device_total_space(self.disk)
         cmd = "blkdiscard %s -o 0 -v -l %d" % (self.disk, size)
         process.run(cmd, shell=True)
         cmd = "blkdiscard %s -o %d \


### PR DESCRIPTION
lv_utils recently deprecated the get_diskspace() in favour of 2
new functions get_device_total_space() and
get_devices_total_space(). So, updating the tests to use the
newer functions.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>