### PR TITLE
added restore backup file in bonding test

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -447,6 +447,7 @@ class Bonding(Test):
             networkinterface = NetworkInterface(host_interface, self.localhost)
             if networkinterface.set_mtu("1500") is not None:
                 self.cancel("Failed to set mtu in host")
+            networkinterface.restore_from_backup()
         try:
             for interface in self.peer_interfaces:
                 peer_networkinterface = NetworkInterface(interface, self.remotehost)


### PR DESCRIPTION
add restore_from_backup() in to bonding for old config file
restore.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>