### PR TITLE
Remove hardcoded node id

### DIFF
--- a/io/disk/fiotest.py.data/fio-libpmem.job
+++ b/io/disk/fiotest.py.data/fio-libpmem.job
@@ -36,12 +36,6 @@ scramble_buffers=1
 direct=1
 
 #
-# Setting for fio process's CPU Node and Memory Node
-#
-numa_cpu_nodes=0
-numa_mem_policy=bind:0
-
-#
 # split means that each job will get a unique CPU from the CPU set
 #
 cpus_allowed_policy=split


### PR DESCRIPTION
Some machine does not have node id 0 and hence the fio job fails.

Signed-off-by: Harish <harish@linux.ibm.com>