### PR TITLE
Remove main() to adapt to latest avocado release

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -21,7 +21,6 @@ Stress test for CPU
 import multiprocessing
 from random import randint
 from avocado import Test
-from avocado import main
 from avocado.utils import process, cpu, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -303,7 +302,3 @@ class cpustresstest(Test):
             "ppc64_cpu --smt=off && ppc64_cpu --smt=on && ppc64_cpu --smt=%s"
             % self.curr_smt, shell=True)
         self.__online_cpus(totalcpus)
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/dwh.py
+++ b/cpu/dwh.py
@@ -20,7 +20,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
 
@@ -94,7 +93,3 @@ class Dwh(Test):
         if process.system('./dwh %s dwh.test' % args,
                           shell=True, ignore_status=True, sudo=True):
             self.fail("Please check the logs for debug")
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -23,7 +23,6 @@ import json
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build
@@ -92,7 +91,3 @@ class Ebizzy(Test):
                                       'real_time': real,
                                       'user': usr_time,
                                       'sys': sys_time})
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/em_cpufreq.py
+++ b/cpu/em_cpufreq.py
@@ -16,7 +16,6 @@
 import random
 import platform
 from avocado import Test
-from avocado import main
 from avocado import skipIf
 from avocado.utils import process, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
@@ -98,7 +97,3 @@ class Cpufreq(Test):
         """
         f_name = "/sys/devices/system/cpu/cpu%s/cpufreq/%s" % (self.cpu, file)
         return open(f_name, 'r').readline().strip('\n').strip(' ')
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/em_cpuhotplug.py
+++ b/cpu/em_cpuhotplug.py
@@ -18,7 +18,6 @@
 import random
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, cpu, genio, distro
 
 
@@ -134,7 +133,3 @@ class Cpuhotplug_Test(Test):
             self.log.info("Failed to online the cpu %s" % cpu_num)
         else:
             self.log.info("Online the cpu : %s" % cpu_num)
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/em_cpuidle.py
+++ b/cpu/em_cpuidle.py
@@ -19,7 +19,6 @@ import subprocess
 import re
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import process, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
 
@@ -104,7 +103,3 @@ class cpuidle(Test):
             return 'nap'
         if val == 'FastSleep':
             return 'fastsleep_'
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/em_cpupower.py
+++ b/cpu/em_cpupower.py
@@ -17,7 +17,6 @@
 import random
 import platform
 from avocado import Test
-from avocado import main
 from avocado import skipIf
 from avocado.utils import process, distro
 from avocado.utils.software_manager import SoftwareManager
@@ -195,7 +194,3 @@ class cpupower(Test):
             self.set_freq_val(cur)
         else:
             self.set_governor(initial_governor)
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/em_quad_level_frequency_transitions.py
+++ b/cpu/em_quad_level_frequency_transitions.py
@@ -22,7 +22,6 @@ import platform
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, distro, cpu, genio
 from avocado import skipIf
 from avocado.utils.software_manager import SoftwareManager
@@ -181,7 +180,3 @@ class freq_transitions(Test):
             1].strip().split(' ')[0]
         output = float(output) * (10 ** 6)
         return output
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/em_smt_folding_test.py
+++ b/cpu/em_smt_folding_test.py
@@ -20,7 +20,6 @@ import platform
 from threading import Thread
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build
 from avocado.utils import process, cpu, distro, genio
 from avocado.utils.software_manager import SoftwareManager
@@ -136,7 +135,3 @@ class SmtFolding(Test):
                           " multi-thread performance ")
         else:
             self.fail("FAIL : Performance is degraded when SMT off")
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/linsched.py
+++ b/cpu/linsched.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, git, build, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -65,7 +64,3 @@ class Linsched(Test):
 
         if process.system('./%s' % self.args, ignore_status=True, shell=True):
             self.fail('Test [%s] failed.' % self.args)
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, process, distro, memory
 from avocado.utils.software_manager import SoftwareManager
 
@@ -76,7 +75,3 @@ class Numactl(Test):
                 self.log.warn('Few tests failed due to less NUMA mem-nodes')
             else:
                 self.fail('test failed, Please check debug log')
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/numatop.py
+++ b/cpu/numatop.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, process, distro, cpu
 from avocado.utils.software_manager import SoftwareManager
 
@@ -88,7 +87,3 @@ class Numatop(Test):
         if not mgen_flag:
             self.fail('Numatop failed to record mgen latency. Please check '
                       'the record file: %s/result_file' % self.sourcedir)
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/pmqa.py
+++ b/cpu/pmqa.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado import skipIf
 from avocado.utils import process, git
 from avocado.utils.software_manager import SoftwareManager
@@ -75,7 +74,3 @@ class Pmqa(Test):
         if not result.stdout == '':
             self.log.info(result.stdout)
             self.fail("few tests cases failed please check log")
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -21,7 +21,6 @@ Test to verify ppc64_cpu command.
 import os
 import glob
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import cpu
 from avocado.utils import distro
@@ -191,7 +190,3 @@ class PPC64Test(Test):
         process.system_output("%s=%s" % (self.smt_str,
                                          self.curr_smt), shell=True)
         process.system_output("dmesg")
-
-
-if __name__ == "__main__":
-    main()

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -19,7 +19,6 @@
 Test for sensors command
 """
 from avocado import Test
-from avocado import main
 from avocado.utils import process, linux_modules
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -116,7 +115,3 @@ class Sensors(Test):
         error_list = self.check_errors('sensors -u')
         if len(error_list) > 0:
             self.fail('sensors -u command failed with %s' % error_list)
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/blktests.py
+++ b/fs/blktests.py
@@ -17,7 +17,6 @@ import os
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, archive, genio, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -68,7 +67,3 @@ class Blktests(Test):
 
     def clear_dmesg(self):
         process.run("dmesg -c ", sudo=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/filebench.py
+++ b/fs/filebench.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, archive, build
 from avocado.utils.software_manager import SoftwareManager
 
@@ -69,7 +68,3 @@ class Filebench(Test):
         cmd = '%s -f %s' % (binary_path, testfile_path)
         out = process.system_output(cmd)
         self.log.info(b"result:" + out)
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/flail.py
+++ b/fs/flail.py
@@ -17,7 +17,6 @@ import os
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, archive
 from avocado.utils.software_manager import SoftwareManager
 
@@ -61,7 +60,3 @@ class Flail(Test):
 
     def clear_dmesg(self):
         process.run("dmesg -C ", sudo=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/fs-fuzz.py
+++ b/fs/fs-fuzz.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, archive, build
 from avocado.utils.software_manager import SoftwareManager
 
@@ -77,7 +76,3 @@ class FsFuzz(Test):
                           ignore_status=True) != 0:
             self.fail("stress test for the C streams layer failed")
         self.verify_dmesg()
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/fsshrink.py
+++ b/fs/fsshrink.py
@@ -17,7 +17,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 
 
@@ -54,7 +53,3 @@ class Fsshrink(Test):
             self.fail("unlink/rmdir (shrink) test failed")
 
         self.verify_dmesg()
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/fsx.py
+++ b/fs/fsx.py
@@ -15,7 +15,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process, genio
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.partition import Partition
@@ -107,7 +106,3 @@ class Fsx(Test):
     def tearDown(self):
         if self.mount_dir:
             self.device.unmount()
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/pjdfstest.py
+++ b/fs/pjdfstest.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, archive, build
 from avocado.utils.software_manager import SoftwareManager
 
@@ -68,7 +67,3 @@ class Pjdfstest(Test):
                                   % str(string.splitlines()))
         except process.CmdError as details:
             self.fail("failed: %s" % details)
-
-
-if __name__ == "__main__":
-    main()

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -28,7 +28,6 @@ import shutil
 
 import avocado
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, git, distro, partition
 from avocado.utils import disk, data_structures, pmem
 from avocado.utils import genio
@@ -517,7 +516,3 @@ class Xfstests(Test):
             error_msg = 'Could not verify test result. Please check the logs.'
 
         return error_msg
-
-
-if __name__ == "__main__":
-    main()

--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -23,7 +23,6 @@ import os
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, distro, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -97,7 +96,3 @@ class Fsfuzzer(Test):
         if process.system("%s %s" % (self._fsfuzz, self._args), sudo=True,
                           ignore_status=True):
             self.fail("fs_fuzzer command return as non zero exit code ")
-
-
-if __name__ == "__main__":
-    main()

--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -19,7 +19,6 @@ import os
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -101,7 +100,3 @@ class Trinity(Test):
         """
 
         process.system('userdel -r  trinity', sudo=True, ignore_status=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/connectathon.py
+++ b/generic/connectathon.py
@@ -22,7 +22,6 @@ import os
 import tempfile
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import git
@@ -95,7 +94,3 @@ class Connectathon(Test):
             self.log.info("Test failed: ")
         if self.nfail != 0:
             raise self.fail('Connectathon test suite failed.')
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/criu.py
+++ b/generic/criu.py
@@ -16,7 +16,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import distro
@@ -60,7 +59,3 @@ class CRIU(Test):
             "grep -w FAIL %s" % logfile, shell=True, ignore_status=True).decode("utf-8")
         if failed_tests:
             self.fail("test failed, Please check debug log for failed test cases")
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/cxl.py
+++ b/generic/cxl.py
@@ -15,7 +15,7 @@
 # Author: sudeesh john <sudeesh@linux.vnet.ibm.com>
 
 import os
-from avocado import Test, main
+from avocado import Test
 from avocado.utils import build, git, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -56,7 +56,3 @@ class Cxl(Test):
             self.fail("%s is failed" % cmd)
         elif "failed" in result.stdout:
             self.fail("%s is failed" % cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -22,7 +22,6 @@ import os
 import time
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import build
 from avocado.utils import process, archive
@@ -190,7 +189,3 @@ class HtxTest(Test):
             daemon_state = process.system_output('/etc/init.d/htx.d status')
             if daemon_state.decode().split(" ")[-1] == 'running':
                 process.system('/usr/lpp/htx/etc/scripts/htxd_shutdown')
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/interbench.py
+++ b/generic/interbench.py
@@ -21,7 +21,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build, disk, memory
@@ -72,7 +71,3 @@ class Interbench(Test):
         args += ' c'
         process.system("%s ' run ' %s" % (os.path.join(
             self.sourcedir, 'interbench'), args), sudo=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -22,7 +22,6 @@
 import os
 import re
 from avocado import Test
-from avocado import main
 from avocado.utils import build, distro, genio
 from avocado.utils import process, archive
 from avocado.utils.partition import Partition
@@ -151,7 +150,3 @@ class LTP(Test):
     def tearDown(self):
         if self.mount_dir:
             self.device.unmount()
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/nstress.py
+++ b/generic/nstress.py
@@ -16,7 +16,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import distro, archive, process
 
 
@@ -61,7 +60,3 @@ class NStress(Test):
                           (self.procs, self.duration),
                           ignore_status=True, sudo=True) != 1:
             self.fail("ncpu test failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/openblas.py
+++ b/generic/openblas.py
@@ -17,7 +17,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import archive
 from avocado.utils.software_manager import SoftwareManager
@@ -62,7 +61,3 @@ class Openblas(Test):
             if '[FAIL]' in line:
                 self.fail("test failed, Please check debug log for failed"
                           "test cases")
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/rcutorture.py
+++ b/generic/rcutorture.py
@@ -22,7 +22,6 @@ import time
 import multiprocessing
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, cpu
 from avocado.utils import linux_modules
 
@@ -130,7 +129,3 @@ class Rcutorture(Test):
     def tearDown(self):
         if linux_modules.module_is_loaded('rcutorture'):
             linux_modules.unload_module('rcutorture')
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/service_check.py
+++ b/generic/service_check.py
@@ -20,7 +20,6 @@
 import os
 import configparser
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.service import SpecificServiceManager
 from avocado.utils import distro
@@ -96,7 +95,3 @@ class service_check(Test):
             self.fail("List of services failed: %s" % services_failed)
         else:
             self.log.info("All Services Passed the ON/OFF test")
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -19,7 +19,6 @@
 import os
 import multiprocessing
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, archive, distro, memory
 from avocado.utils.software_manager import SoftwareManager
 
@@ -161,7 +160,3 @@ class Stressng(Test):
         if ERROR:
             self.fail("Test failed with following errors in dmesg :  %s " %
                       "\n".join(ERROR))
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/stress.py
+++ b/generic/stress.py
@@ -23,7 +23,6 @@ import os
 import multiprocessing
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import disk
 from avocado.utils import build
@@ -112,7 +111,3 @@ class Stress(Test):
         os.chdir(self.sourcedir)
         cmd = ('./src/stress %s' % args)
         process.run(cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/stressapptest.py
+++ b/generic/stressapptest.py
@@ -16,7 +16,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, cpu, memory, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -67,7 +66,3 @@ class StressAppTest(Test):
             os.remove(self.test_file)
         except OSError:
             self.log.warn("Failed to remove fail")
-
-
-if __name__ == "__main__":
-    main()

--- a/generic/sysbench.py
+++ b/generic/sysbench.py
@@ -17,7 +17,6 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process, git
 from avocado.utils.software_manager import SoftwareManager
 
@@ -104,7 +103,3 @@ class Sysbench(Test):
         cmdline = "sysbench %s" % " ".join(args)
         self.run_cmd(cmdline)
         self.verify_dmesg()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/common/bootlist_test.py
+++ b/io/common/bootlist_test.py
@@ -17,7 +17,6 @@ Bootlist Test
 """
 
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils import process
 from avocado import skipUnless
@@ -164,7 +163,3 @@ class BootlisTest(Test):
         self.display_service_firmware_device()
         self.set_original_normal_bootlist()
         self.set_original_service_bootlist()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/common/distro_tools.py
+++ b/io/common/distro_tools.py
@@ -18,7 +18,6 @@
 Test the different tools
 """
 
-from avocado import main
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import pci
@@ -78,7 +77,3 @@ class DisrtoTool(Test):
         else:
             if result.exit_status != 0:
                 self.fail("%s tool failed" % self.tool)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/common/virtual_bind_unbind.py
+++ b/io/common/virtual_bind_unbind.py
@@ -21,7 +21,6 @@ import time
 import netifaces
 from avocado.utils import genio
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.process import CmdError
@@ -134,7 +133,3 @@ class VirtualizationDriverBindTest(Test):
         if self.device_type in ["l-lan", "vnic"]:
             self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
             self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/Avago_storage_adapter/avago3008.py
+++ b/io/disk/Avago_storage_adapter/avago3008.py
@@ -25,7 +25,6 @@ import os
 import time
 from avocado import Test
 from avocado.utils import process
-from avocado import main
 
 
 class Avago3008(Test):
@@ -253,7 +252,3 @@ class Avago3008(Test):
         """
         while self.adapter_status("Current operation") != 'None':
             time.sleep(10)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/Avago_storage_adapter/avago9361.py
+++ b/io/disk/Avago_storage_adapter/avago9361.py
@@ -22,7 +22,6 @@ This scripts runs test on LSI9361
 
 from avocado import Test
 from avocado.utils import process
-from avocado import main
 
 
 class Avago9361(Test):
@@ -98,7 +97,3 @@ class Avago9361(Test):
         """
         if process.system(cmd, ignore_status=True, shell=True) != 0:
             self.fail(errmsg)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/Avago_storage_adapter/avago9361_vd.py
+++ b/io/disk/Avago_storage_adapter/avago9361_vd.py
@@ -23,7 +23,6 @@ This scripts performs Virtual Drive(VD) operations on drives
 import time
 from avocado import Test
 from avocado.utils import process
-from avocado import main
 
 
 class Avago9361(Test):
@@ -418,7 +417,3 @@ class Avago9361(Test):
         if 'ghs_dhs' in str(self.name):
             cmd = "%s /c%d set autorebuild=off" % (self.tool, self.controller)
             self.check_pass(cmd, False, "Failed to set auto rebuild off")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -23,7 +23,6 @@ arcconf - Array configuration utility for PMC-Sierra
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
-from avocado import main
 from avocado.utils import distro
 
 
@@ -150,7 +149,3 @@ class Arcconftest(Test):
         if "SAVECONFIG" not in self.option:
             cmd = "rm -rf /tmp/arcconf_cntl*"
             self.check_pass(cmd, "Failed to remove temporary files")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/arcconf/arcconf_drive_oper.py
+++ b/io/disk/arcconf/arcconf_drive_oper.py
@@ -24,7 +24,6 @@ arcconf - Array configuration utility for PMC-Sierra
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
-from avocado import main
 from avocado.utils import distro
 
 
@@ -188,7 +187,3 @@ class Arcconftest(Test):
                 cmd = "echo y | arcconf delete %s logicaldrive %s" % \
                       (self.crtl_no, self.logicaldrive)
                 self.check_pass(cmd, "Failed to cleanup Logical drive")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/arcconf/arcconf_migration.py
+++ b/io/disk/arcconf/arcconf_migration.py
@@ -25,7 +25,6 @@ import time
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
-from avocado import main
 from avocado.utils import distro
 
 
@@ -238,7 +237,3 @@ class Arcconftest(Test):
         else:
             if cond == 0:
                 self.cancel("Test Skipped!! OS disk requested for removal")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/arcconf/arcconf_raid_oper.py
+++ b/io/disk/arcconf/arcconf_raid_oper.py
@@ -25,7 +25,6 @@ import time
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
-from avocado import main
 from avocado.utils import distro
 
 
@@ -262,7 +261,3 @@ class Arcconftest(Test):
                 cmd = "echo y | arcconf delete %s logicaldrive %s" % \
                       (self.crtl_no, self.logicaldrive)
                 self.check_pass(cmd, "Failed to cleanup Logical drive")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -25,7 +25,6 @@ Bonnie test
 import os
 import getpass
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process, distro
@@ -131,7 +130,3 @@ class Bonnie(Test):
         delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
         if process.system(delete_fs, shell=True, ignore_status=True):
             self.fail("Failed to delete filesystem on %s", self.disk)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -24,7 +24,6 @@ import multiprocessing
 import json
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build
@@ -84,7 +83,3 @@ class Dbench(Test):
         (throughput, procs) = pattern.findall(self.results)[0]
         self.whiteboard = json.dumps({'throughput': throughput,
                                       'procs': procs})
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -24,7 +24,6 @@ name, Size, UUID, mount points and IO Sector sizes
 import platform
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils import distro
@@ -294,7 +293,3 @@ class DiskInfo(Test):
         delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
         if process.system(delete_fs, shell=True, ignore_status=True):
             self.fail("Failed to delete filesystem on %s", self.disk)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -26,7 +26,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import memory
 from avocado.utils import process, distro
@@ -164,7 +163,3 @@ class Disktest(Test):
         delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
         if process.system(delete_fs, shell=True, ignore_status=True):
             self.fail("Failed to delete filesystem on %s", self.disk)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/dlpar_vscsi.py
+++ b/io/disk/dlpar_vscsi.py
@@ -18,7 +18,6 @@ DLPAR operations
 """
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.ssh import Session
 
@@ -103,7 +102,3 @@ class DlparTest(Test):
         for _ in range(self.num_of_dlpar):
             self.dlpar_remove()
             self.dlpar_add()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -26,7 +26,6 @@ import os
 import avocado
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import pmem
@@ -214,7 +213,3 @@ class FioTest(Test):
             self.delete_lv()
         if os.path.exists(self.fio_file):
             os.remove(self.fio_file)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -24,7 +24,6 @@ fs_mark: Benchmark synchronous/async file creation
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process, distro
@@ -110,7 +109,3 @@ class FSMark(Test):
         delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
         if process.system(delete_fs, shell=True, ignore_status=True):
             self.fail("Failed to delete filesystem on %s", self.disk)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -21,7 +21,6 @@ HTX Test
 import os
 import time
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import build
 from avocado.utils import process, archive
@@ -221,7 +220,3 @@ class HtxTest(Test):
         daemon_state = process.system_output('/etc/init.d/htx.d status')
         if daemon_state.decode("utf-8").split(" ")[-1] == 'running':
             process.system('/usr/lpp/htx/etc/scripts/htxd_shutdown')
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/ioping.py
+++ b/io/disk/ioping.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, archive, build
 from avocado.utils.software_manager import SoftwareManager
 
@@ -70,7 +69,3 @@ class Ioping(Test):
 
         if process.system('./ioping %s' % cmd, ignore_status=True, shell=True):
             self.fail("test run fails of  %s" % cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -26,7 +26,6 @@ import json
 import logging
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build
@@ -573,7 +572,3 @@ class IOZone(Test):
             plotter = IOzonePlotter(self.log, results_file=results_path,
                                     output_dir=analysisdir)
             plotter.plot_2d_graphs()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -25,7 +25,6 @@ LTP Filesystem tests
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import build, distro
 from avocado.utils import process, archive
 from avocado.utils.software_manager import SoftwareManager
@@ -133,7 +132,3 @@ class LtpFs(Test):
         delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
         if process.system(delete_fs, shell=True, ignore_status=True):
             self.fail("Failed to delete filesystem on %s", self.disk)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -23,7 +23,6 @@ LTP fsstress test
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import process, archive
 from avocado.utils.software_manager import SoftwareManager
@@ -109,7 +108,3 @@ class LtpFs(Test):
             delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
             if process.system(delete_fs, shell=True, ignore_status=True):
                 self.fail("Failed to delete filesystem on %s", self.disk)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -31,7 +31,6 @@ import os
 
 import avocado
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import lv_utils
 from avocado.utils import distro
@@ -197,7 +196,3 @@ class Lvsetup(Test):
         A volume group with given name is deleted in the ramdisk
         """
         self.delete_lv()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -24,7 +24,6 @@ import shutil
 import time
 from pprint import pprint
 from avocado import Test
-from avocado import main
 from avocado.utils import distro, process
 from avocado.utils import multipath
 from avocado.utils import service
@@ -308,7 +307,3 @@ class MultipathTest(Test):
 
         # Need to wait for some time to make sure multipaths are loaded.
         wait.wait_for(self.mpath_svc.status, timeout=10)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/mvcli_test.py
+++ b/io/disk/mvcli_test.py
@@ -22,7 +22,6 @@ import re
 import platform
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.process import CmdError
 
@@ -266,7 +265,3 @@ class MvcliTest(Test):
         self.test_delete()
         self.log.info("Gathering any kernel errors")
         self.run_command("dmesg -T --level=alert,crit,err,warn")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -29,7 +29,6 @@ import time
 import sys
 import json
 from avocado import Test
-from avocado import main
 from avocado.utils import process, distro
 from avocado.utils import partition as partition_lib
 
@@ -216,7 +215,3 @@ class ParallelDd(Test):
             self.fsys.unmount()
         except process.CmdError:
             pass
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/port_bounce.py
+++ b/io/disk/port_bounce.py
@@ -19,7 +19,6 @@ import re
 import time
 # import telnetlib
 from avocado import Test
-from avocado import main
 import paramiko
 from avocado.utils import process
 from avocado.utils import genio
@@ -318,7 +317,3 @@ class PortBounceTest(Test):
                                        shell=True, sudo=True)
 
         self.log.debug("Kernel Errors: %s", output)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/rawread.py
+++ b/io/disk/rawread.py
@@ -20,7 +20,6 @@ Rawread test
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process, distro
@@ -72,7 +71,3 @@ class Rawread(Test):
 
         if err_val:
             self.fail("test failed for values : %s" % " ".join(err_val))
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/scsi_add_remove.py
+++ b/io/disk/scsi_add_remove.py
@@ -19,7 +19,6 @@
 This script will perform scsi add and remove test case
 """
 import time
-from avocado import main
 from avocado import Test
 from avocado.utils import process, genio
 from avocado.utils.software_manager import SoftwareManager
@@ -127,7 +126,3 @@ class ScsiAddRemove(Test):
         '''
         if self.err_paths:
             self.fail("\nPaths failed to add or remove %s\n" % self.err_paths)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/smartctl.py
+++ b/io/disk/smartctl.py
@@ -25,7 +25,6 @@ hard drives and solid-state drives
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
-from avocado import main
 
 
 class SmartctlTest(Test):
@@ -68,7 +67,3 @@ class SmartctlTest(Test):
         if process.system(cmd, timeout=1200, ignore_status=True,
                           shell=True):
             self.fail("Smartctl option %s FAILS" % self.option)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -29,7 +29,6 @@ import time
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
-from avocado import main
 
 
 class SoftwareRaid(Test):
@@ -154,7 +153,3 @@ class SoftwareRaid(Test):
             self.check_pass(cmd, "Failed to stop the MD device")
             cmd = "mdadm --zero-superblock %s %s" % (self.disk, self.sparedisk)
             self.check_pass(cmd, "Failed to remove the MD device")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/ssd/blkdiscard.py
+++ b/io/disk/ssd/blkdiscard.py
@@ -24,7 +24,6 @@ import avocado
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process, lv_utils
-from avocado import main
 
 # this block need to removed when test moved to python3
 try:
@@ -82,7 +81,3 @@ class Blkdiscard(Test):
                                       shell=True) == 0:
                         self.fail("Blkdiscard passed for the values which is, \
                             not aligned to 4096 but actually it should fail")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/ssd/ezfiotest.py
+++ b/io/disk/ssd/ezfiotest.py
@@ -22,7 +22,6 @@ SSD performance.
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import process
 from avocado.utils import genio
@@ -87,7 +86,3 @@ class EzfioTest(Test):
         Clean up
         """
         os.chdir(self.cwd)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/ssd/nvme_cli_selftests.py
+++ b/io/disk/ssd/nvme_cli_selftests.py
@@ -21,7 +21,6 @@ NVM-Express user space tooling for Linux, which handles NVMe devices.
 import os
 import pkgutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils.software_manager import SoftwareManager
@@ -83,7 +82,3 @@ class NVMeCliSelfTest(Test):
         res = [res.stdout.decode("utf-8"), res.stderr.decode("utf-8")]
         if any('FAILED' in line for line in res):
             self.fail("Test Failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -22,7 +22,6 @@ using nvme cli.
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils import build
@@ -431,7 +430,3 @@ class NVMeTest(Test):
         cmd = '%s subsystem-reset %s' % (self.binary, self.device)
         if process.system(cmd, ignore_status=True, shell=True):
             self.fail("Subsystem reset failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -25,7 +25,6 @@ to measure file system performance.
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process, distro
@@ -116,7 +115,3 @@ class Tiobench(Test):
         delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % self.disk
         if process.system(delete_fs, shell=True, ignore_status=True):
             self.fail("Failed to delete filesystem on %s", self.disk)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/vfc-tests/vfc_dlpar.py
+++ b/io/disk/vfc-tests/vfc_dlpar.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     from pexpect import pxssh
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import multipath
 from avocado.utils import distro
@@ -350,7 +349,3 @@ class VirtualFC(Test):
         '''
         if self.pxssh.isalive():
             self.pxssh.terminate()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/disk/vfc-tests/virtual_fc.py
+++ b/io/disk/vfc-tests/virtual_fc.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     from pexpect import pxssh
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import multipath
 from avocado.utils import distro
@@ -566,7 +565,3 @@ class VirtualFC(Test):
         '''
         if self.pxssh.isalive():
             self.pxssh.terminate()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/driver/driver_bind_test.py
+++ b/io/driver/driver_bind_test.py
@@ -22,7 +22,6 @@ This test verifies that for given adapters.
 import os
 import time
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import pci
 from avocado.utils.software_manager import SoftwareManager
@@ -84,7 +83,3 @@ class DriverBindTest(Test):
                     self.fail('%s not unbound in itertion=%s' % (pci_addr, _))
                 if self.return_code == 2:
                     self.fail('%s not bound back itertion=%s' % (pci_addr, _))
-
-
-if __name__ == "__main__":
-    main()

--- a/io/driver/driver_parameter.py
+++ b/io/driver/driver_parameter.py
@@ -19,7 +19,6 @@ This Script verfies driver module parameter.
 """
 import time
 import netifaces
-from avocado import main
 from avocado.utils import process
 from avocado.utils import linux_modules, genio
 from avocado.utils import configure_network
@@ -153,7 +152,3 @@ class Moduleparameter(Test):
         if linux_modules.module_is_loaded(self.module) is False:
             self.fail("Cannot restore default values for Module : %s"
                       % self.module)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/driver/driver_parameter_block_device.py
+++ b/io/driver/driver_parameter_block_device.py
@@ -19,7 +19,6 @@
 This Script verfies driver module parameter.
 """
 import time
-from avocado import main
 from avocado.utils import process
 from avocado.utils import linux_modules, genio
 from avocado.utils import wait
@@ -169,7 +168,3 @@ class Moduleparameter(Test):
             self.fail("Cannot restore default values for Module : %s"
                       % self.module)
         self.log.info("Restore of default param is success")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/driver/module_unload_load.py
+++ b/io/driver/module_unload_load.py
@@ -17,7 +17,6 @@
 
 import time
 import os
-from avocado import main
 from avocado.utils import process
 from avocado.utils import linux_modules, genio
 from avocado.utils.software_manager import SoftwareManager
@@ -143,7 +142,3 @@ class ModuleLoadUnload(Test):
 
         if self.error_modules:
             self.fail("Failed Modules: %s" % self.error_modules)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/genwqe/genwqetest.py
+++ b/io/genwqe/genwqetest.py
@@ -22,7 +22,6 @@ import os
 import shutil
 import time
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import download
 from avocado.utils.software_manager import SoftwareManager
@@ -198,7 +197,3 @@ class GenWQETest(Test):
         for fol in self.dirs_used:
             if os.path.isdir(fol):
                 shutil.rmtree(fol)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/Network_config.py
+++ b/io/net/Network_config.py
@@ -19,7 +19,6 @@
 # driver name, businfo, hardware address
 
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
@@ -162,7 +161,3 @@ class NetworkconfigTest(Test):
         '''
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -28,7 +28,6 @@ import socket
 import fcntl
 import struct
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import distro
@@ -460,7 +459,3 @@ class Bonding(Test):
     def error_check(self):
         if self.err:
             self.fail("Tests failed. Details:\n%s" % "\n".join(self.err))
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/bridge.py
+++ b/io/net/bridge.py
@@ -18,7 +18,6 @@
 
 import os
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils import process
 from avocado.utils.network.interfaces import NetworkInterface
@@ -100,7 +99,3 @@ class Bridging(Test):
         path = "/etc/sysconfig/network-scripts/ifcfg-%s" \
                % self.bridge_interface
         os.remove(path)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -23,7 +23,6 @@ This test needs to be run as root.
 """
 
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
@@ -184,7 +183,3 @@ class Ethtool(Test):
         self.interface_state_change(self.iface, "up", "yes")
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/htx_nic_devices.py
+++ b/io/net/htx_nic_devices.py
@@ -24,7 +24,6 @@ except ImportError:
 
 from avocado import Test
 from avocado.utils import distro
-from avocado import main
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import build
@@ -779,7 +778,3 @@ class HtxNicTest(Test):
         self.shutdown_htx_daemon()
         self.ip_restore_host()
         self.ip_restore_peer()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -25,7 +25,6 @@ ibv_srq_pingpong
 
 import time
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
@@ -199,7 +198,3 @@ class PingPong(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/mckey.py
+++ b/io/net/infiniband/mckey.py
@@ -23,7 +23,6 @@ import time
 import netifaces
 from netifaces import AF_INET
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process, distro
 from avocado.utils.network.interfaces import NetworkInterface
@@ -174,7 +173,3 @@ class Mckey(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/mofed_install_test.py
+++ b/io/net/infiniband/mofed_install_test.py
@@ -20,7 +20,6 @@ MOFED Install Test
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 
 
@@ -86,7 +85,3 @@ class MOFEDInstallTest(Test):
         os.chdir(self.pwd)
         cmd = "umount %s" % self.workdir
         process.run(cmd, shell=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/ping6.py
+++ b/io/net/infiniband/ping6.py
@@ -23,7 +23,6 @@ import time
 import netifaces
 from netifaces import AF_INET, AF_INET6
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.network.hosts import LocalHost, RemoteHost
@@ -179,7 +178,3 @@ class Ping6(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/rdma_tests.py
+++ b/io/net/infiniband/rdma_tests.py
@@ -22,7 +22,6 @@ RDMA test for infiniband adaptors
 
 import time
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process, distro
@@ -169,7 +168,3 @@ class RDMA(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/rping.py
+++ b/io/net/infiniband/rping.py
@@ -23,7 +23,6 @@ import time
 import netifaces
 from netifaces import AF_INET
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process, distro
 from avocado.utils.network.interfaces import NetworkInterface
@@ -171,7 +170,3 @@ class Rping(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/ucmatose.py
+++ b/io/net/infiniband/ucmatose.py
@@ -23,7 +23,6 @@ import time
 import netifaces
 from netifaces import AF_INET
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process, distro
 from avocado.utils.network.interfaces import NetworkInterface
@@ -165,7 +164,3 @@ class Ucmatose(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/infiniband/udaddy.py
+++ b/io/net/infiniband/udaddy.py
@@ -23,7 +23,6 @@ import time
 import netifaces
 from netifaces import AF_INET
 from avocado import Test
-from avocado import main
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process, distro
 from avocado.utils.network.interfaces import NetworkInterface
@@ -164,7 +163,3 @@ class Udady(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -21,7 +21,6 @@ bandwidth on IP networks.
 
 import os
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import build
@@ -156,7 +155,3 @@ class Iperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -20,7 +20,6 @@
 
 
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.ssh import Session
@@ -129,7 +128,3 @@ class ReceiveMulticastTest(Test):
             self.log.info("unable to unset all mulicast option")
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -15,7 +15,6 @@
 # Author: Harsha Thyagaraja <harshkid@linux.vnet.ibm.com>
 
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
@@ -138,7 +137,3 @@ class MultiportStress(Test):
             networkinterface = NetworkInterface(interface, self.local)
             networkinterface.remove_ipaddr(ipaddr, self.netmask)
             networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/net_tools.py
+++ b/io/net/net_tools.py
@@ -21,7 +21,6 @@ import os
 import re
 import avocado
 from avocado import Test
-from avocado import main
 from avocado import skipUnless
 from avocado.utils import process, distro
 from avocado.utils.software_manager import SoftwareManager
@@ -351,7 +350,3 @@ class Iptunnel(Test):
     def tearDown(self):
         if self.tunnel:
             self._remove_tunnel(self.tunnel)
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -24,7 +24,6 @@ unidirectional throughput, and end-to-end latency.
 
 import os
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import distro
@@ -181,7 +180,3 @@ class Netperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -23,7 +23,6 @@ test lro and gro and interface
 
 import hashlib
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import process
@@ -301,7 +300,3 @@ class NetworkTest(Test):
             process.system(cmd, shell=True, verbose=True, ignore_status=True)
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/pktgen.py
+++ b/io/net/pktgen.py
@@ -21,7 +21,6 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 
 
@@ -106,7 +105,3 @@ class Pktgen(Test):
         self.log.info("Ping response value is %d" % ping_response)
         if ping_response != 0:
             self.cancel("Host not reachable")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/sriov_device_test.py
+++ b/io/net/sriov_device_test.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     from pexpect import pxssh
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.network.interfaces import NetworkInterface
@@ -255,7 +254,3 @@ class NetworkSriovDevice(Test):
     def tearDown(self):
         if self.pxssh.isalive():
             self.pxssh.terminate()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/switch_test.py
+++ b/io/net/switch_test.py
@@ -22,7 +22,6 @@ test lro and gro and interface
 import time
 import paramiko
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.network.hosts import LocalHost
@@ -128,7 +127,3 @@ class SwitchTest(Test):
         '''
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -21,7 +21,6 @@ Tcpdump Test.
 import os
 import netifaces
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils import archive
@@ -160,7 +159,3 @@ class TcpdumpTest(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -22,7 +22,6 @@ workload profiles
 
 import os
 import netifaces
-from avocado import main
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import distro
@@ -169,7 +168,3 @@ class Uperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     from pexpect import pxssh
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -336,7 +335,3 @@ class LPM(Test):
     def tearDown(self):
         if self.pxssh.isalive():
             self.pxssh.terminate()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -28,7 +28,6 @@ try:
 except ImportError:
     from pexpect import pxssh
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -861,7 +860,3 @@ class NetworkVirtualization(Test):
     def tearDown(self):
         if self.pxssh.isalive():
             self.pxssh.terminate()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/virt-net/veth_dlpar.py
+++ b/io/net/virt-net/veth_dlpar.py
@@ -19,7 +19,6 @@ Veth DLPAR operations
 
 import time
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.ssh import Session
 from avocado.utils.network.hosts import LocalHost
@@ -112,7 +111,3 @@ class VethdlparTest(Test):
     def tearDown(self):
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/net/vlan_test.py
+++ b/io/net/vlan_test.py
@@ -22,7 +22,6 @@ except ImportError:
     from pexpect import pxssh
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.process import CmdError
 
@@ -369,7 +368,3 @@ class VlanTest(Test):
             self.restore_host_intf()
             self.restore_peer_intf()
         self.peer_logout()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/nvmf/nvmftest.py
+++ b/io/nvmf/nvmftest.py
@@ -24,7 +24,6 @@ import os
 import json
 import copy
 from avocado import Test
-from avocado import main
 from avocado.utils import process, linux_modules, genio
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils.process import CmdError
@@ -200,7 +199,3 @@ class NVMfTest(Test):
         cmd = "ssh %s \"%s\"" % (self.peer_ips[0], msg)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.log.warn("removing config file on peer failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/io/pci/PowerNVEEH.py
+++ b/io/pci/PowerNVEEH.py
@@ -20,7 +20,6 @@ This scripts basic EEH tests on all PCI device
 """
 
 import time
-from avocado import main
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import pci
@@ -226,7 +225,3 @@ class PowerNVEEH(Test):
                 return True
             time.sleep(1)
         return False
-
-
-if __name__ == '__main__':
-    main()

--- a/io/pci/PowerVMEEH.py
+++ b/io/pci/PowerVMEEH.py
@@ -20,7 +20,6 @@ This scripts basic EEH tests on all PCI device
 """
 
 import time
-from avocado import main
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import pci
@@ -244,7 +243,3 @@ class PowerVMEEH(Test):
                 return True
             time.sleep(1)
         return False
-
-
-if __name__ == '__main__':
-    main()

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -26,7 +26,6 @@ try:
 except ImportError:
     from pexpect import pxssh
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils import pci
@@ -424,7 +423,3 @@ class DlparPci(Test):
     def tearDown(self):
         if self.pxssh.isalive():
             self.pxssh.terminate()
-
-
-if __name__ == "__main__":
-    main()

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -24,7 +24,6 @@ import os
 import re
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import wait
 from avocado.utils import linux_modules, genio, pci, cpu
 from avocado.utils.software_manager import SoftwareManager
@@ -137,7 +136,3 @@ class PCIHotPlugTest(Test):
             return True
 
         return wait.wait_for(is_added, timeout=10) or False
-
-
-if __name__ == "__main__":
-    main()

--- a/io/pci/pci_info_lsvpd.py
+++ b/io/pci/pci_info_lsvpd.py
@@ -21,7 +21,6 @@ Needs to be run as root.
 
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
-from avocado import main
 from avocado.utils import pci
 from avocado.utils import process
 
@@ -111,7 +110,3 @@ class PciLsvpdInfo(Test):
 
         if error:
             self.fail("Errors for above pci addresses: %s" % error)
-
-
-if __name__ == "__main__":
-    main()

--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -23,7 +23,6 @@ import re
 import platform
 
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import process
 from avocado.utils import cpu
@@ -161,7 +160,3 @@ class Kernbench(Test):
         self.log.info("User      : %s", user_time)
         self.log.info("System    : %s", system_time)
         self.log.info("Elapsed   : %s", elapsed_time)
-
-
-if __name__ == "__main__":
-    main()

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -20,7 +20,6 @@ import glob
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import archive, process
@@ -132,7 +131,3 @@ class kselftest(Test):
 
         if self.error:
             self.fail("Testcase failed during selftests")
-
-
-if __name__ == "__main__":
-    main()

--- a/kernel/livepatch.py
+++ b/kernel/livepatch.py
@@ -18,7 +18,6 @@ import shutil
 import tempfile
 import time
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import process
@@ -166,7 +165,3 @@ class Livepatch(Test):
     def test(self):
         self.build_module()
         self.execute_test()
-
-
-if __name__ == "__main__":
-    main()

--- a/kernel/posixtest.py
+++ b/kernel/posixtest.py
@@ -21,7 +21,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build
@@ -70,7 +69,3 @@ class Posixtest(Test):
 
         if error:
             self.fail("Testcase failed during test check the log")
-
-
-if __name__ == "__main__":
-    main()

--- a/kernel/rmaptest.py
+++ b/kernel/rmaptest.py
@@ -23,7 +23,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -84,7 +83,3 @@ class Rmaptest(Test):
         for test in tests:
             cmd = '%s/%s  %s' % (self.workdir, test[0], test[1])
             process.system(cmd, ignore_status=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/kernel/tlbflush.py
+++ b/kernel/tlbflush.py
@@ -20,7 +20,6 @@ import shutil
 import json
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -92,7 +91,3 @@ class Tlbflush(Test):
 
         # call test function
         self.set_value()
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/fork_mem.py
+++ b/memory/fork_mem.py
@@ -19,7 +19,6 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory
 from avocado.utils.software_manager import SoftwareManager
 
@@ -81,7 +80,3 @@ class Forkoff(Test):
 
         if self.fails:
             self.fail("The following test(s) failed: %s" % self.fails)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/hugepage_sanity.py
+++ b/memory/hugepage_sanity.py
@@ -19,7 +19,7 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main, skipUnless
+from avocado import skipUnless
 from avocado.utils import process, build, memory
 from avocado.utils.software_manager import SoftwareManager
 
@@ -57,7 +57,3 @@ class HugepageSanity(Test):
                           % (self.hpagesize, self.num_huge),
                           shell=True, ignore_status=True):
             self.fail("Please Check the log for failures")
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/integrity.py
+++ b/memory/integrity.py
@@ -20,7 +20,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build
 from avocado.utils.software_manager import SoftwareManager
 from avocado.utils import distro
@@ -75,7 +74,3 @@ class Integrity(Test):
             if status == 255:
                 self.cancel("System does not have numa/memory to run the test")
             self.fail("Test failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/ksm_poison.py
+++ b/memory/ksm_poison.py
@@ -20,7 +20,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory
 from avocado.utils.software_manager import SoftwareManager
 
@@ -69,7 +68,3 @@ class KsmPoison(Test):
 
         if ksm.result.exit_status:
             self.fail("Please check the logs for debug")
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -22,7 +22,7 @@ import glob
 import tempfile
 
 from avocado import Test
-from avocado import main, skipUnless
+from avocado import skipUnless
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import kernel
@@ -218,7 +218,3 @@ class LibHugetlbfs(Test):
             if process.system('umount %s' %
                               self.hugetlbfs_dir[hp_size], ignore_status=True):
                 self.log.warn("umount of hugetlbfs dir failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/memcached.py
+++ b/memory/memcached.py
@@ -16,7 +16,6 @@
 import time
 import getpass
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.utils import distro
@@ -114,7 +113,3 @@ class Memcached(Test):
         """
 
         process.system('pkill memcached', ignore_status=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/memhog.py
+++ b/memory/memhog.py
@@ -20,7 +20,6 @@ import os
 import shutil
 import avocado
 from avocado import Test
-from avocado import main
 from avocado.utils import process, memory, distro, pmem, disk, partition
 from avocado.utils.software_manager import SoftwareManager
 
@@ -139,7 +138,3 @@ class MemoHog(Test):
                 shutil.rmtree(self.mnt_dir)
             else:
                 os.remove(self.back_file)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -19,7 +19,6 @@ import re
 import platform
 import multiprocessing
 from avocado import Test
-from avocado import main
 from avocado.utils import process, memory, build, archive
 from avocado.utils.software_manager import SoftwareManager
 
@@ -225,7 +224,3 @@ class MemStress(Test):
 
     def tearDown(self):
         self.hotplug_all(self.blocks_hotpluggable)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/memory_api.py
+++ b/memory/memory_api.py
@@ -23,7 +23,6 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory
 from avocado.utils.software_manager import SoftwareManager
 
@@ -70,7 +69,3 @@ class MemorySyscall(Test):
         self.log.info("Testing mremap with minimal memory and expand it")
         if process.system('./mremap %s' % str(memory.meminfo.MemFree.k), ignore_status=True):
             self.fail('Mremap expansion failed')
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/memtester.py
+++ b/memory/memtester.py
@@ -17,7 +17,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory, archive
 from avocado.utils.software_manager import SoftwareManager
 
@@ -75,7 +74,3 @@ class Memtester(Test):
                               (phyaddr, device, mem, runs), verbose=True,
                               sudo=True, ignore_status=True):
                 self.fail("memtester failed for address %s" % phyaddr)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/migrate_pages.py
+++ b/memory/migrate_pages.py
@@ -20,7 +20,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -95,7 +94,3 @@ class MigratePages(Test):
 
         if process.system(cmd, shell=True, sudo=True, ignore_status=True):
             self.fail('Please check the logs for failure')
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/mprotect.py
+++ b/memory/mprotect.py
@@ -21,7 +21,6 @@ import shutil
 
 import avocado
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory, distro, pmem, partition
 from avocado.utils.software_manager import SoftwareManager
 
@@ -116,7 +115,3 @@ class Mprotect(Test):
             self.part_obj.unmount(force=True)
             self.plib.destroy_namespace(region=self.region, force=True)
             shutil.rmtree(self.mnt_dir)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -25,7 +25,6 @@ import shutil
 
 import avocado
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils import distro
@@ -654,7 +653,3 @@ class NdctlTest(Test):
             if self.plib.run_ndctl_list('-N'):
                 self.plib.destroy_namespace(force=True)
             self.plib.disable_region()
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/ndctl_selftest.py
+++ b/memory/ndctl_selftest.py
@@ -20,7 +20,6 @@ import os
 import json
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, distro, git, genio
 from avocado.utils.software_manager import SoftwareManager
 
@@ -127,7 +126,3 @@ class NdctlTest(Test):
                 failed_tests.append(line)
         if failed_tests:
             self.fail("%s" % failed_tests)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -20,7 +20,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory, distro, genio
 from avocado.utils.software_manager import SoftwareManager
 
@@ -124,7 +123,3 @@ class NumaTest(Test):
         ret = process.system(cmd, shell=True, sudo=True, ignore_status=True)
         if ret != 0:
             self.fail('Please check the logs for failure')
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/stutter.py
+++ b/memory/stutter.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, archive, memory, build
 from avocado.utils.software_manager import SoftwareManager
 
@@ -76,7 +75,3 @@ class Stutter(Test):
         os.chdir(self.sourcedir)
         if process.system('./run.sh', shell=True, ignore_status=True) != 0:
             self.fail("Test failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/sum_check.py
+++ b/memory/sum_check.py
@@ -17,7 +17,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process, memory, disk, genio
 
 
@@ -56,7 +55,3 @@ class SumCheck(Test):
 
     def tearDown(self):
         genio.write_file("/proc/sys/vm/drop_caches", "3")
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -17,7 +17,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
@@ -129,7 +128,3 @@ class Thp(Test):
             self.log.info('Cleaning Up!!!')
             self.device.unmount()
             process.system('rm -rf %s' % self.mem_path, ignore_status=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -20,7 +20,6 @@ import time
 import mmap
 import avocado
 from avocado import Test
-from avocado import main
 from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
@@ -128,7 +127,3 @@ class ThpDefrag(Test):
             memory.set_num_huge_pages(0)
             self.device.unmount()
             process.system('rm -rf %s' % self.mem_path, ignore_status=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -18,7 +18,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado import skipIf, skipUnless
 from avocado.utils import process
 from avocado.utils import memory
@@ -107,7 +106,3 @@ class ThpSwapping(Test):
             self.log.info('Cleaning Up!!!')
             self.device.unmount()
             process.system('rm -rf %s' % self.mem_path, ignore_status=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -20,7 +20,6 @@ import os
 import shutil
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, memory, genio, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -131,7 +130,3 @@ class VATest(Test):
                 genio.write_file(self.hp_file % str(hp_size * 1024), str(0))
         if self.scenario_arg not in [1, 2]:
             memory.set_num_huge_pages(self.exist_pages)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/aiostress.py
+++ b/perf/aiostress.py
@@ -23,7 +23,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -72,7 +71,3 @@ class Aiostress(Test):
         # aio-stress needs a filename (foo) to run tests on.
         cmd = ('./aio-stress foo')
         process.run(cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/blogbench.py
+++ b/perf/blogbench.py
@@ -14,7 +14,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
@@ -69,7 +68,3 @@ class Blogbench(Test):
                       "%s  and %s\n " % (write_score, read_score))
         self.log.info("Please Check Logfile %s for more info of benchmark"
                       % report_path)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/compilebench.py
+++ b/perf/compilebench.py
@@ -22,7 +22,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 
@@ -63,7 +62,3 @@ class Compilebench(Test):
         # shebang set to python2.4
         cmd = ('python %s/compilebench %s' % (self.sourcedir, " ".join(args)))
         process.run(cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/hackbench.py
+++ b/perf/hackbench.py
@@ -23,7 +23,6 @@ import shutil
 import json
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -82,7 +81,3 @@ class Hackbench(Test):
             if self._threshold_time <= time_spent:
                 self.error("Test failed: Time Taken "
                            "greater or equal to threshold")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/libunwind.py
+++ b/perf/libunwind.py
@@ -18,7 +18,6 @@ import os
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, distro, process, cpu
 from avocado.utils.software_manager import SoftwareManager
 
@@ -95,7 +94,3 @@ class Libunwind(Test):
 
         if failures:
             self.fail('Test failed with following:%s' % failures)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/lmbench.py
+++ b/perf/lmbench.py
@@ -22,7 +22,6 @@ import os
 import tempfile
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build
@@ -118,7 +117,3 @@ class Lmbench(Test):
         build.make(self.sourcedir, extra_args='rerun')
         build.make(self.sourcedir, extra_args='rerun')
         build.make(self.sourcedir, extra_args='see')
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -17,7 +17,6 @@
 import os
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import cpu, distro, memory, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -129,7 +128,3 @@ class hv_24x7_all_events(Test):
     def tearDown(self):
         # Collect the dmesg
         process.run("dmesg -T")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -19,7 +19,6 @@ import os
 import re
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import process, distro, cpu, genio
 from avocado.utils.software_manager import SoftwareManager
 from avocado import skipIf
@@ -194,7 +193,3 @@ class EliminateDomainSuffix(Test):
 
     def event_stat1(self, cmd):
         return process.run('%s %s' % (self.perf_args, cmd), ignore_status=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_UDT_probes.py
+++ b/perf/perf_UDT_probes.py
@@ -18,7 +18,6 @@ import os
 import platform
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import distro, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -59,7 +58,3 @@ class PerfProbe(Test):
         res = process.run("readelf -n tick")
         if 'NT_STAPSDT' not in res.stdout_text:
             self.fail("NT_STAPSDT not found in binary")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_basic.py
+++ b/perf/perf_basic.py
@@ -16,7 +16,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -107,7 +106,3 @@ class PerfBasic(Test):
     def tearDown(self):
         if self.name.uid == 10:
             self.run_cmd("rm -f perf.data")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_bench.py
+++ b/perf/perf_bench.py
@@ -16,7 +16,6 @@
 
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import distro, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -77,7 +76,3 @@ class perf_bench(Test):
         bench_cmd = "perf bench %s %s" % (self.optname, self.option)
         self.run_cmd(bench_cmd)
         self.verify_dmesg()
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_c2c.py
+++ b/perf/perf_c2c.py
@@ -18,7 +18,6 @@ import os
 import platform
 import tempfile
 from avocado import Test
-from avocado import main
 from avocado.utils import distro, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -113,7 +112,3 @@ class perf_c2c(Test):
         # Delete the temporary file
         if os.path.isfile(self.temp_file):
             process.run('rm -f %s' % self.temp_file)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -16,7 +16,6 @@
 
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import distro, genio, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -59,7 +58,3 @@ class PerfProbe(Test):
     def tearDown(self):
         # Deleting all the probed events
         process.run('perf probe -d \\*')
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_events_crash_test.py
+++ b/perf/perf_events_crash_test.py
@@ -18,7 +18,6 @@
 import platform
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, process, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -91,7 +90,3 @@ class Perf_crashevent(Test):
         '''
         self.build_perf_test()
         self.execute_perf_test()
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_events_test.py
+++ b/perf/perf_events_test.py
@@ -18,7 +18,6 @@
 import platform
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, process, distro, genio
 from avocado.utils.software_manager import SoftwareManager
 
@@ -101,7 +100,3 @@ class Perf_subsystem(Test):
         self.build_perf_test()
         self.execute_perf_test()
         self.analyse_perf_output(self.output)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_fuzzer.py
+++ b/perf/perf_fuzzer.py
@@ -18,7 +18,6 @@
 import platform
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, process, distro, genio
 from avocado.utils.software_manager import SoftwareManager
 
@@ -94,7 +93,3 @@ class Perffuzzer(Test):
         '''
         self.build_perf_test()
         self.execute_perf_fuzzer()
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -18,7 +18,6 @@
 import os
 import configparser
 from avocado import Test
-from avocado import main
 
 
 class test_generic_events(Test):
@@ -59,7 +58,3 @@ class test_generic_events(Test):
                           '%s' % (val, raw_code))
         if nfail != 0:
             self.fail('Failed to verify generic PMU event codes')
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_hv_gpci.py
+++ b/perf/perf_hv_gpci.py
@@ -16,7 +16,6 @@
 
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import distro, process, genio
 from avocado.utils.software_manager import SoftwareManager
 
@@ -99,7 +98,3 @@ class perf_hv_gpci(Test):
     def tearDown(self):
         # Collect the dmesg
         output = process.run("dmesg -T")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_invalid_flag_test.py
+++ b/perf/perf_invalid_flag_test.py
@@ -15,7 +15,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -50,7 +49,3 @@ class PerfInvalid(Test):
         output = process.run(cmd, ignore_status="True", sudo="True", shell="True")
         if output.exit_status == -11:
             self.fail("perf: failed to execute command %s" % cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_nest_events.py
+++ b/perf/perf_nest_events.py
@@ -16,7 +16,6 @@
 
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import cpu, distro, genio, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -100,7 +99,3 @@ class nestEvents(Test):
     def tearDown(self):
         # Collect the dmesg
         process.run("dmesg -T")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_pcp.py
+++ b/perf/perf_pcp.py
@@ -15,7 +15,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import cpu, distro, genio, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -106,7 +105,3 @@ class PCP(Test):
         output = process.run("systemctl status pmcd", shell=True)
         if "active (running)" and "pmdaperfevent" in output.stdout.decode("utf-8"):
             self.fail("PCP: perfevent pmda not removed from pmcd daemon")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_rawevents.py
+++ b/perf/perf_rawevents.py
@@ -18,7 +18,6 @@ import os
 import platform
 import shutil
 from avocado import Test
-from avocado import main
 from avocado import skipUnless
 from avocado.utils import cpu, distro, process, genio
 from avocado.utils.software_manager import SoftwareManager
@@ -112,7 +111,3 @@ class PerfRawevents(Test):
     def tearDown(self):
         # Collect the dmesg
         process.run("dmesg -T")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_script_bug.py
+++ b/perf/perf_script_bug.py
@@ -18,7 +18,6 @@ import os
 import tempfile
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import build, distro, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -62,7 +61,3 @@ class PerfProbe(Test):
         process.run(probe_del)
         if output.exit_status == -11:
             self.fail("perf script command segfaulted")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -20,7 +20,6 @@ import re
 import tempfile
 
 from avocado import Test
-from avocado import main
 from avocado.utils import distro
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
@@ -159,7 +158,3 @@ class PerfSDT(Test):
         self.remove_library(self.libc)
         if os.path.exists(self.temp_file):
             os.remove(self.temp_file)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_uprobe.py
+++ b/perf/perf_uprobe.py
@@ -19,7 +19,6 @@ import platform
 import shutil
 import tempfile
 from avocado import Test
-from avocado import main
 from avocado.utils import build, distro, process, genio
 from avocado.utils.software_manager import SoftwareManager
 
@@ -119,7 +118,3 @@ class PerfUprobe(Test):
         output = self.cmd_verify('perf probe -d \\*')
         if os.path.isfile(self.temp_file):
             process.run('rm -f %s' % self.temp_file)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perf_watch_point.py
+++ b/perf/perf_watch_point.py
@@ -17,7 +17,6 @@
 import os
 import platform
 from avocado import Test
-from avocado import main
 from avocado import skipUnless
 from avocado.utils import archive
 from avocado.utils import cpu, build, distro, process, genio
@@ -87,7 +86,3 @@ class PerfWatchPoint(Test):
     def tearDown(self):
         process.system('pkill perf', ignore_status=True)
         process.run("rmmod wptest")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perfmon.py
+++ b/perf/perfmon.py
@@ -18,7 +18,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build, git, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -59,7 +58,3 @@ class Perfmon(Test):
             self.workdir, 'tests/validate')).decode("utf-8")
         if 'fail' in out:
             self.fail("test failed:check manually")
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -17,7 +17,6 @@
 import os
 import platform
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, distro, process
 from avocado.utils.software_manager import SoftwareManager
 
@@ -88,7 +87,3 @@ class Perftool(Test):
 
         if count > 0:
             self.fail("%s Test failed" % count)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/rt_tests.py
+++ b/perf/rt_tests.py
@@ -24,7 +24,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process
@@ -64,7 +63,3 @@ class rt_tests(Test):
         args = self.params.get('args', default=' -t 10 -l 100000')
         process.system("%s %s" % (os.path.join(self.sourcedir, test_to_run), args),
                        sudo=True)
-
-
-if __name__ == "__main__":
-    main()

--- a/perf/tbench.py
+++ b/perf/tbench.py
@@ -23,7 +23,6 @@ import signal
 import subprocess
 import re
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build
@@ -78,7 +77,3 @@ class tbench(Test):
         pattern = re.compile(r"Throughput (.*?) MB/sec (.*?) procs")
         (throughput, procs) = pattern.findall(self.results)[0]
         self.log.info({'throughput': throughput, 'procs': procs})
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/ServiceReport.py
+++ b/ras/ServiceReport.py
@@ -16,7 +16,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process, build
 from avocado.utils import archive
 from avocado.utils.software_manager import SoftwareManager
@@ -55,7 +54,3 @@ class ServiceReport(Test):
         cmd = "./servicereport %s" % self.options
         if process.system(cmd, ignore_status=True, sudo=True, shell=True):
             self.fail("ServiceReport: Failed command is: %s" % cmd)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/diag_encl.py
+++ b/ras/diag_encl.py
@@ -18,7 +18,6 @@ import os
 import glob
 import xml.etree.ElementTree
 from avocado import Test, skipIf
-from avocado import main
 from avocado.utils import process, distro
 from avocado.utils import genio
 from avocado.utils.software_manager import SoftwareManager
@@ -90,7 +89,3 @@ class DiagEncl(Test):
             self.fail("type and model are incorrect")
         if machine_serial_xml not in serial_num:
             self.fail("serial is incorrect")
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -16,7 +16,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -99,7 +98,3 @@ class Hwinfo(Test):
                                              shell=True).decode("utf-8"):
             self.log.info("--save-config option failed")
             self.fail("hwinfo: --save-config option failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/kdump.py
+++ b/ras/kdump.py
@@ -18,7 +18,6 @@ import time
 import os
 import socket
 from avocado import Test
-from avocado import main
 try:
     from virttest import remote
 except ImportError:
@@ -101,7 +100,3 @@ class KDUMP(Test):
         for files in file_list:
             if files not in open(log_file).read():
                 self.fail("%s is not saved" % files)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/kdump_nfs.py
+++ b/ras/kdump_nfs.py
@@ -18,7 +18,6 @@ import time
 import os
 import socket
 from avocado import Test
-from avocado import main
 try:
     from virttest import remote
 except ImportError:
@@ -161,7 +160,3 @@ class KDUMP(Test):
         for files in self.file_list:
             if files not in open(log_file_server).read():
                 self.fail("%s is not saved" % files)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/kprobe.py
+++ b/ras/kprobe.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import tempfile
 from avocado import Test
-from avocado import main
 from avocado.utils import genio
 from avocado.utils import build
 from avocado.utils import distro
@@ -162,7 +161,3 @@ class Kprobe(Test):
         self.build_module()
         self.execute_test()
         self.optprobes_disable_test()
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/kretprobe.py
+++ b/ras/kretprobe.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import tempfile
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import process
@@ -131,7 +130,3 @@ class Kretprobe(Test):
     def test(self):
         self.build_module()
         self.execute_test()
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -14,7 +14,6 @@
 # Author: Ramya BS <ramya@linux.vnet.ibm.com>
 
 from avocado import Test
-from avocado import main
 from avocado import skipIf
 from avocado.utils import process
 from avocado.utils import genio
@@ -230,7 +229,3 @@ class Lshwrun(Test):
         if "modified" in self.run_cmd_out("lshw -notime | grep modified"):
             self.fail("modified time stamp is present evev with -notime")
         self.error_check()
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/packages.py
+++ b/ras/packages.py
@@ -15,7 +15,6 @@
 # Author: Pavithra <pavrampu@linux.vnet.ibm.com>
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -72,7 +71,3 @@ class Package_check(Test):
                     self.log.info("%s package is not installed" % package)
         if is_fail >= 1:
             self.fail("%s package(s) not installed by default" % is_fail)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/pstore.py
+++ b/ras/pstore.py
@@ -17,7 +17,6 @@
 import time
 import os
 from avocado import Test
-from avocado import main
 from virttest import remote
 from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
@@ -97,7 +96,3 @@ class PSTORE(Test):
             time_created = self.run_cmd_out("cat %s | tail -3 | head -1 | cut -d' ' -f3" % log_file).strip()
             if time_created < time_init:
                 self.fail("sosreport contains wrong %s file" % files)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/ras_extended.py
+++ b/ras/ras_extended.py
@@ -17,7 +17,6 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process, distro
 from avocado import skipIf
 from avocado.utils.software_manager import SoftwareManager
@@ -250,7 +249,3 @@ class RASTools(Test):
         if self.is_fail >= 1:
             self.fail("%s command(s) failed in lscfg tool verification"
                       % self.is_fail)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/servicelog.py
+++ b/ras/servicelog.py
@@ -18,7 +18,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils.service import ServiceManager
 from avocado.utils.software_manager import SoftwareManager
@@ -243,7 +242,3 @@ class servicelog(Test):
         if self.is_fail >= 1:
             self.fail("%s command(s) failed in servicelog_repair_action"
                       "verification" % self.is_fail)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -18,7 +18,6 @@ import os
 import tempfile
 import shutil
 from avocado import Test
-from avocado import main
 from avocado import skipIf
 from avocado.utils import process
 from avocado.utils import distro
@@ -259,7 +258,3 @@ class Sosreport(Test):
         shutil.rmtree(directory_name)
         if self.is_fail >= 1:
             self.fail("%s command(s) failed in sosreport tool verification" % self.is_fail)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/supportconfig.py
+++ b/ras/supportconfig.py
@@ -18,7 +18,6 @@ import os
 import re
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.software_manager import SoftwareManager
@@ -139,7 +138,3 @@ class Supportconfig(Test):
         # cleanup the plugin dir
         if not plugin_dir_exists:
             process.system("rm -rf %s" % plugin_dir)
-
-
-if __name__ == "__main__":
-    main()

--- a/ras/uprobe.py
+++ b/ras/uprobe.py
@@ -15,7 +15,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import genio
 from avocado.utils import distro
 from avocado.utils import process
@@ -92,7 +91,3 @@ class Uprobe(Test):
 
     def test(self):
         self.execute_test()
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/atlas.py
+++ b/toolchain/atlas.py
@@ -14,7 +14,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
@@ -77,7 +76,3 @@ class Atlas(Test):
         if ret.exit_status:
             self.fail("Make check Has been Failed !!"
                       "Please, refer the log file")
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/bcc.py
+++ b/toolchain/bcc.py
@@ -19,7 +19,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, build, process, distro
 from avocado.utils.software_manager import SoftwareManager
 
@@ -71,7 +70,3 @@ class Bcc(Test):
 
         if build.make(self.builddir, extra_args='test', ignore_status=True):
             self.fail('test failed, Please check debug log')
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/binutils.py
+++ b/toolchain/binutils.py
@@ -22,7 +22,6 @@ import fnmatch
 import shutil
 
 from avocado import Test
-from avocado import main
 
 from avocado.utils import archive
 from avocado.utils import build
@@ -104,7 +103,3 @@ class Binutils(Test):
         elif ret:
             self.fail("'make check' finished with %s, but no FAIL lines were "
                       "found." % ret)
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -18,7 +18,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import distro
@@ -94,7 +93,3 @@ class GCC(Test):
 
         if ret.exit_status:
             self.fail("Few gcc tests failed,refer the log file")
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -17,7 +17,6 @@
 import os
 import re
 from avocado import Test
-from avocado import main
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import distro
@@ -72,7 +71,3 @@ class GDB(Test):
                 for match in re.finditer("of unexpected failures[1-9]", line):
                     self.log.info(line)
                     self.fail("Few gdb tests have failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/glibc.py
+++ b/toolchain/glibc.py
@@ -14,7 +14,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
@@ -68,7 +67,3 @@ class Glibc(Test):
         else:
             self.log.info("Tests Have been Passed\n"
                           "Please Check Logfile %s run info" % logfile)
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/gsl.py
+++ b/toolchain/gsl.py
@@ -17,7 +17,6 @@
 import re
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import archive, process, build
 from avocado.utils.software_manager import SoftwareManager
 
@@ -50,7 +49,3 @@ class GSL(Test):
         match = re.search(r'FAIL:\s+[1-9]', logfile, re.M | re.I)
         if match:
             self.fail("test failed, Please check debug log for failed test cases")
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/libpfm.py
+++ b/toolchain/libpfm.py
@@ -18,7 +18,6 @@
 import os
 from avocado.utils import process
 from avocado import Test
-from avocado import main
 from avocado.utils import build, distro, archive
 from avocado.utils.software_manager import SoftwareManager
 
@@ -75,7 +74,3 @@ class Libpfm(Test):
                 fail = True
         if fail:
             self.fail("Tests failed, Please check the logs")
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/libvecpf.py
+++ b/toolchain/libvecpf.py
@@ -19,7 +19,6 @@ import os
 import re
 
 from avocado import Test
-from avocado import main
 from avocado.utils import build, distro, archive
 from avocado.utils.software_manager import SoftwareManager
 
@@ -70,7 +69,3 @@ class Libvecpf(Test):
 
         if failures:
             self.fail('Test failed with following:%s' % failures)
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -22,7 +22,6 @@ import fnmatch
 import shutil
 
 from avocado import Test
-from avocado import main
 
 from avocado.utils import build
 from avocado.utils import process
@@ -111,7 +110,3 @@ class Ltrace(Test):
         elif ret:
             self.fail("'make check' finished with %s, but no FAIL lines were "
                       "found." % ret)
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/oprofile.py
+++ b/toolchain/oprofile.py
@@ -17,7 +17,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import git
 from avocado.utils.software_manager import SoftwareManager
@@ -56,7 +55,3 @@ class Oprofile(Test):
         if failed_tests:
             self.log.info(failed_tests)
             self.fail("few tests failed")
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/papiTest.py
+++ b/toolchain/papiTest.py
@@ -18,7 +18,6 @@
 import os
 from avocado.utils import process
 from avocado import Test
-from avocado import main
 from avocado.utils import git, build
 from avocado.utils.software_manager import SoftwareManager
 
@@ -78,7 +77,3 @@ class papitest(Test):
         elif errors > 0:
             self.log.warn('number of warnings is %s', warns)
             self.fail("number of errors is %s" % errors)
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/power_time_base_bug.py
+++ b/toolchain/power_time_base_bug.py
@@ -15,7 +15,6 @@
 import os
 import shutil
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import distro
@@ -73,7 +72,3 @@ class PowerTimeBaseBug(Test):
                     len_str = len(line.split('=')[1].lstrip())
                     if len_str <= 8:
                         self.fail('Test failed.')
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/systemtap.py
+++ b/toolchain/systemtap.py
@@ -20,7 +20,6 @@
 import os
 
 from avocado import Test
-from avocado import main
 from avocado.utils import build
 from avocado.utils import process
 from avocado.utils import git
@@ -84,7 +83,3 @@ class Systemtap(Test):
         if failed_tests:
             self.log.info(failed_tests)
             self.fail("Few tests failed,check log")
-
-
-if __name__ == "__main__":
-    main()

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -14,7 +14,6 @@
 
 import os
 from avocado import Test
-from avocado import main
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
@@ -93,7 +92,3 @@ class Valgrind(Test):
         if self.failures:
             self.fail('Following tests failed: %s, Check %s for results' % (
                 self.failures, self.outputdir))
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Avocado framework no longer supports running of tests as stand-alone scripts. So removing the main function from all tests in the repository.

Signed-off-by: Harish <harish@linux.ibm.com>