### PR TITLE
Using the first controller for nvme

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -196,8 +196,9 @@ class NVMeTest(Test):
         cmd = "%s list-ctrl %s" % (self.binary, self.device)
         output = process.system_output(cmd, shell=True,
                                        ignore_status=True).decode("utf-8")
-        if output:
-            return output.split(':')[-1]
+        for line in output.splitlines():
+            if '0]' in line:
+                return line.split(':')[-1]
         return ""
 
     def get_lba(self):


### PR DESCRIPTION
NVMe devices may have more than one controller, and in such cases,
using the first controller will always work when creating
namespaces. This commit forces the test to use the first
controller always.

Example:
nvme list-ctrl /dev/nvme0
[   0]:0x41
[   1]:0x42

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>