### PR TITLE
avago9361_vd: Handle string output properly

### DIFF
--- a/io/disk/Avago_storage_adapter/avago9361_vd.py
+++ b/io/disk/Avago_storage_adapter/avago9361_vd.py
@@ -339,7 +339,7 @@ class Avago9361(Test):
         output = process.run(cmd, ignore_status=True, shell=True)
         if output.exit_status != 0:
             self.fail("Failed to display the progress")
-        for lines in output.stdout.splitlines():
+        for lines in output.stdout_text.splitlines():
             for times in ['Hour', 'Minute', 'Second']:
                 if times in lines:
                     return True


### PR DESCRIPTION
Handle string output properly in process.run()

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>