### PR TITLE
Terminate all open remote ssh connections in nic tests

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -456,6 +456,8 @@ class Bonding(Test):
                 peer_public_networkinterface = NetworkInterface(interface,
                                                                 self.remotehost_public)
                 peer_public_networkinterface.set_mtu("1500")
+        self.remotehost.remote_session.quit()
+        self.remotehost_public.remote_session.quit()
 
     def error_check(self):
         if self.err:

--- a/io/net/htx_nic_devices.py
+++ b/io/net/htx_nic_devices.py
@@ -778,3 +778,4 @@ class HtxNicTest(Test):
         self.shutdown_htx_daemon()
         self.ip_restore_host()
         self.ip_restore_peer()
+        self.remotehost.remote_session.quit()

--- a/io/net/infiniband/ib_pingpong.py
+++ b/io/net/infiniband/ib_pingpong.py
@@ -84,11 +84,11 @@ class PingPong(Test):
         self.peer_port = int(self.params.get("PEERPORT", default="1"))
         self.tmo = self.params.get("TIMEOUT", default="120")
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
+                                                      self.remotehost)
         smm = SoftwareManager()
         detected_distro = distro.detect()
         pkgs = []
@@ -198,3 +198,4 @@ class PingPong(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
+        self.remotehost.remote_session.quit()

--- a/io/net/infiniband/mckey.py
+++ b/io/net/infiniband/mckey.py
@@ -98,11 +98,11 @@ class Mckey(Test):
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
         self.ip_val = self.local_ip.split(".")[-1]
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
+                                                      self.remotehost)
         self.option = self.option.replace("PEERIP", self.peer_ip)
         self.option = self.option.replace("LOCALIP", self.local_ip)
         self.option = self.option.replace("IPVAL", self.ip_val)
@@ -173,3 +173,4 @@ class Mckey(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
+        self.remotehost.remote_session.quit()

--- a/io/net/infiniband/ping6.py
+++ b/io/net/infiniband/ping6.py
@@ -111,11 +111,11 @@ class Ping6(Test):
         self.option = self.option.replace("peer_ip", self.peer_ip)
         self.option_list = self.option.split(",")
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
+                                                      self.remotehost)
 
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
@@ -178,3 +178,4 @@ class Ping6(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
+        self.remotehost.remote_session.quit()

--- a/io/net/infiniband/rdma_tests.py
+++ b/io/net/infiniband/rdma_tests.py
@@ -94,11 +94,11 @@ class RDMA(Test):
         self.log.info("test with %s", self.tool_name)
         self.test_op = self.params.get("test_opt", default="")
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
+                                                      self.remotehost)
 
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
@@ -168,3 +168,4 @@ class RDMA(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
+        self.remotehost.remote_session.quit()

--- a/io/net/infiniband/rping.py
+++ b/io/net/infiniband/rping.py
@@ -103,11 +103,11 @@ class Rping(Test):
         self.option = self.option.replace("interface", self.iface)
         self.option_list = self.option.split(",")
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
+                                                      self.remotehost)
 
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
@@ -170,3 +170,4 @@ class Rping(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
+        self.remotehost.remote_session.quit()

--- a/io/net/infiniband/ucmatose.py
+++ b/io/net/infiniband/ucmatose.py
@@ -98,11 +98,11 @@ class Ucmatose(Test):
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
+                                                      self.remotehost)
 
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"
@@ -164,3 +164,4 @@ class Ucmatose(Test):
             self.fail("Failed to set mtu in host")
         if self.peer_networkinterface.set_mtu('1500') is not None:
             self.fail("Failed to set mtu in peer")
+        self.remotehost.remote_session.quit()

--- a/io/net/infiniband/udaddy.py
+++ b/io/net/infiniband/udaddy.py
@@ -97,11 +97,11 @@ class Udady(Test):
         self.timeout = "2m"
         self.local_ip = netifaces.ifaddresses(self.iface)[AF_INET][0]['addr']
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
+                                                      self.remotehost)
 
         if detected_distro.name == "Ubuntu":
             cmd = "service ufw stop"

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -75,15 +75,15 @@ class Iperf(Test):
         if self.peer_ip == "":
             self.cancel("%s peer machine is not available" % self.peer_ip)
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
-        remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
-                                       password=self.peer_password)
+                                                      self.remotehost)
+        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+                                            password=self.peer_password)
         self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             remotehost_public)
+                                                             self.remotehost_public)
         if self.peer_networkinterface.set_mtu(self.mtu) is not None:
             self.cancel("Failed to set mtu in peer")
         if self.networkinterface.set_mtu(self.mtu) is not None:
@@ -155,3 +155,5 @@ class Iperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.remotehost.remote_session.quit()
+        self.remotehost_public.remote_session.quit()

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -137,3 +137,5 @@ class MultiportStress(Test):
             networkinterface = NetworkInterface(interface, self.local)
             networkinterface.remove_ipaddr(ipaddr, self.netmask)
             networkinterface.restore_from_backup()
+            self.remotehost.remote_session.quit()
+            self.remotehost_public.remote_session.quit()

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -87,15 +87,15 @@ class Netperf(Test):
             self.cancel("%s peer machine is not available" % self.peer_ip)
         self.timeout = self.params.get("TIMEOUT", default="600")
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
-        remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
-                                       password=self.peer_password)
+                                                      self.remotehost)
+        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+                                            password=self.peer_password)
         self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             remotehost_public)
+                                                             self.remotehost_public)
         if self.peer_networkinterface.set_mtu(self.mtu) is not None:
             self.cancel("Failed to set mtu in peer")
         if self.networkinterface.set_mtu(self.mtu) is not None:
@@ -180,3 +180,5 @@ class Netperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.remotehost.remote_session.quit()
+        self.remotehost_public.remote_session.quit()

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -79,15 +79,15 @@ class NetworkTest(Test):
         self.peer_user = self.params.get("peer_user", default="root")
         self.peer_password = self.params.get("peer_password", '*',
                                              default=None)
-        remotehost = RemoteHost(self.peer, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer).name
+        self.remotehost = RemoteHost(self.peer, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
-        remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
-                                       password=self.peer_password)
+                                                      self.remotehost)
+        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+                                            password=self.peer_password)
         self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             remotehost_public)
+                                                             self.remotehost_public)
         self.mtu = self.params.get("mtu", default=1500)
         self.mtu_set()
         if self.networkinterface.ping_check(self.peer, count=5) is not None:
@@ -300,3 +300,5 @@ class NetworkTest(Test):
             process.system(cmd, shell=True, verbose=True, ignore_status=True)
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.remotehost.remote_session.quit()
+        self.remotehost_public.remote_session.quit()

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -70,15 +70,15 @@ class TcpdumpTest(Test):
         self.peer_password = self.params.get("peer_password", '*',
                                              default="None")
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
-        remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
-                                       password=self.peer_password)
+                                                      self.remotehost)
+        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+                                            password=self.peer_password)
         self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             remotehost_public)
+                                                             self.remotehost_public)
         if self.peer_networkinterface.set_mtu(self.mtu) is not None:
             self.cancel("Failed to set mtu in peer")
         if self.networkinterface.set_mtu(self.mtu) is not None:
@@ -159,3 +159,5 @@ class TcpdumpTest(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.remotehost.remote_session.quit()
+        self.remotehost_public.remote_session.quit()

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -83,15 +83,15 @@ class Uperf(Test):
         if self.peer_ip == "":
             self.cancel("%s peer machine is not available" % self.peer_ip)
         self.mtu = self.params.get("mtu", default=1500)
-        remotehost = RemoteHost(self.peer_ip, self.peer_user,
-                                password=self.peer_password)
-        self.peer_interface = remotehost.get_interface_by_ipaddr(self.peer_ip).name
+        self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
+                                     password=self.peer_password)
+        self.peer_interface = self.remotehost.get_interface_by_ipaddr(self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
-                                                      remotehost)
-        remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
-                                       password=self.peer_password)
+                                                      self.remotehost)
+        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+                                            password=self.peer_password)
         self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             remotehost_public)
+                                                             self.remotehost_public)
         if self.peer_networkinterface.set_mtu(self.mtu) is not None:
             self.cancel("Failed to set mtu in peer")
         if self.networkinterface.set_mtu(self.mtu) is not None:
@@ -168,3 +168,5 @@ class Uperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.remotehost.remote_session.quit()
+        self.remotehost_public.remote_session.quit()


### PR DESCRIPTION
Test which uses RemoteHost module to open multiple ssh
connections are not being terminated at the end of test,
Results in un clean setup for next runs. So this patch adds
remote_session.quit() after test finishes

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>