### PR TITLE
softwareraid: Overhaul using utils

### DIFF
--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -25,10 +25,9 @@ Some RAID levels include redundancy and so can survive some degree of device
 failure.
 """
 
-import time
 from avocado import Test
 from avocado.utils.software_manager import SoftwareManager
-from avocado.utils import process
+from avocado.utils import softwareraid
 
 
 class SoftwareRaid(Test):
@@ -40,7 +39,7 @@ class SoftwareRaid(Test):
     def setUp(self):
         """
         Checking if the required packages are installed,
-        if not found packages will be installed
+        if not found packages will be installed.
         """
 
         smm = SoftwareManager()
@@ -48,108 +47,46 @@ class SoftwareRaid(Test):
             self.log.info("Mdadm must be installed before continuing the test")
             if SoftwareManager().install("mdadm") is False:
                 self.cancel("Unable to install mdadm")
-        cmd = "mdadm -V"
-        self.check_pass(cmd, "Unable to get mdadm version")
-        self.disk = self.params.get('disks', default='').strip(" ")
-        self.raid = self.params.get('raidname', default='/dev/md/mdsraid')
-        self.raidlevel = str(self.params.get('raid', default='0'))
-        self.metadata = str(self.params.get('metadata', default='1.2'))
-        self.setup = self.params.get('setup', default=True)
-        self.run_test = self.params.get('run_test', default=False)
-        self.cleanup = self.params.get('cleanup', default=True)
-        self.sparedisk = ""
-        if self.raidlevel == 'linear' or self.raidlevel == '0':
-            self.disk_count = len(self.disk.split(" "))
-        else:
-            self.disk = self.disk.split(" ")
-            self.sparedisk = self.disk.pop()
-            self.remadd = ''.join(self.disk[-1:])
-            self.disk_count = len(self.disk)
-            self.disk = ' '.join(self.disk)
-        self.force = self.params.get('force', default=False)
+        disk = self.params.get('disks', default='').strip(" ")
+        if not disk:
+            self.cancel('No disks given')
+        disk = disk.split()
+        spare = self.params.get('spare_disks', default='').strip(" ")
+        if spare:
+            spare = spare.split()
+        raid = self.params.get('raidname', default='/dev/md/mdsraid')
+        raidlevel = str(self.params.get('raid', default='0'))
+        metadata = str(self.params.get('metadata', default='1.2'))
+        self.remadd = ''
+        if raidlevel not in ['0', 'linear']:
+            self.remadd = disk[-1]
+        self.sraid = softwareraid.SoftwareRaid(raid, raidlevel, disk,
+                                               metadata, spare)
 
-    def test_run(self):
+    def test(self):
         """
-        Decides which functions to be run for a perticular raid level
+        Decides which functions to be run for a perticular raid level, and runs
+        those tests.
         """
-        if self.setup:
-            self.create_raid()
-        if self.run_test:
-            if self.raidlevel != 'linear' and self.raidlevel != '0':
-                self.extensivetest()
 
-    def create_raid(self):
-        """
-        Only basic operations are run viz create and delete
-        """
-        cmd = "echo 'yes' | mdadm --create --verbose --assume-clean \
-            %s --level=%s --raid-devices=%d %s --metadata %s" \
-            % (self.raid, self.raidlevel, self.disk_count, self.disk,
-               self.metadata)
-        if self.sparedisk:
-            cmd += " --spare-devices=1 %s " % self.sparedisk
-        if self.force:
-            cmd += " --force"
-        self.check_pass(cmd, "Failed to create a MD device")
-        self.mdadm_detail()
-
-    def extensivetest(self):
-        """
-        Extensive software raid options are run viz create, delete, assemble,
-        create spares, remove and add drives
-        """
-        cmd = "mdadm --fail %s %s" % (self.raid, self.remadd)
-        self.check_pass(cmd, "Unable to fail a drive from MD device")
-        self.mdadm_detail()
-        cmd = "mdadm --manage %s --remove %s" % (self.raid, self.remadd)
-        self.check_pass(cmd, "Failed to remove a drive from MD device")
-        self.mdadm_detail()
-        cmd = "mdadm --manage %s --add %s" % (self.raid, self.remadd)
-        self.check_pass(cmd, "Failed to add back the drive to MD device")
-        self.mdadm_detail()
-        cmd = "mdadm --manage %s --stop" % self.raid
-        self.check_pass(cmd, "Failed to stop/remove the MD device")
-        cmd = "mdadm --assemble %s %s %s" \
-              % (self.raid, self.disk, self.sparedisk)
-        self.check_pass(cmd, "Failed to assemble back the MD device")
-        while self.is_mdadm_recovering():
-            time.sleep(30)
-        process.system(cmd, ignore_status=True, shell=True)
-        self.mdadm_detail()
-
-    def mdadm_detail(self):
-        """
-        Function to print the details of mdadm array
-        """
-        cmd = "mdadm --detail %s" % self.raid
-        output = process.run(cmd, ignore_status=True, shell=True)
-        if output.exit_status != 0:
-            self.fail("Failed to display MD device details")
-        return output.stdout.decode("utf-8").splitlines()
-
-    def is_mdadm_recovering(self):
-        """
-        Function to check if the array is recovering or not
-        """
-        for line in self.mdadm_detail():
-            if 'State' in line and 'recovering' in line:
-                return True
-        return False
-
-    def check_pass(self, cmd, errmsg):
-        """
-        Function to check if the cmd is successful or not, if not display
-        appropriate message
-        """
-        if process.system(cmd, ignore_status=True, shell=True) != 0:
-            self.fail(errmsg)
+        if not self.sraid.create():
+            self.fail("Failed to create")
+        if not self.remadd:
+            return
+        if not self.sraid.remove_disk(self.remadd):
+            self.fail("Failed to remove disk")
+        if not self.sraid.add_disk(self.remadd):
+            self.fail("Failed to add disk")
+        if not self.sraid.stop():
+            self.fail("Failed to stop raid")
+        if not self.sraid.assemble():
+            self.fail("Failed to assemble raid")
 
     def tearDown(self):
         """
-        Stop/Remove the MD device
+        Stop/Remove the raid device.
         """
-        if self.cleanup:
-            cmd = "mdadm --manage %s --stop" % self.raid
-            self.check_pass(cmd, "Failed to stop the MD device")
-            cmd = "mdadm --zero-superblock %s %s" % (self.disk, self.sparedisk)
-            self.check_pass(cmd, "Failed to remove the MD device")
+
+        if self.sraid:
+            self.sraid.stop()
+            self.sraid.clear_superblock()

--- a/io/disk/softwareraid.py.data/Readme
+++ b/io/disk/softwareraid.py.data/Readme
@@ -2,7 +2,7 @@ mdadm - manage MD devices aka Linux Software RAID
 
 Values to be passed in yaml file:
 
-* Devices on which this scripts should be run. disks: "/dev/sdx /dev/sdy ..." (comman separated disks)
+* Devices on which this scripts should be run. disks: "/dev/sdx /dev/sdy ..." (space separated disks)
 
 * Raid Name to be created, optional parameter.
 
@@ -10,14 +10,7 @@ Values to be passed in yaml file:
 
 * metadata levels for raid
 
-* Setup - True if only raid needs to be created and exit
-
-* Cleanup - True if only raid needs to be deleted and exit
-
-* Run_tests - True if only mdadm tests (like add, fail, remove device, etc)
-needs to be run on created raid
-
-* force - True if force option needs to be passed while creating raid.
+* spare disks (space separated disks) [optional parameter]
 
 Note: Please specify minimum of 5 disks, for creating all levels of software
 raid. If 5 disks are not available, create 5 partitions, and specify those

--- a/io/disk/softwareraid.py.data/Readme
+++ b/io/disk/softwareraid.py.data/Readme
@@ -12,6 +12,9 @@ Values to be passed in yaml file:
 
 * spare disks (space separated disks) [optional parameter]
 
+* required disks - This is a configurable value of minimum required disks for each raid level.
+  Usually, it is 2 for RAID1, 3 for RAID5 and RAID10 and 4 for RAID6.
+
 Note: Please specify minimum of 5 disks, for creating all levels of software
 raid. If 5 disks are not available, create 5 partitions, and specify those
 partitions in the yaml file.

--- a/io/disk/softwareraid.py.data/softwareraid.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid.yaml
@@ -1,6 +1,6 @@
 disks:
-run_test: True
-force: True
+raidname:
+spare_disks:
 raidlevel: !mux
     raidlinear:
         raid: linear
@@ -15,7 +15,7 @@ raidlevel: !mux
     raid6:
         raid: 6
 metadata: !mux
-    superblock-0.90:
+    superblock-0.9:
         metadata: 0.90
         !filter-out : /run/raidlevel/raid0
     superblock-1.0:

--- a/io/disk/softwareraid.py.data/softwareraid.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid.yaml
@@ -17,6 +17,7 @@ raidlevel: !mux
 metadata: !mux
     superblock-0.90:
         metadata: 0.90
+        !filter-out : /run/raidlevel/raid0
     superblock-1.0:
         metadata: 1.0
     superblock-1.1:

--- a/io/disk/softwareraid.py.data/softwareraid.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid.yaml
@@ -8,12 +8,16 @@ raidlevel: !mux
         raid: 0
     raid1:
         raid: 1
+        required_disks: 2
     raid5:
         raid: 5
+        required_disks: 3
     raid10:
         raid: 10
+        required_disks: 3
     raid6:
         raid: 6
+        required_disks: 4
 metadata: !mux
     superblock-0.9:
         metadata: 0.90

--- a/io/disk/softwareraid.py.data/softwareraid_cleanup.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid_cleanup.yaml
@@ -1,7 +1,0 @@
-disks:
-raidname: /dev/md/avocado
-setup: False
-run_test: False
-cleanup: True
-force: True
-raid: 1

--- a/io/disk/softwareraid.py.data/softwareraid_setup.yaml
+++ b/io/disk/softwareraid.py.data/softwareraid_setup.yaml
@@ -1,8 +1,0 @@
-disks:
-raidname: /dev/md/avocado
-setup: True
-run_test: False
-cleanup: False
-force: True
-raid: 1
-metadata: 1.2


### PR DESCRIPTION
Moved all functions to utils, so that they can be used in
other tests.

Use case: avocado-misc-tests/issues/1674

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>