### PR TITLE
lvsetup: Reduce usage of unnecessary utilities

### DIFF
--- a/io/disk/lvsetup.py.data/README
+++ b/io/disk/lvsetup.py.data/README
@@ -5,15 +5,10 @@ volume and merges snapshot with the logical volume.
 
 Inputs Needed in yaml file:
 ---------------------------
-disks: Name of the disks on which volume groups, logical volumes,
+lv_disks: Name of the disks on which volume groups, logical volumes,
       snapshots are created. Created on loop device if not specified
-vg_name: Name of the volume group.
-lv_name: Name of the logical volume.
 lv_size: Size of the logical volume as string in the form "#G"
          (for example 30G).
-ramdisk_vg_size: Size of the physical volume to be created.
-ramdisk_basedir: Base directory to place the sparse file
-ramdisk_sparse_filename: Name of the sparse file.
 lv_snapshot_name: Name of the snapshot with origin the logical
                   volume.
 lv_snapshot_size: Size of the snapshot with origin the logical

--- a/io/disk/lvsetup.py.data/lvsetup_single.yaml
+++ b/io/disk/lvsetup.py.data/lvsetup_single.yaml
@@ -1,6 +1,0 @@
-# btrfs needs minimum LV size of 641M
-lv_disks:
-lv_size:
-vg_name:
-lv_name:
-fs: xfs


### PR DESCRIPTION
Reduce the usage of vg_ramdisk() functions so as to maintain
the code better. vg_ramdisk() does a lot more than is needed,
in a complex way.

Follow the issue for more details:
avocado-framework/avocado/pull/3857

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>