### PR TITLE
Network_config: Fix getting interface type

### DIFF
--- a/io/net/Network_config.py
+++ b/io/net/Network_config.py
@@ -55,9 +55,12 @@ class NetworkconfigTest(Test):
         except Exception:
             self.networkinterface.save(self.ipaddr, self.netmask)
         self.networkinterface.bring_up()
-        cmd = "basename /sys/class/net/%s/device/driver/module/drivers/*" % self.iface
-        self.iface_type, self.driver = process.system_output(
-            cmd, shell=True).decode("utf-8").split(':')
+        cmd = "basename -a /sys/class/net/%s/device/driver/module/drivers/*" % self.iface
+        output = process.system_output(cmd, shell=True).decode("utf-8")
+        for line in output.splitlines():
+            if line.split(':')[0] in ['pci', 'vio']:
+                self.iface_type, self.driver = line.split(':')
+                break
         self.businfo = self.get_bus_info(self.iface, self.iface_type)
 
     @staticmethod


### PR DESCRIPTION
Interface type was got by checking the command:
`basename /sys/class/net/<iface>/device/driver/module/drivers/*`

But mellanox devices had 2 types, as below:
```
mdev:mlx5_core  pci:mlx5_core
```

So, handling such cases with this commit.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>
Reported-by: Manvanthara Puttashankar <manvanth@linux.vnet.ibm.com>