### PR TITLE
multipath: Fix restoring config file backup.

### DIFF
--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -301,7 +301,7 @@ class MultipathTest(Test):
         """
         Restore config file, if existed, and restart services
         """
-        if os.path.isfile(self.mpath_file):
+        if os.path.isfile("%s.bkp" % self.mpath_file):
             shutil.copyfile("%s.bkp" % self.mpath_file, self.mpath_file)
         self.mpath_svc.restart()
 


### PR DESCRIPTION
When restoring multipath.conf backup, we are just checking
if conf file is present. But we should actually check if the
backup file is present. Fixing that with this commit.

```
Traceback (most recent call last):
  File "/io/disk/multipath_test.py", line 305, in tearDown
    shutil.copyfile("%s.bkp" % self.mpath_file, self.mpath_file)
  File "/usr/lib64/python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/etc/multipath.conf.bkp'
```

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>