### PR TITLE
Added option to not check mountpoint for generic device type

### DIFF
--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -67,7 +67,7 @@ class Thp(Test):
             os.makedirs(self.mem_path)
         self.device = Partition(device="none", mountpoint=self.mem_path)
         self.device.mount(mountpoint=self.mem_path, fstype="tmpfs",
-                          args='-o size=%dM' % free_mem)
+                          args='-o size=%dM' % free_mem, mnt_check=False)
 
     def test(self):
         '''

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -55,7 +55,7 @@ class ThpDefrag(Test):
         if os.path.exists(self.mem_path):
             os.makedirs(self.mem_path)
         self.device = Partition(device="none", mountpoint=self.mem_path)
-        self.device.mount(mountpoint=self.mem_path, fstype="tmpfs")
+        self.device.mount(mountpoint=self.mem_path, fstype="tmpfs", mnt_check=False)
         free_space = (disk.freespace(self.mem_path)) // 1024
         # Leaving out some free space in tmpfs
         self.count = (free_space // self.block_size) - 3

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -69,7 +69,7 @@ class ThpSwapping(Test):
                 os.makedirs(self.mem_path)
             self.device = Partition(device="none", mountpoint=self.mem_path)
             self.device.mount(mountpoint=self.mem_path, fstype="tmpfs",
-                              args="-o size=%sM" % tmpfs_size)
+                              args="-o size=%sM" % tmpfs_size, mnt_check=False)
 
     def test(self):
         '''


### PR DESCRIPTION
Patch adds option to not check mountpoint for generic device type

Signed-off-by: Harish <harish@linux.ibm.com>