### PR TITLE
Adding 24 hours yamls for HTX tests

### DIFF
--- a/io/disk/htx_block_devices.py.data/htx_all_devices_24_hours.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_all_devices_24_hours.yaml
@@ -1,4 +1,4 @@
 htx_disks: ''
 all: True
-time_limit: 1
+time_limit: 1440
 mdt_file: 'mdt.hd'

--- a/io/disk/htx_block_devices.py.data/htx_block_devices_24_hours.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_block_devices_24_hours.yaml
@@ -1,4 +1,4 @@
 htx_disks: ''
-all: True
-time_limit: 1
+all: False
+time_limit: 1440
 mdt_file: 'mdt.hd'

--- a/io/net/htx_nic_devices.py.data/htx_nic_devices_24_hours.yaml
+++ b/io/net/htx_nic_devices.py.data/htx_nic_devices_24_hours.yaml
@@ -1,0 +1,14 @@
+mdt_file: 'net.mdt'
+host_public_ip: x.xx.xxx.xx
+peer_public_ip: x.xx.xxx.xy
+peer_password: "*******"
+peer_user: "root"
+htx_host_interfaces: ""
+peer_interfaces: ""
+host_ips: ""
+netmask: ""
+peer_ips: ""
+net_ids: ""
+# time limit in minutes
+time_limit: 1440
+htx_rpm: ""


### PR DESCRIPTION
Adding 24 hours yamls for HTX tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>