### PR TITLE
add connect() from ssh.py to avoid ssh-keygen

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -118,6 +118,8 @@ class Bonding(Test):
         self.log.info("Bond Test on IB Interface? = %s", self.ib)
         self.session = Session(self.peer_first_ipinterface, user=self.user,
                                password=self.password)
+        if not self.session.connect():
+            self.fail("failed connecting to peer")
         self.setup_ip()
         self.err = []
         self.remotehost = RemoteHost(self.peer_first_ipinterface, self.user,
@@ -460,3 +462,6 @@ class Bonding(Test):
     def error_check(self):
         if self.err:
             self.fail("Tests failed. Details:\n%s" % "\n".join(self.err))
+
+    def tearDown(self):
+        self.session.quit()

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -63,6 +63,8 @@ class Iperf(Test):
         self.networkinterface.bring_up()
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
+        if not self.session.connect():
+            self.fail("failed connecting to peer")
         smm = SoftwareManager()
         for pkg in ["gcc", "autoconf", "perl", "m4", "libtool"]:
             if not smm.check_installed(pkg) and not smm.install(pkg):
@@ -155,3 +157,4 @@ class Iperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.session.quit()

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -60,6 +60,8 @@ class ReceiveMulticastTest(Test):
 
         self.session = Session(self.peer, user=self.user,
                                password=self.peer_password)
+        if not self.session.connect():
+            self.fail("failed connecting to peer")
         self.count = self.params.get("count", default="500000")
         smm = SoftwareManager()
         pkgs = ["net-tools"]
@@ -128,3 +130,4 @@ class ReceiveMulticastTest(Test):
             self.log.info("unable to unset all mulicast option")
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.session.quit()

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -66,6 +66,8 @@ class Netperf(Test):
         self.networkinterface.bring_up()
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
+        if not self.session.connect():
+            self.fail("failed connecting to peer")
         smm = SoftwareManager()
         detected_distro = distro.detect()
         pkgs = ['gcc']
@@ -180,3 +182,4 @@ class Netperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.session.quit()

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -65,6 +65,8 @@ class Uperf(Test):
         self.networkinterface.bring_up()
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
+        if not self.session.connect():
+            self.fail("failed connecting to peer")
         smm = SoftwareManager()
         detected_distro = distro.detect()
         pkgs = ["gcc", "autoconf", "perl", "m4", "git-core", "automake"]
@@ -168,3 +170,4 @@ class Uperf(Test):
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.session.quit()


### PR DESCRIPTION
to avoid password during command run in peer machine.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>