### PR TITLE
add connect() from utils to avoid ssh-keygen for hmc and vios

### DIFF
--- a/io/disk/dlpar_vscsi.py
+++ b/io/disk/dlpar_vscsi.py
@@ -39,6 +39,7 @@ class DlparTest(Test):
         self.vios_pwd = self.params.get('vios_pwd', '*', default=None)
         self.session = Session(self.vios_ip, user=self.vios_user,
                                password=self.vios_pwd)
+        self.session.connect()
         cmd = "lscfg -l %s" % self.disk
         for line in process.system_output(cmd, shell=True).decode("utf-8") \
                                                           .splitlines():
@@ -102,3 +103,6 @@ class DlparTest(Test):
         for _ in range(self.num_of_dlpar):
             self.dlpar_remove()
             self.dlpar_add()
+
+    def tearDown(self):
+        self.session.quit()

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -67,6 +67,8 @@ class NetworkVirtualization(Test):
             self.cancel("LPAR Name not got from lparstat command")
         self.session_hmc = Session(self.hmc_ip, user=self.hmc_username,
                                    password=self.hmc_pwd)
+        if not self.session_hmc.connect():
+            self.cancel("failed connecting to HMC")
         cmd = 'lssyscfg -r sys  -F name'
         output = self.session_hmc.cmd(cmd)
         self.server = ''
@@ -108,8 +110,10 @@ class NetworkVirtualization(Test):
         self.vios_ip = self.params.get('vios_ip', '*', default=None)
         self.vios_user = self.params.get('vios_username', '*', default=None)
         self.vios_pwd = self.params.get('vios_pwd', '*', default=None)
-        self.session = Session(self.vios_ip, user=self.vios_user,
-                               password=self.vios_pwd)
+        if 'vios' in str(self.name.name):
+            self.session = Session(self.vios_ip, user=self.vios_user,
+                                   password=self.vios_pwd)
+            self.session.connect()
         self.count = int(self.params.get('vnic_test_count', default="1"))
         self.num_of_dlpar = int(self.params.get("num_of_dlpar", default='1'))
         self.device_ip = self.params.get('device_ip', '*',
@@ -797,4 +801,5 @@ class NetworkVirtualization(Test):
 
     def tearDown(self):
         self.session_hmc.quit()
-        self.session.quit()
+        if 'vios' in str(self.name.name):
+            self.session.quit()

--- a/io/net/virt-net/veth_dlpar.py
+++ b/io/net/virt-net/veth_dlpar.py
@@ -45,6 +45,7 @@ class VethdlparTest(Test):
         self.vios_pwd = self.params.get('vios_pwd', '*', default=None)
         self.session = Session(self.vios_ip, user=self.vios_user,
                                password=self.vios_pwd)
+        self.session.connect()
         local = LocalHost()
         self.networkinterface = NetworkInterface(self.interface, local)
         try:
@@ -111,3 +112,4 @@ class VethdlparTest(Test):
     def tearDown(self):
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
         self.networkinterface.restore_from_backup()
+        self.session.quit()

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -56,6 +56,8 @@ class DlparPci(Test):
             self.cancel("LPAR Name not got from lparstat command")
         self.session = Session(self.hmc_ip, user=self.hmc_user,
                                password=self.hmc_pwd)
+        if not self.session.connect():
+            self.cancel("failed connecting to HMC")
         cmd = 'lssyscfg -r sys  -F name'
         output = self.session.cmd(cmd)
         self.server = ''


### PR DESCRIPTION
to avoid password of hmc and vios during test run chnage for
dlpar_vscsi.py,veth_dlpar.py,veth_dlpar.py,network_virtualization.py

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>