### PR TITLE
copy files using utils module

### DIFF
--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -98,12 +98,10 @@ class Iperf(Test):
         archive.extract(tarball, self.iperf)
         self.version = os.path.basename(tarball.split('.tar')[0])
         self.iperf_dir = os.path.join(self.iperf, self.version)
-        out = self.session.get_raw_ssh_command('ls')
-        cmd_l = " ".join((out.split()[1:7]))
-        cmd = "/usr/bin/scp %s -r %s %s@%s:/tmp" % (cmd_l, self.iperf_dir,
-                                                    self.peer_user,
-                                                    self.peer_ip)
-        if process.system(cmd, shell=True, ignore_status=True) != 0:
+        destination = "%s:/tmp" % self.peer_ip
+        output = self.session.copy_files(self.iperf_dir, destination,
+                                         recursive=True)
+        if not output:
             self.cancel("unable to copy the iperf into peer machine")
         cmd = "cd /tmp/%s;./configure ppc64le;make" % self.version
         output = self.session.cmd(cmd)

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -112,12 +112,10 @@ class Netperf(Test):
         self.version = "%s-%s" % ("netperf",
                                   os.path.basename(tarball.split('.zip')[0]))
         self.neperf = os.path.join(self.netperf, self.version)
-        out = self.session.get_raw_ssh_command('ls')
-        cmd_l = " ".join((out.split()[1:7]))
-        cmd = "/usr/bin/scp %s -r %s %s@%s:/tmp" % (cmd_l, self.neperf,
-                                                    self.peer_user,
-                                                    self.peer_ip)
-        if process.system(cmd, shell=True, ignore_status=True) != 0:
+        destination = "%s:/tmp" % self.peer_ip
+        output = self.session.copy_files(self.neperf, destination,
+                                         recursive=True)
+        if not output:
             self.cancel("unable to copy the netperf into peer machine")
         cmd = "cd /tmp/%s;./configure ppc64le;make" % self.version
         output = self.session.cmd(cmd)

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -193,16 +193,14 @@ class NetworkTest(Test):
         process.run("dd if=/dev/zero of=/tmp/tempfile bs=1024000000 count=1",
                     shell=True)
         md_val1 = hashlib.md5(open('/tmp/tempfile', 'rb').read()).hexdigest()
-        out = self.session.get_raw_ssh_command('ls')
-        cmd_l = " ".join((out.split()[1:7]))
-        cmd = "/usr/bin/scp %s /tmp/tempfile %s:/tmp" % (cmd_l, self.peer)
-        ret = process.system(cmd, shell=True, verbose=True, ignore_status=True)
-        if ret != 0:
+        destination = "%s:/tmp" % self.peer
+        output = self.session.copy_files('/tmp/tempfile', destination)
+        if not output:
             self.fail("unable to copy into peer machine")
 
-        cmd = "/usr/bin/scp %s %s:/tmp/tempfile /tmp" % (cmd_l, self.peer)
-        ret = process.system(cmd, shell=True, verbose=True, ignore_status=True)
-        if ret != 0:
+        source = "%s:/tmp/tempfile" % self.peer
+        output = self.session.copy_files(source, '/tmp')
+        if not output:
             self.fail("unable to copy from peer machine")
 
         md_val2 = hashlib.md5(open('/tmp/tempfile', 'rb').read()).hexdigest()

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -105,12 +105,10 @@ class Uperf(Test):
                                    expire='7d')
         archive.extract(tarball, self.teststmpdir)
         self.uperf_dir = os.path.join(self.teststmpdir, "uperf-master")
-        out = self.session.get_raw_ssh_command('ls')
-        cmd_l = " ".join((out.split()[1:7]))
-        cmd = "/usr/bin/scp %s -r %s %s@%s:/tmp" % (cmd_l, self.uperf_dir,
-                                                    self.peer_user,
-                                                    self.peer_ip)
-        if process.system(cmd, shell=True, ignore_status=True) != 0:
+        destination = "%s:/tmp" % self.peer_ip
+        output = self.session.copy_files(self.uperf_dir, destination,
+                                         recursive=True)
+        if not output:
             self.cancel("unable to copy the uperf into peer machine")
         cmd = "cd /tmp/uperf-master;autoreconf -fi;./configure ppc64le;make"
         output = self.session.cmd(cmd)


### PR DESCRIPTION
changes for copy files using utils in iperf, netperf, uperf
and network_test files.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>