### PR TITLE
Add iSCSI test suite

### DIFF
--- a/io/net/ethtool_test.py.data/ethtool_iscsi_test.yaml
+++ b/io/net/ethtool_test.py.data/ethtool_iscsi_test.yaml
@@ -1,0 +1,36 @@
+interface:
+peer_ip:
+host_ip:
+netmask:
+args: !mux
+    PrivateFlag:
+        privflag_test: True
+    Driver:
+        arg: -i
+    Autonegotiation:
+        arg: -r
+    PauseParameter:
+        arg: -a
+    Coalescing:
+        arg: -c
+    RegisterDump:
+        arg: -d
+    EEPROMDump:
+       arg: -e
+    RingParameter:
+        arg: -g
+    ShowOffloadProtocolFeature:
+        arg: -k
+    AdapterInitiate:
+        arg: -p
+        action_elapse: 3
+    Statistics:
+        arg: -S
+    SelfTest:
+        arg: -t
+    Show-permaddr:
+        arg: -P
+    Get-dump:
+        arg: -w
+    Show-time-stamping:
+        arg: -T


### PR DESCRIPTION
I've made some tests that test iSCSI specific configs. These tests are based off of existing network and disk tests so I've titled my tests [old_test]_iscsi.py. Hopefully this makes it easier to compare to old tests and understand their functionality. Please review and let me know if more work needs to be done on these tests. 
This is just a starting point to enable basic testing for iSCSI. Hopefully more tests will be added in the future.
I've also made a config file for the fvt-avocado-wrapper which I will submit once my iscsi tests are added to this repo.

Thanks,
Kyle