### PR TITLE
Fix: Use a unique exit status to avoid failures

### DIFF
--- a/memory/integrity.py
+++ b/memory/integrity.py
@@ -71,6 +71,6 @@ class Integrity(Test):
         status = process.system('./mem_integrity_test -s %s' %
                                 self.scenario_arg, shell=True, ignore_status=True)
         if status != 0:
-            if status == 255:
+            if status == 201:
                 self.cancel("System does not have numa/memory to run the test")
             self.fail("Test failed")

--- a/memory/integrity.py.data/mem_integrity_test.c
+++ b/memory/integrity.py.data/mem_integrity_test.c
@@ -177,7 +177,7 @@ void get_numa_nodes_to_use(unsigned long memory_to_use)
 		printf("Nodes used in test %d %d \n", nodes_to_use[0], nodes_to_use[1]);
 	}else {
 		printf("10 percent of total memory is not found in 2 nodes\n");
-		exit(255);
+		exit(201);
 	}
 }
 
@@ -291,7 +291,7 @@ void write_read_pattern_numa_migration()
         printf("\nScenario : Numa Migration \n\n");
 	if(numa_available == -1){
 		printf("Numa library is not present");
-		exit(255);
+		exit(201);
 	}
 	max_node = numa_max_node();
 
@@ -374,7 +374,7 @@ int main(int argc, char *argv[])
 	printf("Total memory size %lu bytes \n", total_mem);
 	if (argc < 2){
 		printf("Usage <execname> -s <scenario_no> \n");
-		exit(255);
+		exit(201);
 	}
 	option = getopt(argc, argv,"s:");
 	if (option != -1){


### PR DESCRIPTION
Failures like below does return a code of 255
```
$ ./mem_integrity -s 3
...
...
madvise: Device or resource busy
```
So use a different, unique code to catch the failure

Signed-off-by: Harish <harish@linux.ibm.com>