### PR TITLE
Update ebizzy tarball download link

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -43,15 +43,15 @@ class Ebizzy(Test):
         '''
         Build ebizzy
         Source:
-        http://liquidtelecom.dl.sourceforge.net/project/ebizzy/ebizzy/0.3
+        https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3
         /ebizzy-0.3.tar.gz
         '''
         sm = SoftwareManager()
         for package in ['gcc', 'make', 'patch']:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
-        tarball = self.fetch_asset('http://liquidtelecom.dl.sourceforge.net'
-                                   '/project/ebizzy/ebizzy/0.3'
+        tarball = self.fetch_asset('http://sourceforge.net/projects'
+                                   '/ebizzy/files/ebizzy/0.3'
                                    '/ebizzy-0.3.tar.gz')
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('.tar.')[0])
@@ -60,8 +60,8 @@ class Ebizzy(Test):
         patch = self.params.get(
             'patch', default='Fix-build-issues-with-ebizzy.patch')
         os.chdir(self.sourcedir)
-        p1 = 'patch -p0 < %s' % (self.get_data(patch))
-        process.run(p1, shell=True)
+        patch_cmd = 'patch -p0 < %s' % (self.get_data(patch))
+        process.run(patch_cmd, shell=True)
         process.run('[ -x configure ] && ./configure', shell=True)
         build.make(self.sourcedir)
 


### PR DESCRIPTION
Ebizzy test fails to fetch source tarball as the link used for download is no longer working/valid.

#
Fetching asset from cpu/ebizzy.py:Ebizzy.test
JOB ID     : bd2879565ad2afa97a748cabc0136654898bac33
JOB LOG    : /home/tests/results/job-2020-07-22T05.24-bd28795/job.log
 (1/1) cpu/ebizzy.py:Ebizzy.test:  ERROR: Failed to fetch ebizzy-0.3.tar.gz. (132.88 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
# 

Update the test to fetch the tarball using the correct link.

This patch also fixes a pylint warning for p1 variable.

Signed-off-by : Sachin Sant <sachinp@linux.vnet.ibm.com>