### PR TITLE
Fix: Access mode of temporary directory

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -126,8 +126,9 @@ class LTP(Test):
         logfile = os.path.join(self.logdir, 'ltp.log')
         failcmdfile = os.path.join(self.logdir, 'failcmdfile')
 
+        os.chmod(self.teststmpdir, 0o755)
         self.args += (" -q -p -l %s -C %s -d %s -S %s"
-                      % (logfile, failcmdfile, self.workdir,
+                      % (logfile, failcmdfile, self.teststmpdir,
                          self.get_data('skipfile')))
         if self.mem_leak:
             self.args += " -M %s" % self.mem_leak


### PR DESCRIPTION
Avocado's temporary creation API by default allows only created user to read, write and execute from the tmp dir. Due to this lot
of LTP tests fail without access from ltp user, hence changing the mode before running the tests, also using teststmpdir which is apt here

Signed-off-by: Harish <harish@linux.ibm.com>