### PR TITLE
perf_24x7_hardware_counters.py: event error logging corrected

### DIFF
--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -114,8 +114,7 @@ class EliminateDomainSuffix(Test):
 
     def test_event_wo_domain_param(self):
         result1 = self.event_stat('/ sleep 1')
-        if "invalid or unsupported event" not in result1.stderr.decode("utf-8") or "Required "\
-                "parameter 'domain' not specified" not in result1.stdout.decode("utf-8"):
+        if "Required parameter 'domain' not specified" not in result1.stdout.decode("utf-8"):
             self.fail('Domain is not specified, perf unable'
                       ' to recognize it has invalid event')
         else:


### PR DESCRIPTION
perf event related error logging was corrected, so to reflect the correct
error, the condition to check the error was modified.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>