### PR TITLE
ras_extended.py: Executing bootlist tool test is Failed.

### DIFF
--- a/ras/ras_extended.py
+++ b/ras/ras_extended.py
@@ -150,9 +150,9 @@ class RASTools(Test):
             cmd = "bootlist %s" % list_item
             self.run_cmd(cmd)
         interface = self.run_cmd_out(
-            "ifconfig | head -1 | cut -d':' -f1")
-        disk_name = self.run_cmd_out("df -h | egrep '(s|v)d[a-z][1-8]' | "
-                                     "tail -1 | cut -d' ' -f1").strip("12345")
+            "ifconfig | egrep '^(net|eth)' | cut -d':' -f1")
+        disk_name = self.run_cmd_out("lsblk -i | egrep '(s|v)d[a-z]' | "
+                                     "cut -d' ' -f1 | head -1")
         file_path = os.path.join(self.workdir, 'file')
         process.run("echo %s > %s" %
                     (disk_name, file_path), ignore_status=True, sudo=True, shell=True)


### PR DESCRIPTION
changed commands to get interface and disk_name in Executing bootlist tool.

Signed-off-by: Naveen kumar T <naveet89@in.ibm.com>