### PR TITLE
Added logic to provide upstream git url for kself test case

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -81,8 +81,16 @@ class kselftest(Test):
             location = self.params.get('location', default='https://github.c'
                                        'om/torvalds/linux/archive/master.zip')
             path = ''
-            if 'zip' in location:
-                tarball = self.fetch_asset("kselftest.zip", locations=[location],
+            git_location = True
+            kselfdir = ''
+            if ".zip" in location:
+                kselfdir = "kselftest.zip"
+                git_location = False
+            elif ".tar" in location:
+                kselfdir = "kselftest.tar"
+                git_location = False
+            if not git_location:
+                tarball = self.fetch_asset(kselfdir, locations=[location],
                                            expire='1d')
                 archive.extract(tarball, self.workdir)
                 path = glob.glob(os.path.join(self.workdir, "linux*"))


### PR DESCRIPTION
Added logic in kself test case as location can be provided
just as upstream git format as this can be used to provide
custom or fork kernel self test case

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>