### PR TITLE
htx_block_devices.py added LV and Software raid

### DIFF
--- a/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
@@ -2,3 +2,13 @@ htx_disks: ''
 all: False
 time_limit: 1
 mdt_file: 'mdt.hd'
+lv: !mux
+    lv:
+        lv: True
+    no_lv:
+        lv: False
+raid: !mux
+    raid:
+        raid: True
+    no_raid:
+        raid: False


### PR DESCRIPTION
Test creates LV,software raid and runs htx test on them, as an option.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>