### PR TITLE
Fix perf install command by linux-perf for debian

### DIFF
--- a/perf/perf_basic.py
+++ b/perf/perf_basic.py
@@ -53,11 +53,13 @@ class PerfBasic(Test):
     def setUp(self):
         smg = SoftwareManager()
         dist = distro.detect()
-        if dist.name in ['Ubuntu', 'debian']:
+        if dist.name in ['Ubuntu']:
             linux_tools = "linux-tools-" + os.uname()[2][3]
             pkgs = [linux_tools]
             if dist.name in ['Ubuntu']:
                 pkgs.extend(['linux-tools-common'])
+        elif dist.name in ['debian']:
+            pkgs = ['linux-perf']
         elif dist.name in ['centos', 'fedora', 'rhel', 'SuSE']:
             pkgs = ['perf']
         else:

--- a/perf/perf_c2c.py
+++ b/perf/perf_c2c.py
@@ -46,7 +46,7 @@ class perf_c2c(Test):
             deps.extend(['linux-tools-common', 'linux-tools-%s' %
                          platform.uname()[2]])
         elif 'debian' in detected_distro.name:
-            deps.extend(['linux-tools-%s' % platform.uname()[2][3]])
+            deps.extend(['linux-perf'])
         elif self.distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
             deps.extend(['perf'])
         else:

--- a/perf/perf_fuzzer.py
+++ b/perf/perf_fuzzer.py
@@ -53,6 +53,8 @@ class Perffuzzer(Test):
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility
         # enabler for older runners, but should be removed soon
+        elif detected_distro.name in ['debian']:
+            deps.extend(['linux-perf'])
         elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'redhat']:
             deps.extend(['perf'])
         else:


### PR DESCRIPTION
Fix perf install command by linux-perf for debian as bellow files

perf_basic.py
perf_c2c.py
perf_fuzzer.py

Signed-off-by:  xiaohaiyan <xiaohaiyan@uniontech.com>