### PR TITLE
fixed lro test and add ip config as an option in network_test

### DIFF
--- a/io/net/network_test.py.data/network_test.yaml
+++ b/io/net/network_test.py.data/network_test.yaml
@@ -5,6 +5,7 @@ peer_user: "root"
 peer_password: "********"
 host_ip:
 netmask:
+ip_config: True
 mtu: !mux
     1500:
         mtu: "1500"


### PR DESCRIPTION
include a parameter for ip config as an option to config ip.
and fixed lro test to handle bondig interface.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>