### PR TITLE
fix as ebizzy as bug fix and enhancement

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -50,9 +50,9 @@ class Ebizzy(Test):
         for package in ['gcc', 'make', 'patch']:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
-        tarball = self.fetch_asset('http://sourceforge.net/projects'
-                                   '/ebizzy/files/ebizzy/0.3'
-                                   '/ebizzy-0.3.tar.gz')
+        url = 'http://sourceforge.net/projects/ebizzy/files/ebizzy/' \
+              '0.3/ebizzy-0.3.tar.gz"'
+        tarball = self.fetch_asset(self.params.get("ebizy_url", default=url))
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('.tar.')[0])
         self.sourcedir = os.path.join(self.workdir, version)

--- a/cpu/ebizzy.py.data/ebizzy.yaml
+++ b/cpu/ebizzy.py.data/ebizzy.yaml
@@ -1,4 +1,5 @@
 setup:
+    ebizy_url: 'http://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz'
     duration: !mux
         default:
             seconds: 100

--- a/cpu/em_smt_folding_test.py
+++ b/cpu/em_smt_folding_test.py
@@ -55,9 +55,10 @@ class SmtFolding(Test):
         for package in deps:
             if not smg.check_installed(package) and not smg.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
-        tarball = self.fetch_asset('http://liquidtelecom.dl.sourceforge.net'
-                                   '/project/ebizzy/ebizzy/0.3'
-                                   '/ebizzy-0.3.tar.gz')
+        url = 'http://sourceforge.net/projects//ebizzy/files/ebizzy/0.3/' \
+              'ebizzy-0.3.tar.gz'
+        tarball = self.fetch_asset(self.params.get("ebizy_url", default=url),
+                                   expire='7d')
         self.cpu_unit = self.params.get('cpu_unit', default=.1)
         self.dlpar_loop = self.params.get('range', default=10)
 

--- a/cpu/em_smt_folding_test.py.data/em_smt_folding_test.yaml
+++ b/cpu/em_smt_folding_test.py.data/em_smt_folding_test.yaml
@@ -1,3 +1,4 @@
 setup:
+    ebizy_url: 'http://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz'
     cpu_unit: .1
     range: 10


### PR DESCRIPTION
1-Fix ebizzy tar file link as old link not valid any more
2-add expire param for fecth as it avoid download again

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>