### PR TITLE
Use `--prefix=/usr` by default for glibc

### DIFF
--- a/toolchain/glibc.py
+++ b/toolchain/glibc.py
@@ -46,7 +46,8 @@ class Glibc(Test):
                 os.makedirs(glibc_dir)
             glibc_dir = sm.get_source("glibc", glibc_dir)
         os.chdir(self.build_dir)
-        process.run('%s/configure --prefix=%s' % (glibc_dir, self.build_dir),
+        process.run('%s/configure --prefix=%s'
+                    % (glibc_dir, self.params.get("prefix", default="/usr")),
                     ignore_status=True, sudo=True)
         build.make(self.build_dir)
 

--- a/toolchain/glibc.py.data/glibc.yaml
+++ b/toolchain/glibc.py.data/glibc.yaml
@@ -5,3 +5,4 @@ run_type: !mux
         type: 'upstream'
     distro:
         type: 'distro'
+prefix: '/usr'


### PR DESCRIPTION
The `glibc.py` test specifies a _prefix_ of `self.build_dir` when doing
`./configure`.

This is mostly innocuous unless a `make install` is performed, which
is not done by `glibc.py`.

It is an issue, however, when doing a `make check` because some glibc
tests are unable to find the system's `libgcc_s.so.1` and FAIL.
There is an obscure reference to this known issue at
https://sourceware.org/glibc/wiki/Testing/Testsuite#Known_testsuite_failures

Thus, default _prefix_ to `/usr`.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>