### PR TITLE
handle for Exception shouldn't raise if backup file not available

### DIFF
--- a/io/net/Network_config.py
+++ b/io/net/Network_config.py
@@ -163,4 +163,7 @@ class NetworkconfigTest(Test):
         unset ip for host interface
         '''
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")

--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -448,7 +448,10 @@ class Bonding(Test):
             networkinterface = NetworkInterface(host_interface, self.localhost)
             if networkinterface.set_mtu("1500") is not None:
                 self.cancel("Failed to set mtu in host")
-            networkinterface.restore_from_backup()
+            try:
+                networkinterface.restore_from_backup()
+            except Exception:
+                self.log.info("backup file not availbale, could not restore file.")
         try:
             for interface in self.peer_interfaces:
                 peer_networkinterface = NetworkInterface(interface, self.remotehost)

--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -182,4 +182,7 @@ class Ethtool(Test):
         '''
         self.interface_state_change(self.iface, "up", "yes")
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -157,7 +157,10 @@ class Iperf(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")
         self.remotehost.remote_session.quit()
         self.remotehost_public.remote_session.quit()
         self.session.quit()

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -129,5 +129,8 @@ class ReceiveMulticastTest(Test):
                           ignore_status=True) != 0:
             self.log.info("unable to unset all mulicast option")
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")
         self.session.quit()

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -136,6 +136,9 @@ class MultiportStress(Test):
         for ipaddr, interface in zip(self.ipaddr, self.host_interfaces):
             networkinterface = NetworkInterface(interface, self.local)
             networkinterface.remove_ipaddr(ipaddr, self.netmask)
-            networkinterface.restore_from_backup()
+            try:
+                networkinterface.restore_from_backup()
+            except Exception:
+                self.log.info("backup file not availbale, could not restore file.")
             self.remotehost.remote_session.quit()
             self.remotehost_public.remote_session.quit()

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -182,7 +182,10 @@ class Netperf(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")
         self.remotehost.remote_session.quit()
         self.remotehost_public.remote_session.quit()
         self.session.quit()

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -310,7 +310,10 @@ class NetworkTest(Test):
             self.session.cmd(cmd)
         if self.ip_config:
             self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-            self.networkinterface.restore_from_backup()
+            try:
+                self.networkinterface.restore_from_backup()
+            except Exception:
+                self.log.info("backup file not availbale, could not restore file.")
         self.remotehost.remote_session.quit()
         self.remotehost_public.remote_session.quit()
         if 'scp' or 'ssh' in str(self.name.name):

--- a/io/net/switch_test.py
+++ b/io/net/switch_test.py
@@ -126,4 +126,7 @@ class SwitchTest(Test):
         unset ip address
         '''
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -158,6 +158,9 @@ class TcpdumpTest(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")
         self.remotehost.remote_session.quit()
         self.remotehost_public.remote_session.quit()

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -170,7 +170,10 @@ class Uperf(Test):
         except Exception:
             self.peer_public_networkinterface.set_mtu('1500')
         self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        self.networkinterface.restore_from_backup()
+        try:
+            self.networkinterface.restore_from_backup()
+        except Exception:
+            self.log.info("backup file not availbale, could not restore file.")
         self.remotehost.remote_session.quit()
         self.remotehost_public.remote_session.quit()
         self.session.quit()


### PR DESCRIPTION
for restore_from_backup(), if backup file is there it will move or
else it shouldn't raise exception.to avoid test fail.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>