### PR TITLE
ndctl: Remove "all" from disable/enable test case

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -255,7 +255,6 @@ class NdctlTest(Test):
         ns_names = []
         for ns in namespaces:
             ns_names.append(self.plib.run_ndctl_list_val(ns, 'dev'))
-        ns_names.append('all')
 
         for namespace in ns_names:
             self.plib.disable_namespace(namespace=namespace)


### PR DESCRIPTION
Removing "all" is valid because if create-namespace fails, the pmem lib will
throw an error. And if one of the namespace disable fails, it will still throw
an error. So we got all the cases covered. This "all" is redundant.

If in future, ndctl treats "all" to behave differently for zero namespaces, we
will again have to change the test cases. Future proof it.

Signed-off-by: Santosh S <santosh@fossix.org>