### PR TITLE
iperf test yaml for virtual devices

### DIFF
--- a/io/net/iperf_test.py.data/iperf_virt_test.yaml
+++ b/io/net/iperf_test.py.data/iperf_virt_test.yaml
@@ -1,0 +1,15 @@
+interface: ""
+peer_ip: ""
+peer_public_ip: ""
+host_ip: ""
+netmask: ""
+peer_user_name: "root"
+peer_password: "********"
+EXPECTED_THROUGHPUT : 90
+IPERF_SERVER_RUN : 1
+iperf_download: "https://sourceforge.net/projects/iperf2/files/iperf-2.0.13.tar.gz"
+mtu: !mux
+    1500:
+        mtu: "1500"
+    9000:
+        mtu: "9000"


### PR DESCRIPTION
sriov virtual devices do not support all MTUs, so created a
separate yaml

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>