### PR TITLE
Fix: typo in ebizzy URL

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -51,7 +51,7 @@ class Ebizzy(Test):
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
         url = 'http://sourceforge.net/projects/ebizzy/files/ebizzy/' \
-              '0.3/ebizzy-0.3.tar.gz"'
+              '0.3/ebizzy-0.3.tar.gz'
         tarball = self.fetch_asset(self.params.get("ebizy_url", default=url))
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('.tar.')[0])


### PR DESCRIPTION
Patch fixes a minor typo issue introduced in a recent commit

Signed-off-by: Harish <harish@linux.ibm.com>