### PR TITLE
Adding security related test suites

### DIFF
--- a/generic/ltp.py.data/ltp-security.yaml
+++ b/generic/ltp.py.data/ltp-security.yaml
@@ -1,0 +1,24 @@
+setup:
+    general: !mux
+        runltp: !mux
+            script: 'runltp'
+            crypto:
+                args: '-f crypto'
+            cve:
+                args: '-f cve'
+            ima:
+                args: '-f ima'
+            net_stress.ipsec_dccp:
+                args: '-f net_stress.ipsec_dccp'
+            net_stress.ipsec_icmp:
+                args: '-f net_stress.ipsec_icmp'
+            net_stress.ipsec_sctp:
+                args: '-f net_stress.ipsec_sctp'
+            net_stress.ipsec_tcp:
+                args: '-f net_stress.ipsec_tcp'
+            net_stress.ipsec_udp:
+                args: '-f net_stress.ipsec_udp'
+            securebits:
+                args: '-f securebits'
+            tpm_tools:
+                args: '-f tpm_tools'


### PR DESCRIPTION
Adding the following test suites:
crypto
cve
ima
net_stress.ipsec_dccp
net_stress.ipsec_icmp
net_stress.ipsec_sctp
net_stress.ipsec_tcp
net_stress.ipsec_udp
securebits
tpm_tools

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>