### PR TITLE
nvmftest: Using ssh and scp utils

### DIFF
--- a/io/nvmf/nvmftest.py.data/README.txt
+++ b/io/nvmf/nvmftest.py.data/README.txt
@@ -17,3 +17,5 @@ Inputs Needed (in multiplexer file):
 ------------------------------------
 * namespaces    -   space separated namespaces on the peer to configure for NVMf
 * peer_ips      -   space separated peer IP address
+* peer_user     -   user name of peer system to login
+* peer_password -   passowrd of peer_user on peer system to login

--- a/io/nvmf/nvmftest.py.data/nvmftest.yaml
+++ b/io/nvmf/nvmftest.py.data/nvmftest.yaml
@@ -1,2 +1,4 @@
 namespaces: ''
 peer_ips: ''
+peer_user:
+peer_password:


### PR DESCRIPTION
Using the ssh and scp utils for nvmf tests.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>