### PR TITLE
Patch to fix bootlist testcase.

### DIFF
--- a/ras/ras_extended.py
+++ b/ras/ras_extended.py
@@ -150,7 +150,7 @@ class RASTools(Test):
             cmd = "bootlist %s" % list_item
             self.run_cmd(cmd)
         interface = self.run_cmd_out(
-            "ifconfig | head -1 | cut -d':' -f1")
+            "ifconfig | head -1 | egrep '^(net|eth)' | cut -d':' -f1")
         disk_name = self.run_cmd_out("df -h | egrep '(s|v)d[a-z][1-8]' | "
                                      "tail -1 | cut -d' ' -f1").strip("12345")
         file_path = os.path.join(self.workdir, 'file')


### PR DESCRIPTION
Changed ifconfig command in bootlist test.

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>

# avocado run ras_extended.py
JOB ID     : f06130084f0286ac7915883cab3d0bbe74af2015
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2020-09-29T06.16-f061300/job.log
 (01/11) ras_extended.py:RASTools.test1_uesensor:  PASS (1.59 s)
 (02/11) ras_extended.py:RASTools.test1_serv_config:  PASS (1.70 s)
 (03/11) ras_extended.py:RASTools.test1_ls_vscsi:  PASS (1.55 s)
 (04/11) ras_extended.py:RASTools.test1_ls_veth:  PASS (1.59 s)
 (05/11) ras_extended.py:RASTools.test1_ls_vdev:  PASS (1.58 s)
 (06/11) ras_extended.py:RASTools.test1_lsdevinfo:  PASS (3.01 s)
 (07/11) ras_extended.py:RASTools.test1_hvcsadmin:  PASS (1.93 s)
 (08/11) ras_extended.py:RASTools.test1_bootlist:  PASS (2.27 s)
 (09/11) ras_extended.py:RASTools.test1_vpdupdate:  PASS (3.49 s)
 (10/11) ras_extended.py:RASTools.test3_lsvpd:  PASS (3.18 s)
 (11/11) ras_extended.py:RASTools.test3_lscfg:  PASS (1.98 s)
RESULTS    : PASS 11 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2020-09-29T06.16-f061300/results.html
JOB TIME   : 25.05 s
[root@ltc-zz8-lp3 ras]# 
