### PR TITLE
Patch to fix bootlist testcase v2

### DIFF
--- a/ras/ras_extended.py
+++ b/ras/ras_extended.py
@@ -150,7 +150,7 @@ class RASTools(Test):
             cmd = "bootlist %s" % list_item
             self.run_cmd(cmd)
         interface = self.run_cmd_out(
-            "ifconfig | head -1 | cut -d':' -f1")
+            "lsvio -e | cut -d' ' -f2")
         disk_name = self.run_cmd_out("df -h | egrep '(s|v)d[a-z][1-8]' | "
                                      "tail -1 | cut -d' ' -f1").strip("12345")
         file_path = os.path.join(self.workdir, 'file')


### PR DESCRIPTION
Changed ifconfig command to lsvio in bootlist test.

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>

[root@ltc-zz8-lp4 ras]# avocado run ras_extended.py 
JOB ID     : 4e75ca57bbb2888fda94adee0c55b635978a046a
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2020-10-01T11.10-4e75ca5/job.log
 (01/11) ras_extended.py:RASTools.test1_uesensor: PASS (1.77 s)
 (02/11) ras_extended.py:RASTools.test1_serv_config: PASS (1.92 s)
 (03/11) ras_extended.py:RASTools.test1_ls_vscsi: PASS (1.73 s)
 (04/11) ras_extended.py:RASTools.test1_ls_veth: PASS (1.85 s)
 (05/11) ras_extended.py:RASTools.test1_ls_vdev: PASS (1.76 s)
 (06/11) ras_extended.py:RASTools.test1_lsdevinfo: PASS (5.18 s)
 (07/11) ras_extended.py:RASTools.test1_hvcsadmin: PASS (2.14 s)
 (08/11) ras_extended.py:RASTools.test1_bootlist: PASS (3.65 s)
 (09/11) ras_extended.py:RASTools.test1_vpdupdate: PASS (2754.51 s)
 (10/11) ras_extended.py:RASTools.test3_lsvpd: PASS (3.50 s)
 (11/11) ras_extended.py:RASTools.test3_lscfg: PASS (2.25 s)
RESULTS    : PASS 11 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2020-10-01T11.10-4e75ca5/results.html
JOB TIME   : 2781.60 s
