### PR TITLE
Fixed failures is few commands - v3

### DIFF
--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -38,6 +38,13 @@ class Sosreport(Test):
         return process.system_output(cmd, shell=True, ignore_status=True,
                                      sudo=True).decode("utf-8")
 
+    def run_cmd_search(self, cmd, search_str):
+        self.output = self.run_cmd_out(cmd)
+        for line in self.output.splitlines():
+            if search_str in line:
+                search_line = line.split()
+        return search_line[0].strip()
+
     def setUp(self):
         dist = distro.detect()
         sm = SoftwareManager()
@@ -167,9 +174,7 @@ class Sosreport(Test):
             self.is_fail += 1
             self.log.info("--profile option failed")
 
-        dir_name = self.run_cmd_out("sosreport --batch --tmp-dir=%s --build | "
-                                    "grep located | "
-                                    "cut -d':' -f2" % directory_name).strip()
+        dir_name = self.run_cmd_search("sosreport --batch --tmp-dir=%s --build" % directory_name, directory_name)
         if not os.path.isdir(dir_name):
             self.is_fail += 1
             self.log.info("--build option failed")
@@ -180,18 +185,13 @@ class Sosreport(Test):
             self.log.info("--quiet --no-report option failed")
         self.run_cmd("sosreport --batch --tmp-dir=%s --debug" % directory_name, None)
 
-        self.run_cmd("sosreport --batch --tmp-dir=%s --config-file=/etc/sos.conf" % directory_name)
-        file_name = self.run_cmd_out("sosreport --batch --tmp-dir=%s --tmp-dir=/root | "
-                                     "grep root | tail -1" % directory_name).strip()
+        file_name = self.run_cmd_search("sosreport --batch --tmp-dir=%s" % directory_name, directory_name)
         if not os.path.exists(file_name):
             self.is_fail += 1
             self.log.info("--tmp-dir option failed")
 
-        dir_name = self.run_cmd_out("sosreport --no-report --batch --build | "
-                                    "grep located | "
-                                    "cut -d':' -f2").strip()
-        sosreport_dir = os.path.join(dir_name, 'sos_reports')
-        if os.listdir(sosreport_dir) != []:
+        dir_name = self.run_cmd_search("sosreport --no-report --batch --build", '/var/tmp/sosreport')
+        if os.listdir(dir_name) == []:
             self.is_fail += 1
             self.log.info("--no-report option failed")
         file_list = self.params.get('file_list', default=['proc/device-tree/'])
@@ -254,7 +254,7 @@ class Sosreport(Test):
         directory_name = tempfile.mkdtemp()
         self.is_fail = 0
         self.run_cmd("sosreport --batch --tmp-dir=%s -o "
-                     "pci,powerpc,procenv,process,processor,kdump" % directory_name)
+                     "pci,powerpc,process,processor,kdump" % directory_name)
         shutil.rmtree(directory_name)
         if self.is_fail >= 1:
             self.fail("%s command(s) failed in sosreport tool verification" % self.is_fail)


### PR DESCRIPTION
Fixed failues in --build, --batch and --tmp commands.

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>

Logs:

[root@ltc-zz8-lp4 ras]# avocado run sosreport.py
JOB ID     : c87ec26820a86ceb5c1266d2fd870644a86c7460
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2020-10-16T06.00-c87ec26/job.log
 (1/6) sosreport.py:Sosreport.test_short: PASS (751.77 s)
 (2/6) sosreport.py:Sosreport.test_user: PASS (186.05 s)
 (3/6) sosreport.py:Sosreport.test_plugins: PASS (540.72 s)
 (4/6) sosreport.py:Sosreport.test_others: PASS (871.73 s)
 (5/6) sosreport.py:Sosreport.test_archive: PASS (733.00 s)
 (6/6) sosreport.py:Sosreport.test_PPC: PASS (94.76 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2020-10-16T06.00-c87ec26/results.html
JOB TIME   : 3179.12 s
