### PR TITLE
Add missing package for ndctl test

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -120,7 +120,8 @@ class NdctlTest(Test):
                 deps.extend(['libtool',
                              'libkmod-devel', 'libudev-devel', 'systemd-devel',
                              'libuuid-devel-static', 'libjson-c-devel',
-                             'keyutils-devel', 'kmod-bash-completion'])
+                             'keyutils-devel', 'kmod-bash-completion',
+                             'bash-completion-devel'])
             elif self.dist.name == 'rhel':
                 deps.extend(['libtool',
                              'kmod-devel', 'libuuid-devel', 'json-c-devel',

--- a/memory/ndctl_selftest.py
+++ b/memory/ndctl_selftest.py
@@ -65,7 +65,7 @@ class NdctlTest(Test):
                 deps.extend(['libkmod-devel', 'libudev-devel',
                              'keyutils-devel', 'libuuid-devel-static',
                              'libjson-c-devel', 'systemd-devel',
-                             'kmod-bash-completion'])
+                             'kmod-bash-completion', 'bash-completion-devel'])
             else:
                 deps.extend(['kmod-devel', 'libuuid-devel', 'json-c-devel',
                              'systemd-devel', 'keyutils-libs-devel', 'jq',


### PR DESCRIPTION
Patch adds missing package for upstream ndctl configuration

Signed-off-by: Harish <harish@linux.ibm.com>