### PR TITLE
bonding: test changes the peer's interface MTU indiscriminatley

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -296,8 +296,17 @@ class Bonding(Test):
             for interface in self.peer_interfaces:
                 peer_networkinterface = NetworkInterface(interface,
                                                          self.remotehost)
-                if peer_networkinterface.set_mtu(mtu) is not None:
-                    self.cancel("Failed to set mtu in peer")
+                cmd = "cat /sys/class/net/%s/device/name" % peer_networkinterface.name
+                output = self.session.cmd(cmd).stdout.decode("utf-8")
+                if output != "vnic\n":
+                    if peer_networkinterface.set_mtu(mtu) is not None:
+                        self.cancel("Failed to set mtu in peer")
+                elif output == "vnic\n" and mtu == '9000':
+                    if peer_networkinterface.set_mtu(mtu) is not None:
+                        self.cancel("Failed to set mtu in peer")
+                else:
+                    self.log.info("Peer interface is vNIC and it does not\
+                                   support %s MTU" % mtu)
             if self.ping_check():
                 self.log.info("Ping passed for Mode %s", self.mode,
                               mtu)


### PR DESCRIPTION
Currently the bonding test would change the MTU of the peer's interface from
2000-9000. If the peer's interface is an ibmvnic interface, vNIC doesn't support
MTU values that aren't 1500 or 9000 and the entire test fails since it cannot
change the MTU.

This fix checks if the peer's interface is an ibmvnic interface and if it is,
the test will only change the MTU if it is 9000.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>