### PR TITLE
tcpdump: reads count field from input file as a string

### DIFF
--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -137,7 +137,7 @@ class TcpdumpTest(Test):
         """
         perform nping
         """
-        nping_count = round((120 * self.count) / 100)
+        nping_count = round((120 * int(self.count)) / 100)
         detected_distro = distro.detect()
         if detected_distro.name == "SuSE":
             cmd = "./nping/nping --%s %s -c %s" % (param,


### PR DESCRIPTION
Avocado converts the count field as a string when the test treats it as an int.
This fix converts the count field to an int when preforming arthmetic.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>