### PR TITLE
changes for multiple vnic with different adapter id

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -236,11 +236,13 @@ class NetworkVirtualization(Test):
         '''
         Network virtualized device add operation
         '''
-        for slot, mac, device_ip, netmask in zip(self.slot_num, self.mac_id,
-                                                 self.device_ip, self.netmask):
+        for slot, mac, sriov_port, adapter_id, device_ip, netmask in zip(self.slot_num, self.mac_id,
+                                                                         self.sriov_port,
+                                                                         self.backing_adapter_id,
+                                                                         self.device_ip, self.netmask):
             if not self.check_slot_availability(slot):
                 self.fail("Slot does not exist")
-            self.device_add_remove(slot, mac, 'add')
+            self.device_add_remove(slot, mac, sriov_port, adapter_id, 'add')
             self.interface_naming(mac, slot)
             output = self.list_device(slot)
             if 'slot_num=%s' % slot not in str(output):
@@ -461,7 +463,7 @@ class NetworkVirtualization(Test):
             if self.check_slot_availability(slot):
                 self.fail("Slot does not exist")
             self.update_backing_devices(slot)
-            self.device_add_remove(slot, '', 'remove')
+            self.device_add_remove(slot, '', '', '', 'remove')
             output = self.list_device(slot)
             if 'slot_num=%s' % slot in str(output):
                 self.log.debug(output)
@@ -477,14 +479,14 @@ class NetworkVirtualization(Test):
         if validate_string not in output.stdout_text:
             self.fail("command fail in vios")
 
-    def device_add_remove(self, slot, mac, operation):
+    def device_add_remove(self, slot, mac, sriov_port, adapter_id, operation):
         '''
         Adds and removes a Network virtualized device based
         on the operation
         '''
         backing_device = "backing_devices=sriov/%s/%s/%s/%s/%s/%s"\
                          % (self.vios_name[0], self.vios_id[0],
-                            self.backing_adapter_id[0], self.sriov_port[0],
+                            adapter_id, sriov_port,
                             self.bandwidth, self.vnic_priority[0])
         if operation == 'add':
             cmd = 'chhwres -m %s --id %s -r virtualio --rsubtype vnic \

--- a/io/net/virt-net/network_virtualization.py.data/README
+++ b/io/net/virt-net/network_virtualization.py.data/README
@@ -16,9 +16,12 @@ RHEL :
 Links :
 -> https://pypi.python.org/packages/source/p/pycrypto/pycrypto-2.6.1.tar.gz#md5=55a61a054aa66812daf5161a0d5d7eda
 
-Explanation of the input parameters:
-lpar ---> lpar on which the Network virtualized interface needs to be added/deleted
-server ---> name of the server which hosts the lpar
+Explanation of the input parameters for single vnic:
+hmc_pwd ---> HMC password
+hmc_username ---> HMC user name
+vios_ip ---> ip of vios for vios failover
+vios_username ---> vios user name
+vios_pwd---> vios password
 slot_num ---> slot number on which the Network virtualized interface will be added. Should be 3 - 2999 and unused currently. space separated for more
 vios_names ---> space separated name of the vios used to add/remove Network virtualized interface
 sriov_adapters ---> space separated location code (DRC) of the the adapters that is assigned to the hypervisor
@@ -31,9 +34,26 @@ auto_failover --> enable auto_failover flag, 1 to enable or 0 to disable, defaul
 device_ip ---> Ip to be configured for the added Network virtualized interface, space separated if multiple
 netmask ---> netmask value for the added Network virtualized interface, space separated if multiple
 peer_ip ---> Peer ip to which the added Network virtualized interface will ping to check for ping test
-count ---> The number of times the unbind and bind test has to be executed
+vnic_test_count ---> The number of times the failover test has to be executed
 num_of_dlpar --> number of times ddlpar remove and add operation to be executed
 mac_id ---> MAC ID to be set for the vnic interface. This is needed for us to have control over interface name via interface file or udev rules, space separated if multiple
 
-NOTE: The last device listed by "ip link show" will be used to configure and test the
-driver unbind/bind and failover functionalities 
+Explanation of the input parameters for multiple vnic:
+hmc_pwd ---> HMC password
+hmc_username ---> HMC user name
+slot_num ---> multiple slot number separated with space, on which the Network virtualized interface will be added. Should be 3 - 2999 and unused currently. space separated for more
+vios_names ---> space separated name of the vios used to add/remove Network virtualized interface
+sriov_adapters ---> space separated location code (DRC) of the the adapters that is assigned to the hypervisor.
+if want mutiple Network virtualized interface from same adapter, ex : "U78D5.ND1.CSS130E-P1-C4-C1 U78D5.ND1.CSS130E-P1-C4-C1"
+if want mutiple Network virtualized interface from different adapter, ex : "U78D5.ND1.CSS130E-P1-C4-C1 U78D5.ND2.CSS140C-P1-C5-C1"
+sriov_ports ---> space separated ports using which the Network virtualized interface will be added/removed
+priority: space seperated prirotiy value for backing devices should be range of 1-100 (1,100,50,.. 1 for active and 100, 50 for consecutive backing device). 1 represents highest priority, 100 represents lowest, 50 is default if param not specified
+auto_failover ---> enable auto_failover flag, 1 to enable or 0 to disable, defaults to 1
+bandwidth ---> The percentage of the ports bandwidth this Network virtualized interface is entitled to, space seprated for more
+device_ip ---> space separated ip address
+netmasks ---> space separated netmask
+peer_ip ---> space separated peer ip
+mac_id ---> MAC ID to be set for the vnic interface. This is needed for us to have control over interface name via interface file or udev rules, space separated mac id
+
+NOTE: all failover test will not execute when it will create multiple Network virtualized interface.
+and for now multiple Network virtualized interface with multiple backing device will not work.

--- a/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml
@@ -1,0 +1,17 @@
+ubuntu_url: 'http://ausgsa.ibm.com/projects/r/rsctdev/builds/muthu/rmuts006a/ppc64le'
+debs: ['src_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core_3.2.0.6-15111_ppc64el.deb', 'rsct.basic_3.2.0.6-15111_ppc64el.deb', 'devices.chrp.base.servicerm_2.5.0.1-15111_ppc64el.deb', 'dynamicrm_2.0.1-3_ppc64el.deb']
+hmc_pwd: ""
+hmc_username: ""
+slot_num: "6 7"
+vios_names: ""
+sriov_adapters: "U78D5.ND2.CSS140C-P1-C5-C1 U78D5.ND2.CSS140C-P1-C5-C1"
+sriov_ports: "0 1"
+priority: "1 100"
+auto_failover: True
+bandwidth: 2
+device_ip: "147.1.1.247 111.1.1.77"
+netmasks: "255.255.255.0 255.255.255.0"
+peer_ip: "147.1.1.246 111.1.1.88"
+vnic_test_count: 1
+num_of_dlpar: 1
+mac_id: "02:03:05:02:05:06 02:03:05:02:05:04"

--- a/io/net/virt-net/network_virtualization.py.data/single_vnic_single_backing.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/single_vnic_single_backing.yaml
@@ -1,0 +1,20 @@
+ubuntu_url: 'http://ausgsa.ibm.com/projects/r/rsctdev/builds/muthu/rmuts006a/ppc64le'
+debs: ['src_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core_3.2.0.6-15111_ppc64el.deb', 'rsct.basic_3.2.0.6-15111_ppc64el.deb', 'devices.chrp.base.servicerm_2.5.0.1-15111_ppc64el.deb', 'dynamicrm_2.0.1-3_ppc64el.deb']
+hmc_pwd: ""
+hmc_username: ""
+vios_ip: ""
+vios_username: ""
+vios_pwd: ""
+slot_num: "6"
+vios_names: ""
+sriov_adapters: "U78D5.ND2.CSS140C-P1-C5-C1 U78D5.ND2.CSS140C-P1-C5-C1"
+sriov_ports: "0 1"
+priority: "1 100"
+auto_failover: True
+bandwidth: 2
+device_ip: "147.1.1.247"
+netmasks: "255.255.255.0"
+peer_ip: "147.1.1.246"
+vnic_test_count: 1
+num_of_dlpar: 1
+mac_id: "02:03:05:02:05:06"


### PR DESCRIPTION
script will create mutiple vnic with different adapter id and different port.
because we can't create bond interfcae with same adapter vnic interface.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>