### PR TITLE
removing controlpath file before test started

### DIFF
--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -64,6 +64,11 @@ class NetworkTest(Test):
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
         self.ip_config = self.params.get("ip_config", default=True)
+        for root, dirct, files in os.walk("/root/.ssh"):
+            for file in files:
+                if file.startswith("avocado-master-root"):
+                    path = os.path.join(root, file)
+                    os.remove(path)
         local = LocalHost()
         self.networkinterface = NetworkInterface(self.iface, local)
         if self.ip_config:

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -65,6 +65,11 @@ class NetworkVirtualization(Test):
         self.lpar = self.get_partition_name("Partition Name")
         if not self.lpar:
             self.cancel("LPAR Name not got from lparstat command")
+        for root, dirct, files in os.walk("/root/.ssh"):
+            for file in files:
+                if file.startswith("avocado-master-root"):
+                    path = os.path.join(root, file)
+                    os.remove(path)
         self.session_hmc = Session(self.hmc_ip, user=self.hmc_username,
                                    password=self.hmc_pwd)
         if not self.session_hmc.connect():


### PR DESCRIPTION
removng controlpath if existing inside /root/.ssh before test.

Signed-off-by: bismurti bidhibrata pattajoshi <bbidhibr@in.ibm.com>