### PR TITLE
virt-net: handle more than one vnic backing device

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -669,8 +669,8 @@ class NetworkVirtualization(Test):
         """
         priority = None
         cmd = 'lshwres -r virtualio -m %s --rsubtype vnic --level lpar \
-               --filter lpar_names=%s -F slot_num,backing_devices' \
-               % (self.server, self.lpar)
+               --filter slots=%s,lpar_names=%s -F slot_num,backing_devices' \
+               % (self.server, self.slot_num[0], self.lpar)
         output = self.session_hmc.cmd(cmd)
         if output.exit_status != 0:
             self.log.debug(output.stderr)


### PR DESCRIPTION
Currently, the get_failover_priority only checks if the first vNIC device has
the slot number. There is the case where the lshwres command retrieves multiple
vNIC devices. The output is formatted where it creates an array of all the
vNIC devices and checks if the slot number matches each one.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>