### PR TITLE
enhancing the vfc-dlpar.py to work with vfc bootable disk

### DIFF
--- a/io/disk/vfc-tests/vfc_dlpar.py
+++ b/io/disk/vfc-tests/vfc_dlpar.py
@@ -52,6 +52,7 @@ class VirtualFC(Test):
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default=None)
         self.hmc_username = self.params.get("hmc_username", '*', default=None)
         self.count = self.params.get("count", default=1)
+        self.skip_drc = self.params.get("skip_drc_name", default=None)
         self.opp_sleep_time = 150
         self.lpar = self.get_partition_name("Partition Name")
         if not self.lpar:
@@ -83,7 +84,8 @@ class VirtualFC(Test):
             self.vfc_dic["wwpn"] = self.get_wwpn(self.vfc_dic["c_slot"])
             self.vfc_dic["drc"] = self.get_drc_name(self.vfc_dic["c_slot"])
             self.vfc_dic["paths"] = self.get_paths(self.vfc_dic["drc"])
-            self.dic_list.append(self.vfc_dic)
+            if self.vfc_dic["drc"] != self.skip_drc:
+                self.dic_list.append(self.vfc_dic)
         self.log.info("complete list : %s" % self.dic_list)
 
     @staticmethod

--- a/io/disk/vfc-tests/vfc_dlpar.py.data/README.txt
+++ b/io/disk/vfc-tests/vfc_dlpar.py.data/README.txt
@@ -7,4 +7,4 @@ hmc_ip :      HMC IP or host name (9.XX.XXX.XXX)
 hmc_username: username of the HMC
 hmc_pwd:      password of the HMC
 count:        Number of times the vfc interfaces has to remove and add back
-
+skip_drc_name: you can get drc_name from "lsslot -c slot" output. It will skip its corresponding vfc interface from dlpar operation.

--- a/io/disk/vfc-tests/vfc_dlpar.py.data/vfc_dlpar.yaml
+++ b/io/disk/vfc-tests/vfc_dlpar.py.data/vfc_dlpar.yaml
@@ -1,3 +1,4 @@
 hmc_pwd: ''
 hmc_username: ''
+skip_drc_name: 'U9080.HEX.134C1F8-V1-C201'
 count: 1


### PR DESCRIPTION
The script was failing when we have one of the vfc interfaces as bootable disk.
Hence added an option to skipp the bootable vfc interface and perform the dlpar
on rest of the vfc interfaces.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>