### PR TITLE
ndctl.py: namespace size align fixes

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -678,7 +678,8 @@ class NdctlTest(Test):
         ns_name = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
         self.plib.disable_namespace(namespace=ns_name)
-        self.write_read_infoblock(ns_name, align=self.get_size_alignval())
+        map_align = memory.get_supported_huge_pages_size()[0] * 1024
+        self.write_read_infoblock(ns_name, align=map_align)
         self.plib.enable_namespace(namespace=ns_name)
 
     @avocado.fail_on(pmem.PMemException)
@@ -695,7 +696,9 @@ class NdctlTest(Test):
         ns_name = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
         self.plib.disable_namespace(namespace=ns_name)
-        self.write_read_infoblock(ns_name, align=self.get_unsupported_alignval())
+        map_align = memory.get_supported_huge_pages_size()[0] * 1024
+        self.write_read_infoblock(
+            ns_name, align=self.get_unsupported_alignval(map_align))
         try:
             self.plib.enable_namespace(namespace=ns_name)
         except pmem.PMemException:
@@ -756,7 +759,7 @@ class NdctlTest(Test):
         self.plib.disable_namespace(namespace=ns_name)
         align = self.get_size_alignval()
         size = size - align
-        self.write_read_infoblock(ns_name, size=size, align=align)
+        self.write_read_infoblock(ns_name, size=size)
         self.plib.enable_namespace(namespace=ns_name)
 
     @avocado.fail_on(pmem.PMemException)

--- a/memory/pmem_dm.py
+++ b/memory/pmem_dm.py
@@ -33,16 +33,13 @@ class PmemDeviceMapper(Test):
     Ndctl user space tooling for Linux, which handles NVDIMM devices.
     """
 
-    @staticmethod
-    def get_size_alignval():
+    def get_size_alignval(self):
         """
         Return the size align restriction based on platform
         """
-        if 'Hash' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0'):
-            def_align = 16 * 1024 * 1024
-        else:
-            def_align = 2 * 1024 * 1024
-        return def_align
+        if not os.path.exists("/sys/bus/nd/devices/region0/align"):
+            self.cancel("Test cannot execute without the size alignment value")
+        return int(genio.read_one_line("/sys/bus/nd/devices/region0/align"), 16)
 
     def build_fio(self):
         """


### PR DESCRIPTION
1) Fix: Handle namespace size align value based on sysfs
Patch fixes the assumption of default namespace size alignment for Hash and Radix. So going forward a sysfs attribute is used to correspond to be namespace size alignment.

2) Fix size alignment usage for write-infoblock test
Currently write-infoblock test uses namespace size alignment as base value for kernel mapping alignment. Fix it by using base
hugepage value (same as ndctl base kernel mapping alignment) as kernel mapping align value.

Signed-off-by: Harish <harish@linux.ibm.com>