### PR TITLE
kselftest.py: Fixes and enhancements for SuSE

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -132,8 +132,9 @@ class kselftest(Test):
         Execute the kernel selftest
         """
         self.error = False
+        kself_args = self.params.get("kself_args", default='')
         build.make(self.sourcedir,
-                   extra_args='summary=1 %s run_tests' % self.comp)
+                   extra_args='%s %s run_tests' % (kself_args, self.comp))
         for line in open(os.path.join(self.logdir, 'debug.log')).readlines():
             if self.run_type == 'upstream':
                 self.find_match(r'not ok (.*) selftests:(.*)', line)

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -17,12 +17,11 @@ import os
 import platform
 import re
 import glob
-import shutil
 
 from avocado import Test
 from avocado.utils import build
 from avocado.utils import distro
-from avocado.utils import archive, process, git
+from avocado.utils import archive, git
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -116,22 +115,13 @@ class kselftest(Test):
             elif detected_distro.name in ['Ubuntu', 'debian']:
                 self.buldir = smg.get_source('linux', self.workdir)
             elif 'SuSE' in detected_distro.name:
-                smg._source_install('kernel-default')
-                smg.get_source('kernel-source', self.workdir)
-                packages = '/usr/src/packages/'
-                os.chdir(os.path.join(packages, 'SOURCES'))
-                process.system('./mkspec', ignore_status=True)
-                shutil.copy(os.path.join(packages, 'SOURCES/kernel'
-                                                   '-default.spec'),
-                            os.path.join(packages, 'SPECS/kernel'
-                                                   '-default.spec'))
-                self.buldir = smg.prepare_source(os.path.join(
-                    packages, 'SPECS/kernel'
-                              '-default.spec'), dest_path=self.teststmpdir)
-                for l_dir in glob.glob(os.path.join(self.buldir, 'linux*')):
-                    if os.path.isdir(l_dir) and 'Makefile' in os.listdir(l_dir):
-                        self.buldir = os.path.join(
-                            self.buldir, os.listdir(self.buldir)[0])
+                if not smg.check_installed("kernel-source") and not\
+                        smg.install("kernel-source"):
+                    self.cancel(
+                        "Failed to install kernel-source for this test.")
+                if not os.path.exists("/usr/src/linux"):
+                    self.cancel("kernel source missing after install")
+                self.buldir = "/usr/src/linux"
 
         self.sourcedir = os.path.join(self.buldir, self.testdir)
         if build.make(self.sourcedir):

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -135,7 +135,14 @@ class kselftest(Test):
         build.make(self.sourcedir,
                    extra_args='summary=1 %s run_tests' % self.comp)
         for line in open(os.path.join(self.logdir, 'debug.log')).readlines():
-            self.find_match(r'not ok (.*) selftests:(.*)', line)
+            if self.run_type == 'upstream':
+                self.find_match(r'not ok (.*) selftests:(.*)', line)
+            elif self.run_type == 'distro':
+                if distro.detect().name == 'SuSE' and\
+                        distro.detect().version == 12:
+                    self.find_match(r'selftests:(.*)\[FAIL\]', line)
+                else:
+                    self.find_match(r'not ok (.*) selftests:(.*)', line)
 
         if self.error:
             self.fail("Testcase failed during selftests")

--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -4,6 +4,7 @@ setup:
             comp: "vm"
         power:
             comp: "powerpc"
+            kself_args: "summary=1"
         mem_plug:
             comp: "memory-hotplug"
     run_type: !mux


### PR DESCRIPTION
1. Make kselftest run simple on SuSE
Patch uses kernel-source package to install the source and run the kselftest from that on SuSE

2. Fix: Parsing test result for older sles releses
The sles12 distro kernel still executes kselftest with results displayed with older version, handle that and parse the test
results appropriately

Signed-off-by: Harish <harish@linux.ibm.com>