### PR TITLE
Trinity test capture kernel tainting.

### DIFF
--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -94,7 +94,7 @@ class Trinity(Test):
         match = re.search(br'Call Trace:', dmesg, re.M | re.I)
         if match:
             self.log.info("some call traces seen please check")
-        match = re.search(br'tainting:', dmesg, re.M | re.I)
+        match = re.search(br'tainting', dmesg, re.M | re.I)
         if match:
             self.log.info("kernel become tainting please check")
 

--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -94,6 +94,9 @@ class Trinity(Test):
         match = re.search(br'Call Trace:', dmesg, re.M | re.I)
         if match:
             self.log.info("some call traces seen please check")
+        match = re.search(br'tainting:', dmesg, re.M | re.I)
+        if match:
+            self.log.info("kernel become tainting please check")
 
     def tearDown(self):
         """

--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -31,7 +31,7 @@ class GDB(Test):
         sm = SoftwareManager()
         dist = distro.detect()
         packages = ['gcc', 'dejagnu', 'flex', 'bison', 'texinfo']
-        if dist.name == 'Ubuntu':
+        if dist.name in ['Ubuntu','debian']:
             packages.extend(['g++', 'binutils-dev'])
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility

--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -31,7 +31,7 @@ class GDB(Test):
         sm = SoftwareManager()
         dist = distro.detect()
         packages = ['gcc', 'dejagnu', 'flex', 'bison', 'texinfo']
-        if dist.name in ['Ubuntu', 'debian']:
+        if dist.name == 'Ubuntu':
             packages.extend(['g++', 'binutils-dev'])
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility

--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -31,7 +31,7 @@ class GDB(Test):
         sm = SoftwareManager()
         dist = distro.detect()
         packages = ['gcc', 'dejagnu', 'flex', 'bison', 'texinfo']
-        if dist.name in ['Ubuntu','debian']:
+        if dist.name in ['Ubuntu', 'debian']:
             packages.extend(['g++', 'binutils-dev'])
         # FIXME: "redhat" as the distro name for RHEL is deprecated
         # on Avocado versions >= 50.0.  This is a temporary compatibility


### PR DESCRIPTION
Trinity test can tainting the kernel, add this error message capture.

Signed-off-by: yiwei <yiwei@uniontech.com>