### PR TITLE
Numa test case fix and enhancement

### DIFF
--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -20,8 +20,11 @@ import os
 import shutil
 
 from avocado import Test
+from avocado import skipIf
 from avocado.utils import process, build, memory, distro, genio
 from avocado.utils.software_manager import SoftwareManager
+
+SINGLE_NODE = len(memory.numa_nodes_with_memory()) < 2
 
 
 class NumaTest(Test):
@@ -46,10 +49,6 @@ class NumaTest(Test):
         self.hpage = self.params.get('h_page', default=False)
 
         nodes = memory.numa_nodes_with_memory()
-        if len(nodes) < 2:
-            self.cancel('Test requires two numa nodes to run.'
-                        'Node list with memory: %s' % nodes)
-
         pkgs = ['gcc', 'make']
         hp_check = 0
         if self.hpage:
@@ -86,6 +85,7 @@ class NumaTest(Test):
 
         build.make(self.teststmpdir)
 
+    @skipIf(SINGLE_NODE, "Test requires two numa nodes to run")
     def test_movepages(self):
         os.chdir(self.teststmpdir)
         self.log.info("Starting test...")
@@ -111,6 +111,7 @@ class NumaTest(Test):
         if ret != 0:
             self.fail('Please check the logs for failure')
 
+    @skipIf(SINGLE_NODE, "Test requires two numa nodes to run")
     def test_thp_compare(self):
         """
         Test PFN's before and after offlining

--- a/memory/numa_test.py.data/softoffline.c
+++ b/memory/numa_test.py.data/softoffline.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 	int page_size = getpagesize();
 	int mapflag = MAP_ANONYMOUS;
 	int protflag = PROT_READ|PROT_WRITE;
-	char *old_pfn, *new_pfn;
+	unsigned long *old_pfn, *new_pfn;
 
 	while ((c = getopt(argc, argv, "m:n:hH")) != -1) {
 		switch(c) {
@@ -67,8 +67,8 @@ int main(int argc, char *argv[])
 			break;
 		}
 	}
-	old_pfn = (char*) malloc(nr_pages * sizeof(char));
-	new_pfn = (char*) malloc(nr_pages * sizeof(char));
+	old_pfn = (unsigned long*) malloc(nr_pages * sizeof(unsigned long));
+	new_pfn = (unsigned long*) malloc(nr_pages * sizeof(unsigned long));
 
 	if (!(mapflag & (MAP_SHARED | MAP_PRIVATE)))
 		errmsg("Specify shared or private using -m flag\n");
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 		if (!old_pfn[i] || !new_pfn[i])
 			continue;
 		if (old_pfn[i] == new_pfn[i]){
-			printf("pfn matches, softoffline failed\n");
+			printf("pfn matches, softoffline failed at %d\n", i);
 			return -1;
 		}
 	}


### PR DESCRIPTION
1. Fix: Use unsigned long for storing PFNs
Sometimes the old PFNs match due to pfn values stored as char's, also the type does not match with the get_pfn utility function.
This patch solves those compilation warnings also.

2. Add numa node check for specific tests
Patch adds checks for specific tests that allows other test to run even on a single numa machine

Signed-off-by: Harish <harish@linux.ibm.com>