### PR TITLE
cpu/ebizzy.py : Add taskset and perf stat for ebizzy

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -68,6 +68,12 @@ class Ebizzy(Test):
     # Note: default we use always mmap()
     def test(self):
 
+        perfstat = self.params.get('perfstat', default='')
+        if perfstat:
+            perfstat = 'perf stat ' + perfstat
+        taskset = self.params.get('taskset', default='')
+        if taskset:
+            taskset = 'taskset -c ' + taskset
         args = self.params.get('args', default='')
         num_chunks = self.params.get('num_chunks', default=1000)
         chunk_size = self.params.get('chunk_size', default=512000)
@@ -77,8 +83,8 @@ class Ebizzy(Test):
                                                       seconds, num_threads)
         args = args + ' ' + args2
 
-        results = process.system_output('%s/ebizzy %s'
-                                        % (self.sourcedir, args)).decode("utf-8")
+        results = process.system_output('%s %s %s/ebizzy %s'
+                                        % (perfstat, taskset, self.sourcedir, args)).decode("utf-8")
         pattern = re.compile(r"(.*?) records/s")
         records = pattern.findall(results)[0]
         pattern = re.compile(r"real (.*?) s")

--- a/cpu/ebizzy.py.data/ebizzy.yaml
+++ b/cpu/ebizzy.py.data/ebizzy.yaml
@@ -1,4 +1,10 @@
 ebizy_url: 'http://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz'
+perf:
+    default:
+        perfstat: -a
+pin: !mux
+    default:
+        taskset: '0'
 duration: !mux
     default:
         seconds: 100


### PR DESCRIPTION
This patch adds capability to pin cpus using taskset and also record
perf statistics while running ebizzy.
This feature can be extended to other relevant wrappers in future. It
gives flexibility to the user to run perf monitors for specific runs
instead of a system wide monitoring.

Signed-off-by: Abhishek Goel <huntbag@linux.vnet.ibm.com>