### PR TITLE
netperf: use tag --build

### DIFF
--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -117,12 +117,12 @@ class Netperf(Test):
                                          recursive=True)
         if not output:
             self.cancel("unable to copy the netperf into peer machine")
-        cmd = "cd /tmp/%s;./configure ppc64le;make" % self.version
+        cmd = "cd /tmp/%s;./configure --build=powerpc64le;make" % self.version
         output = self.session.cmd(cmd)
         if not output.exit_status == 0:
             self.fail("test failed because command failed in peer machine")
         os.chdir(self.neperf)
-        process.system('./configure ppc64le', shell=True)
+        process.system('./configure --build=powerpc64le', shell=True)
         build.make(self.neperf)
         self.perf = os.path.join(self.neperf, 'src', 'netperf')
         self.expected_tp = self.params.get("EXPECTED_THROUGHPUT", default="90")


### PR DESCRIPTION
When building netperf on both the host and remote machines, a warning is
displayed "configure: WARNING: you should use --build, --host, --target".
To have the test pass cleanly, the flag --build is used when building netperf.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>