### PR TITLE
virt-net: parsing for system name fix

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -77,11 +77,12 @@ class NetworkVirtualization(Test):
             self.cancel("failed connecting to HMC")
         cmd = 'lssyscfg -r sys  -F name'
         output = self.session_hmc.cmd(cmd)
-        self.server = ''
-        for line in output.stdout_text.splitlines():
-            if line in self.lpar:
-                self.server = line
-                break
+        self.server = self.params.get("server", "*", default=None)
+        if not self.server:
+            for line in output.stdout_text.splitlines():
+                if line in self.lpar:
+                    self.server = line
+                    break
         if not self.server:
             self.cancel("Managed System not got")
         self.slot_num = self.params.get("slot_num", '*', default=None)

--- a/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/multiple_vnic_nobacking.yaml
@@ -2,6 +2,7 @@ ubuntu_url: 'http://ausgsa.ibm.com/projects/r/rsctdev/builds/muthu/rmuts006a/ppc
 debs: ['src_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core_3.2.0.6-15111_ppc64el.deb', 'rsct.basic_3.2.0.6-15111_ppc64el.deb', 'devices.chrp.base.servicerm_2.5.0.1-15111_ppc64el.deb', 'dynamicrm_2.0.1-3_ppc64el.deb']
 hmc_pwd: ""
 hmc_username: ""
+server:
 slot_num: "6 7"
 vios_names: ""
 sriov_adapters: "U78D5.ND2.CSS140C-P1-C5-C1 U78D5.ND2.CSS140C-P1-C5-C1"

--- a/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
@@ -2,6 +2,7 @@ ubuntu_url: 'http://ausgsa.ibm.com/projects/r/rsctdev/builds/muthu/rmuts006a/ppc
 debs: ['src_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core_3.2.0.6-15111_ppc64el.deb', 'rsct.basic_3.2.0.6-15111_ppc64el.deb', 'devices.chrp.base.servicerm_2.5.0.1-15111_ppc64el.deb', 'dynamicrm_2.0.1-3_ppc64el.deb']
 hmc_pwd:
 hmc_username:
+server:
 vios_ip: ""
 vios_username: ""
 vios_pwd: ""

--- a/io/net/virt-net/network_virtualization.py.data/single_vnic_single_backing.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/single_vnic_single_backing.yaml
@@ -2,6 +2,7 @@ ubuntu_url: 'http://ausgsa.ibm.com/projects/r/rsctdev/builds/muthu/rmuts006a/ppc
 debs: ['src_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core_3.2.0.6-15111_ppc64el.deb', 'rsct.basic_3.2.0.6-15111_ppc64el.deb', 'devices.chrp.base.servicerm_2.5.0.1-15111_ppc64el.deb', 'dynamicrm_2.0.1-3_ppc64el.deb']
 hmc_pwd: ""
 hmc_username: ""
+server:
 vios_ip: ""
 vios_username: ""
 vios_pwd: ""


### PR DESCRIPTION
Found a bug where I had a machine ltczep10 and another machine ltczep1. The test
would act on the latter machine because of the line `if line in self.lpar`.
This fix assumes the format of an LPAR
`<name_of_the_system>-lp<partiton_number>`.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>