### PR TITLE
bridge.py: check if config file exists before deleting

### DIFF
--- a/io/net/bridge.py
+++ b/io/net/bridge.py
@@ -98,4 +98,5 @@ class Bridging(Test):
         # TODO:need to get this functionality into avocado utils interfcae.py
         path = "/etc/sysconfig/network-scripts/ifcfg-%s" \
                % self.bridge_interface
-        os.remove(path)
+        if os.path.isfile(path):
+            os.remove(path)


### PR DESCRIPTION
Check if the config file exists before deleting it.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>