### PR TITLE
netperf: make UDP/TCP_STREAM option have dynamic socket buffer arg

### DIFF
--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -148,7 +148,18 @@ class Netperf(Test):
         cmd = "timeout %s %s -H %s" % (self.timeout, self.perf,
                                        self.peer_ip)
         if self.option != "":
-            cmd = "%s -t %s" % (cmd, self.option)
+            if "TCP_STREAM" in self.option:
+                socket_size = process.run("cat /proc/sys/net/ipv4/tcp_rmem",
+                                          shell=True, ignore_status=True)
+                cmd = "%s %s -m %s" % (cmd, self.option,
+                                       socket_size.stdout.decode("utf-8").split('\t')[1])
+            elif "UDP_STREAM" in self.option:
+                socket_size = process.run("cat /proc/sys/net/ipv4/udp_mem",
+                                          shell=True, ignore_status=True)
+                cmd = "%s %s -m %s" % (cmd, self.option,
+                                       socket_size.stdout.decode("utf-8").split('\t')[1])
+            else:
+                cmd = "%s -t %s" % (cmd, self.option)
         cmd = "%s -l %s -i %s,%s" % (cmd, self.duration, self.max,
                                      self.min)
         result = process.run(cmd, shell=True, ignore_status=True)

--- a/io/net/netperf_test.py.data/netperf_test_virt.yaml
+++ b/io/net/netperf_test.py.data/netperf_test_virt.yaml
@@ -16,9 +16,9 @@ option: !mux
     generic:
         option: ''
     tcp_stream:
-        option: 'TCP_STREAM -- -m 63000'
+        option: 'TCP_STREAM --'
     udp_stream:
-        option: 'UDP_STREAM -- -m 63000'
+        option: 'UDP_STREAM --'
     tcp_rr:
         option: 'TCP_RR'
     udp_rr:


### PR DESCRIPTION
Currently the netperf stream tests have a hard value of 63000 bytes given as an
argument when it should depend on each system. This fix reads the default socket
buffer size from /proc/ and sends it as an argument.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>