### PR TITLE
Add timestamp to dynamic debug command

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -153,7 +153,7 @@ class NetworkVirtualization(Test):
                'failover' in str(self.name.name):
                 self.cancel("this test is not needed")
         self.local = LocalHost()
-        cmd = "echo 'module ibmvnic +p; func send_subcrq -p' > /sys/kernel/debug/dynamic_debug/control"
+        cmd = "echo 'module ibmvnic +pt; func send_subcrq -pt' > /sys/kernel/debug/dynamic_debug/control"
         result = process.run(cmd, shell=True, ignore_status=True)
         if result.exit_status:
             self.fail("failed to enable debug mode")
@@ -838,7 +838,7 @@ class NetworkVirtualization(Test):
         self.session_hmc.quit()
         if 'vios' in str(self.name.name):
             self.session.quit()
-        cmd = "echo 'module ibmvnic -p; func send_subcrq -p' > /sys/kernel/debug/dynamic_debug/control"
+        cmd = "echo 'module ibmvnic -pt; func send_subcrq -pt' > /sys/kernel/debug/dynamic_debug/control"
         result = process.run(cmd, shell=True, ignore_status=True)
         if result.exit_status:
             self.log.debug("failed to disable debug mode")


### PR DESCRIPTION
added -t option to capture timestamps when enabling dynamic
debug for vnic module

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>