### PR TITLE
Adding nvme_fc module dependencies in config file

### DIFF
--- a/io/driver/module_unload_load.py.data/config
+++ b/io/driver/module_unload_load.py.data/config
@@ -4,3 +4,4 @@ xhci_hcd=xhci_pci
 qla2xxx=multipath
 lpfc=multipath
 ibmvfc=multipath
+nvme_fc=lpfc multipath


### PR DESCRIPTION
nvme_fc is driver module of nvmf which is a new module.
Hence added the dependent driver module of it in config file.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>