### PR TITLE
virt-net: dynamic debug should only be turned off when the vNIC adapt…

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -840,7 +840,8 @@ class NetworkVirtualization(Test):
         self.session_hmc.quit()
         if 'vios' in str(self.name.name):
             self.session.quit()
-        cmd = "echo 'module ibmvnic -pt; func send_subcrq -pt' > /sys/kernel/debug/dynamic_debug/control"
-        result = process.run(cmd, shell=True, ignore_status=True)
-        if result.exit_status:
-            self.log.debug("failed to disable debug mode")
+        if 'test_remove' in str(self.name.name):
+            cmd = "echo 'module ibmvnic -pt; func send_subcrq -pt' > /sys/kernel/debug/dynamic_debug/control"
+            result = process.run(cmd, shell=True, ignore_status=True)
+            if result.exit_status:
+                self.log.debug("failed to disable debug mode")


### PR DESCRIPTION
…er is removed

Currently, dynamic debug is turned off after every vNIC related test.
Dynamic debug should remain on when running other tests in the test
bucket. This patch turns off dynamic debug only when the vNIC adapter is
removed.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>