### PR TITLE
Add perf package to scheduler tests

### DIFF
--- a/cpu/cpuidle-latency.py
+++ b/cpu/cpuidle-latency.py
@@ -15,11 +15,12 @@
 # Based on code by Pratik Sampat<psampat@linux.ibm.com>
 
 import os
+import platform
 import shutil
 
 from avocado import Test
 from avocado.utils import process
-from avocado.utils import build, git
+from avocado.utils import build, distro, git
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -39,7 +40,18 @@ class Cpuidle_latency(Test):
         https://github.com/pratiksampat/cpuidle-latency-measurements.git
         '''
         sm = SoftwareManager()
-        for package in ['gcc', 'make']:
+        distro_name = distro.detect().name
+        deps = ['gcc', 'make']
+        if 'Ubuntu' in distro_name:
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
+        elif distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
+            deps.extend(['perf'])
+        else:
+            self.cancel("Install the package for perf supported \
+                         by %s" % distro_name)
+
+        for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
         url = 'https://github.com/pratiksampat/cpuidle-latency-measurements.git'

--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -21,9 +21,11 @@
 import os
 import json
 import re
+import platform
 
 from avocado import Test
 from avocado.utils import archive
+from avocado.utils import distro
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils.software_manager import SoftwareManager
@@ -47,7 +49,18 @@ class Ebizzy(Test):
         /ebizzy-0.3.tar.gz
         '''
         sm = SoftwareManager()
-        for package in ['gcc', 'make', 'patch']:
+        distro_name = distro.detect().name
+        deps = ['gcc', 'make', 'patch']
+        if 'Ubuntu' in distro_name:
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
+        elif distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
+            deps.extend(['perf'])
+        else:
+            self.cancel("Install the package for perf supported \
+                         by %s" % distro_name)
+
+        for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
         url = 'http://sourceforge.net/projects/ebizzy/files/ebizzy/' \

--- a/cpu/schbench.py
+++ b/cpu/schbench.py
@@ -13,10 +13,11 @@
 # Author: Abhishek Goel<huntbag@linux.vnet.ibm.com>
 
 import os
+import platform
 
 from avocado import Test
 from avocado.utils import process
-from avocado.utils import build, git
+from avocado.utils import build, distro, git
 from avocado.utils.software_manager import SoftwareManager
 
 
@@ -36,7 +37,18 @@ class Schbench(Test):
         https://git.kernel.org/pub/scm/linux/kernel/git/mason/schbench.git
         '''
         sm = SoftwareManager()
-        for package in ['gcc', 'make']:
+        distro_name = distro.detect().name
+        deps = ['gcc', 'make']
+        if 'Ubuntu' in distro_name:
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
+        elif distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
+            deps.extend(['perf'])
+        else:
+            self.cancel("Install the package for perf supported \
+                         by %s" % distro_name)
+
+        for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
         url = 'https://git.kernel.org/pub/scm/linux/kernel/git/mason/schbench.git'


### PR DESCRIPTION
Scheduler tests needs to install perf package to run, adding it

Signed-off-by: Harish <harish@linux.ibm.com>