### PR TITLE
virt-net: fix check_slot_availability to search slots

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -192,7 +192,7 @@ class NetworkVirtualization(Test):
         '''
         cmd = 'lshwres -r virtualio -m %s --rsubtype vnic --filter \
            "lpar_names=%s" -F slot_num' % (self.server, self.lpar)
-        for slot in self.session_hmc.cmd(cmd).stdout_text:
+        for slot in self.session_hmc.cmd(cmd).stdout_text.splitlines():
             if 'No results were found' in slot:
                 return True
             if slot_num == slot:


### PR DESCRIPTION
check_slot_availability was splitting the slot numbers with more than
one character. So instead of comparing slot 12, it would compare slot
1 then slot 2.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>