### PR TITLE
LPM: allow a peer LPAR to coordinate the LPM test 

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -47,6 +47,27 @@ class LPM(Test):
         set up required packages and gather necessary test inputs
         '''
         self.install_packages()
+        self.using_peer = False
+        if (self.params.get("lpar", default='')
+                and self.params.get("lpar_ip", default='')):
+            self.lpar = self.params.get("lpar", default='')
+            self.log.info("Migrating %s partition", self.lpar)
+            self.lpar_ip = self.params.get("lpar_ip", default='')
+            self.lpar_user = self.params.get("lpar_user", default='root')
+            self.lpar_pwd = self.params.get("lpar_pwd", "*",
+                                            default='********')
+            self.peer_session = Session(self.lpar_ip, user=self.lpar_user,
+                                        password=self.lpar_pwd)
+            if not self.peer_session.connect():
+                self.cancel("failed connecting to peer lpar")
+            self.using_peer = True
+        else:
+            self.lpar = self.get_partition_name("Partition Name")
+            if not self.lpar:
+                self.cancel("LPAR Name not got from lparstat command")
+            self.lpar_ip = self.get_mcp_component("MNName")
+            if not self.lpar_ip:
+                self.cancel("LPAR IP not got from lsrsrc command")
         self.rsct_service_start()
 
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
@@ -56,12 +77,6 @@ class LPM(Test):
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
         self.options = self.params.get("options", default='')
         self.net_device_type = self.params.get("net_device_type", default='')
-        self.lpar = self.get_partition_name("Partition Name")
-        if not self.lpar:
-            self.cancel("LPAR Name not got from lparstat command")
-        self.lpar_ip = self.get_mcp_component("MNName")
-        if not self.lpar_ip:
-            self.cancel("LPAR IP not got from lsrsrc command")
         self.session = Session(self.hmc_ip, user=self.hmc_user,
                                password=self.hmc_pwd)
         if not self.session.connect():
@@ -165,15 +180,28 @@ class LPM(Test):
         '''
         try:
             for svc in ["rsct", "rsct_rm"]:
-                process.run('startsrc -g %s' % svc, shell=True, sudo=True)
+                cmd = 'startsrc -g %s' % svc
+                if self.using_peer:
+                    self.peer_session.cmd(cmd)
+                else:
+                    process.run(cmd, shell=True, sudo=True)
         except CmdError as details:
             self.log.debug(str(details))
             self.fail("Starting service %s failed", svc)
 
-        output = process.system_output("lssrc -a", ignore_status=True,
-                                       shell=True, sudo=True).decode("utf-8")
-        if "inoperative" in output:
-            self.fail("Failed to start the rsct and rsct_rm services")
+        try:
+            cmd = "lssrc -a"
+            output = ""
+            if self.using_peer:
+                output = self.peer_session.cmd(cmd).stdout_text
+            else:
+                output = process.system_output(cmd, ignore_status=True,
+                                               shell=True, sudo=True).decode("utf-8")
+            if "inoperative" in output:
+                self.fail("Failed to start the rsct and rsct_rm services")
+        except CmdError as details:
+            self.log.debug(str(details))
+            self.fail("Command lssrc -a failed")
 
     def is_RMC_active(self, server):
         '''
@@ -191,13 +219,30 @@ class LPM(Test):
         '''
         Start RMC services which is needed for LPM migration
         '''
-        for svc in ["-z", "-A", "-p"]:
-            process.run('/opt/rsct/bin/rmcctrl %s' %
-                        svc, shell=True, sudo=True)
+        try:
+            for svc in ["-z", "-A", "-p"]:
+                cmd = '/opt/rsct/bin/rmcctrl %s' % svc
+                if self.using_peer:
+                    self.peer_session.cmd(cmd)
+                else:
+                    process.run(cmd, shell=True, sudo=True)
+        except CmdError as details:
+            self.log.debug(str(details))
+            self.fail("Starting service %s failed", svc)
+
         if not wait.wait_for(self.is_RMC_active(server), timeout=60):
-            process.run(
-                '/usr/sbin/rsct/install/bin/recfgct', shell=True, sudo=True)
-            process.run('/opt/rsct/bin/rmcctrl -p', shell=True, sudo=True)
+            try:
+                cmd1 = '/usr/sbin/rsct/install/bin/recfgct'
+                cmd2 = '/opt/rsct/bin/rmcctrl -p'
+                if self.using_peer:
+                    self.peer_session.cmd(cmd1)
+                    self.peer_session.cmd(cmd2)
+                else:
+                    process.run(cmd1, shell=True, sudo=True)
+                    process.run(cmd2, shell=True, sudo=True)
+            except CmdError as details:
+                self.log.debug(str(details))
+                self.fail("Command recfgct or rmcctrl has failed", svc)
             if not wait.wait_for(self.is_RMC_active(server), timeout=300):
                 self.fail("ERROR : RMC connection is down !!")
 
@@ -337,3 +382,5 @@ class LPM(Test):
 
     def tearDown(self):
         self.session.quit()
+        if self.using_peer:
+            self.peer_session.quit()

--- a/io/net/virt-net/lpm.py.data/lpm_5_iterations_from_peer.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_5_iterations_from_peer.yaml
@@ -1,0 +1,21 @@
+hmc_pwd:
+hmc_username:
+slot_num:
+vios_names:
+remote_server:
+remote_vios_names:
+sriov_adapters:
+sriov_ports:
+remote_sriov_adapters:
+remote_sriov_ports:
+bandwidth:
+lpar:
+lpar_ip:
+options: "--vniccfg 2"
+iteration: !mux
+    default: !mux
+        1:
+        2:
+        3:
+        4:
+        5:

--- a/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_from_peer.yaml
@@ -1,0 +1,5 @@
+hmc_pwd:
+hmc_username:
+remote_server:
+lpar_ip:
+lpar:


### PR DESCRIPTION
Currently the LPM tests are self-validating; the LPAR being migrated is also the LPAR running the test. This fix allows an external LPAR to test migration of another LPAR.

Signed-off-by: Matthew Merck <merckmatthew@gmail.com>
Reviewed-by: Cristobal Forno <cforno12@linux.ibm.com>