### PR TITLE
connectathon.py:Added libtirpc-devel package to compile and run tests

### DIFF
--- a/generic/connectathon.py
+++ b/generic/connectathon.py
@@ -54,11 +54,11 @@ class Connectathon(Test):
         packages = ['gcc', 'make']
 
         if detected_distro.name == "SuSE":
-            packages.extend(['git-core'])
-        elif detected_distro.name == "centos":
-            packages.extend(['libtirpc-devel'])
-        else:
-            packages.extend(['git'])
+            packages.extend(['git-core', 'libtirpc-devel'])
+        elif detected_distro.name in ["centos", "rhel", "fedora"]:
+            packages.extend(['git', 'libtirpc-devel'])
+        elif detected_distro.name == "Ubuntu":
+            packages.extend(['libtirpc-dev'])
 
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
Connectathon tests needs to install libtirpc-devel package to
compile and run, adding it

Signed-off-by: Shirisha Ganta <SHIRISHA.Ganta1@ibm.com>