### PR TITLE
README: add how to run tests with parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,20 @@ Once you have the avocado installed, you can run the tests like below::
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-18T15.32-0018adb/html/results.html
     TIME       : 62.67 s
 
+To run test that requires paramters, you'll need to populated the provided YAML
+files in the corresponding ``*.py.data`` directory. In each directory, there
+should be a README explaining what each parameter cooresponds to. Once you have
+the YAML file populated you can run the test like below::
+
+  # avocado run avocado-misc-tests/io/common/bootlist_test.py -m avocado-misc-tests/io/common/bootlist_test.py.data/bootlist_test_network.yaml
+  JOB ID     : bd3c103f1b2fff2d35b507f83a03d1ace4a008c5
+  JOB LOG    : /root/avocado-fvt-wrapper/results/job-2021-04-15T14.33-bd3c103/job.log
+   (1/3) avocado-misc-tests/io/common/bootlist_test.py:BootlisTest.test_normal_mode;run-8e25: PASS (0.99 s)
+   (2/3) avocado-misc-tests/io/common/bootlist_test.py:BootlisTest.test_service_mode;run-8e25: PASS (0.69 s)
+   (3/3) avocado-misc-tests/io/common/bootlist_test.py:BootlisTest.test_both_mode;run-8e25: PASS (1.36 s)
+  RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
+  JOB HTML   : /root/avocado-fvt-wrapper/results/job-2021-04-15T14.33-bd3c103/results.html
+  JOB TIME   : 13.43 s
 
 Tests are be organized per category basis, each category with its own
 directory.  Additionally, the tests are categorized by the use of the


### PR DESCRIPTION
Added section in root README where it describes how to run tests with YAML file
as an input file.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>