### PR TITLE
Fix build warning in MAP_SYNC test.

### DIFF
--- a/memory/ndctl.py.data/map_sync.c
+++ b/memory/ndctl.py.data/map_sync.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
cc     map_sync.c   -o map_sync
map_sync.c: In function ‘error’:
map_sync.c:31:35: warning: implicit declaration of function ‘strerror’; did you mean ‘error’? [-Wimplicit-function-declaration]
         printf("%s with %s\n", s, strerror(eno));
                                   ^~~~~~~~
                                   error
