### PR TITLE
Remove workers value from yaml file

### DIFF
--- a/generic/stress-ng.py.data/stress-ng.yaml
+++ b/generic/stress-ng.py.data/stress-ng.yaml
@@ -1,4 +1,4 @@
-workers: "null"
+workers:
 ttimeout: '5m'
 verify: True
 syslog: True


### PR DESCRIPTION
due to 'null' string the default value is not assigned properly,
due to which test command execution is not happening.
This patch fixes the issue and assigns the default value
correctly when workers value is null.

Signed-off-by: Shirisha Ganta <SHIRISHA.Ganta1@ibm.com>