### PR TITLE
Update hwinfo test case to allow it to run on RHEL variant

### DIFF
--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -33,11 +33,6 @@ class Hwinfo(Test):
             self.fail("hwinfo: %s command failed to execute" % cmd)
 
     def setUp(self):
-        # FIXME: "redhat" as the distro name for RHEL is deprecated
-        # on Avocado versions >= 50.0.  This is a temporary compatibility
-        # enabler for older runners, but should be removed soon
-        if distro.detect().name in ['rhel', 'redhat']:
-            self.cancel('Hwinfo not supported on RHEL')
         sm = SoftwareManager()
         if not sm.check_installed("hwinfo") and not sm.install("hwinfo"):
             self.cancel("Fail to install hwinfo required for this test.")


### PR DESCRIPTION
The test case fails on RHEL with following error
Hwinfo.test_list: CANCEL: Hwinfo not supported on RHEL (0.00 s)

Given that hwinfo tool is available with recent releases of Red Hat
Enterprise Linux, remove the check for rhel from the test case.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>