### PR TITLE
perf_rawevents test case functionality and code style fixes 

### DIFF
--- a/perf/perf_rawevents.py
+++ b/perf/perf_rawevents.py
@@ -67,7 +67,7 @@ class PerfRawevents(Test):
             self.copy_files(filename)
 
         os.chdir(self.teststmpdir)
-        # Clear the dmesg, by that we can capture the delta at the end of the test.
+        # Clear the dmesg to capture the delta at the end of the test.
         process.run("dmesg -c")
 
     def run_event(self, filename, eventname):
@@ -86,7 +86,7 @@ class PerfRawevents(Test):
         if self.fail_cmd:
             for cmd in range(len(self.fail_cmd)):
                 self.log.info("Failed command: %s", self.fail_cmd[cmd])
-            self.fail("perf_raw_events: some of the events failed, refer to log")
+            self.fail("perf_raw_events: refer log file for failed events")
 
     def test(self):
         cpu_family = cpu.get_family()

--- a/perf/perf_rawevents.py
+++ b/perf/perf_rawevents.py
@@ -18,13 +18,8 @@ import os
 import platform
 import shutil
 from avocado import Test
-from avocado import skipUnless
 from avocado.utils import cpu, distro, process, genio
 from avocado.utils.software_manager import SoftwareManager
-
-CPU_FAMILY = cpu.get_family()
-IS_POWER9 = 'power9' in CPU_FAMILY
-IS_POWER8 = 'power8' in CPU_FAMILY
 
 
 class PerfRawevents(Test):
@@ -93,20 +88,18 @@ class PerfRawevents(Test):
                 self.log.info("Failed command: %s", self.fail_cmd[cmd])
             self.fail("perf_raw_events: some of the events failed, refer to log")
 
-    @skipUnless(IS_POWER8, 'Supported only on Power8')
-    def test_raw_events_power8(self):
-        self.run_event('raw_codes_p8', 'raw')
-        self.error_check()
-
-    @skipUnless(IS_POWER8, 'Supported only on Power8')
-    def test_name_events_power8(self):
-        self.run_event('name_events_p8', 'name')
-        self.error_check()
-
-    @skipUnless(IS_POWER9, 'Supported only on Power9')
-    def test_raw_events_power9(self):
-        self.run_event('raw_codes_p9', 'raw')
-        self.error_check()
+    def test(self):
+        cpu_family = cpu.get_family()
+        if cpu_family == 'power8':
+            self.run_event('raw_codes_p8', 'raw')
+            self.error_check()
+            self.run_event('name_events_p8', 'name')
+            self.error_check()
+        elif cpu_family == 'power9':
+            self.run_event('raw_codes_p9', 'raw')
+            self.error_check()
+        else:
+            self.cancel('This test is not supported on %s' % cpu_family)
 
     def tearDown(self):
         # Collect the dmesg


### PR DESCRIPTION
perf_rawevent test iterates over all cpu families irrespective of where
the test is being run. For example running this test on IBM POWER9 will also
invoke (and skip) test scenarios meant for IBM POWER8 only family.

(1/3) perf/perf_rawevents.py:PerfRawevents.test_raw_events_power8: SKIP: Supported only on Power8
(2/3) perf/perf_rawevents.py:PerfRawevents.test_name_events_power8: SKIP: Supported only on Power8
(3/3) perf/perf_rawevents.py:PerfRawevents.test_raw_events_power9: PASS

Restructure the code to detect the cpu family and accordingly run the corresponding test scenario.

Second patch fixes code style warnings

Signed-off-by: Sachin Sant sachinp@linux.vnet.ibm.com