### PR TITLE
Add POWER10 support to perf_genericevents test

### DIFF
--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -38,6 +38,8 @@ class test_generic_events(Test):
             self.generic_events = dict(parser.items('POWER8'))
         elif 'POWER9' in cpu_info:
             self.generic_events = dict(parser.items('POWER9'))
+        elif 'POWER10' in cpu_info:
+            self.generic_events = dict(parser.items('POWER10'))
 
     def test(self):
         nfail = 0

--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -52,3 +52,26 @@ dTLB-load-misses = 0x300fc
 iTLB-load-misses = 0x400fc
 mem-loads = 0x34340401e0
 mem-stores = 0x343c0401e0
+
+[POWER10]
+cpu-cycles = 0x600f4
+instructions = 0x500fa
+branch-instructions = 0x4d05e
+branch-misses = 0x400f6
+cache-references = 0x100fc
+cache-misses = 0x3e054
+L1-dcache-load-misses = 0x3e054
+L1-dcache-loads = 0x100fc
+L1-dcache-prefetches = 0x1002c
+L1-dcache-store-misses = 0x300f0
+L1-icache-load-misses = 0x200fc
+L1-icache-loads = 0x4080
+L1-icache-prefetches = 0x40a0
+LLC-load-misses = 0x300fe
+LLC-loads = 0x1340000001c040
+branch-load-misses = 0x400f6
+branch-loads = 0x4d05e
+dTLB-load-misses = 0x300fc
+iTLB-load-misses = 0x400fc
+mem-loads = 0x34340401e0
+mem-stores = 0x343c0401e0


### PR DESCRIPTION
perf_genericevents test fails on a POWER10 system with
ERROR: 'test_generic_events' object has no attribute 'generic_events' (0.04 s)

The testcase lacks support for POWER10.
This patch adds that support.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>