### PR TITLE
xfstests - Remove libbtrfs-dev package from dependency list

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -173,7 +173,7 @@ class Xfstests(Test):
             packages.extend(
                 ['xfslibs-dev', 'uuid-dev', 'libuuid1',
                  'libattr1-dev', 'libacl1-dev', 'libgdbm-dev',
-                 'uuid-runtime', 'libaio-dev', 'fio', 'dbench', 'libbtrfs-dev'])
+                 'uuid-runtime', 'libaio-dev', 'fio', 'dbench'])
             if self.detected_distro.version in ['14']:
                 packages.extend(['libtool'])
             elif self.detected_distro.version in ['18', '20']:


### PR DESCRIPTION
Xfs tests were cancelled as libbtrfs-dev package not available in ubuntu 18.04.

Solution:
Checked in xfs git repository and observed that libbtrfs-dev package is no longer required(https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/tree/README) for distro ubuntu.
Also verified building package without libbtrfs-dev. Hence removing the libbtrfs-dev from dependency list

Signed-off-by: Spoorthy<spoorts2@in.ibm.com>