### PR TITLE
perf_basic.py: linux-tools package version is not selected properly for ubuntu distro

### DIFF
--- a/perf/perf_basic.py
+++ b/perf/perf_basic.py
@@ -54,7 +54,7 @@ class PerfBasic(Test):
         smg = SoftwareManager()
         dist = distro.detect()
         if dist.name in ['Ubuntu']:
-            linux_tools = "linux-tools-" + os.uname()[2][3]
+            linux_tools = "linux-tools-" + os.uname()[2]
             pkgs = [linux_tools]
             if dist.name in ['Ubuntu']:
                 pkgs.extend(['linux-tools-common'])


### PR DESCRIPTION
Problem:
perf basics tests were failing as proper linux-tools package version was not selected under ubuntu distro

Fix:
os.uname command to get kernel release is fixed in order to get proper linux-tools package version

Signed-off-by:Spoorthy<spoorts2@in.ibm.com>