### PR TITLE
This patch adds a new test for Processor Version Register(pvr)

### DIFF
--- a/cpu/pvr.py
+++ b/cpu/pvr.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+#
+# Copyright: 2017 IBM
+# Author:  Pooja B Surya <pooja@linux.vnet.ibm.com>
+# Update: Sachin Sant <sachinp@linux.vnet.ibm.com>
+
+import os
+import re
+
+import configparser
+from avocado import Test
+from avocado.utils import process
+from avocado.utils import genio
+from avocado.utils.software_manager import SoftwareManager
+from avocado.utils import distro
+
+
+class pvr(Test):
+
+    '''
+    Processor version register(pvr) test case
+
+    :avocado: tags=cpu,power
+    '''
+
+    def setUp(self):
+        if "ppc" not in os.uname()[4]:
+            self.cancel("supported only on Power platform")
+        smm = SoftwareManager()
+        detected_distro = distro.detect()
+        parser = configparser.ConfigParser()
+        parser.read(self.get_data("pvr.cfg"))
+        if detected_distro.name == "Ubuntu":
+            pkg = 'device-tree-compiler'
+        else:
+            pkg = 'dtc'
+        if not smm.check_installed(pkg) and not smm.install(pkg):
+            self.cancel("%s package is needed for the test to be run" % pkg)
+
+        val = genio.read_file("/proc/cpuinfo")
+        if 'pSeries|PowerNV' and 'POWER8' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p8')
+        elif 'pSeries' and '2.2' and 'POWER9' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p9LPAR_2.2')
+        elif 'pSeries' and '2.3' and 'POWER9' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p9LPAR_2.3')
+        elif 'PowerNV' and '2.1' and 'POWER9' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p9NV_2.1')
+        elif 'PowerNV' and '2.2' and 'POWER9' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p9NV_2.2')
+        elif 'PowerNV' and '2.3' and 'POWER9' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p9NV_2.3')
+        elif 'pSeries' and '1.0' and 'POWER10' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p10_1')
+        elif 'pSeries' and '2.0' and 'POWER10' in val:
+            self.pvr_value = parser.get('PVR_Values', 'pvr_value_p10_2')
+        else:
+            self.fail("Unsupported processor family")
+
+    def test(self):
+        self.log.info("====== Verifying CPU PVR entries =====")
+        self.log.info(self.pvr_value)
+        pvr_cpu = genio.read_file("/proc/cpuinfo")
+        res = re.sub(' ', '', pvr_cpu)
+        match = re.search(self.pvr_value, res)
+        self.log.info("self.pvr_value, res = %s" % res)
+        if match:
+            self.log.info("PVR from /proc/cpuinfo for the system is correct")
+        else:
+            self.fail("PVR from /proc/cpuinfo for the system is not correct")
+        pvr_dtc = process.run("dtc -I fs /proc/device-tree -O dts |grep %s | "
+                              "head -1" % self.pvr_value, shell=True,
+                              ignore_status=True)
+        if not pvr_dtc.exit_status:
+            self.log.info("PVR from device tree for the system is correct")
+        else:
+            self.fail("PVR from device tree for the system is not correct")

--- a/cpu/pvr.py.data/pvr.cfg
+++ b/cpu/pvr.py.data/pvr.cfg
@@ -1,0 +1,9 @@
+[PVR_Values]
+pvr_value_p8 = 4b0201
+pvr_value_p9NV_2.1 = 4e1201
+pvr_value_p9NV_2.2 = 4e1202
+pvr_value_p9NV_2.3 = 4e1203
+pvr_value_p9LPAR_2.2 = 4e0202
+pvr_value_p9LPAR_2.3 = 4e0203
+pvr_value_p10_1 = 800100
+pvr_value_p10_2 = 800200


### PR DESCRIPTION
This patch adds a new test for Processor Version Register(pvr)

The test supported on IBM POWER architecutre checks pvr value for various
IBM POWER processor families and verifies it.

This work is based on code originally written by Pooja.

Signed-off-by: Pooja B Surya <pooja@linux.vnet.ibm.com>
Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>