### PR TITLE
Audit test case fixes

### DIFF
--- a/security/audit-tests.py
+++ b/security/audit-tests.py
@@ -48,11 +48,12 @@ class Audit(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
 
-        url = "https://github.com/linux-audit/audit-testsuite/archive/master.zip"
+        url = ("https://github.com/linux-audit/audit-testsuite/archive/"
+               "refs/heads/main.zip")
 
         tarball = self.fetch_asset(url, expire='7d')
         archive.extract(tarball, self.workdir)
-        self.sourcedir = os.path.join(self.workdir, 'audit-testsuite-master')
+        self.sourcedir = os.path.join(self.workdir, 'audit-testsuite-main')
         os.chdir(self.sourcedir)
         if build.make(self.sourcedir) > 0:
             self.cancel("Building audit test suite failed")

--- a/security/audit-tests.py
+++ b/security/audit-tests.py
@@ -67,4 +67,4 @@ class Audit(Test):
         for line in output.stdout_text.splitlines():
             if 'Result: FAIL' in line:
                 self.log.info(line)
-                self.fail("Some of the test(s) failed, please refer to the log")
+                self.fail("Some of the test(s) failed, refer to the log file")


### PR DESCRIPTION
Audit test fails to execute with following error:
Audit.test: ERROR: Failed to fetch main.zip (HTTP Error 404: Not Found).
    
url to download source code of audit-tests no longer works.
Use the correct url for download.

Also fix pycodestyle warning for > 79 characters.
    security/audit-tests.py:70:80: E501 line too long (80 > 79 characters)    

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>