### PR TITLE
ndctl.yaml: Fix default yaml input for few options

### DIFF
--- a/memory/ndctl.py.data/ndctl.yaml
+++ b/memory/ndctl.py.data/ndctl.yaml
@@ -1,10 +1,10 @@
 region: 'region0'
 size: "null"
-map: "null"
+map:
 git_branch: 'pending'
 preserve_change: True
 mnt_point: '/mnt/pmem'
-fio_job: "null"
+fio_job:
 version: !mux
     upstream:
         package : 'upstream'

--- a/memory/pmem_dm.py.data/pmem_dm.yaml
+++ b/memory/pmem_dm.py.data/pmem_dm.yaml
@@ -1,8 +1,8 @@
-preserve_dm: "null"
+preserve_dm: False
 mnt_point: '/mnt/pmem'
-fio_job: "null"
-fio_url: "null"
-package: "null"
+fio_job:
+fio_url:
+package:
 split: !mux
     ns_split:
         split_ns : True


### PR DESCRIPTION
Patch fixes default yaml input for few options so that the test runs with valid yaml value

Signed-off-by: Harish <harish@linux.ibm.com>