### PR TITLE
[net] virt-net: logport assigned out of scope

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -760,6 +760,7 @@ class NetworkVirtualization(Test):
         Get the logical port id of the
         backing device
         '''
+        logport = None
         for backing_dev in self.backing_dev_list().splitlines():
             if backing_dev.startswith('%s,' % slot):
                 backing_dev = backing_dev.strip('%s,"' % slot)
@@ -768,6 +769,9 @@ class NetworkVirtualization(Test):
                     if '0' in entry[2] and 'Operational' in entry[3]:
                         logport = entry[1]
                         break
+        if not logport:
+            self.log.info("Logport: %s" % logport)
+            self.cancel("Could not get logical port id of backing device")
         return logport
 
     def get_active_device_logport(self, slot):
@@ -775,6 +779,7 @@ class NetworkVirtualization(Test):
         Get the logical port id of the Network
         virtualized device
         '''
+        logport = None
         for backing_dev in self.backing_dev_list().splitlines():
             if backing_dev.startswith('%s,' % slot):
                 backing_dev = backing_dev.strip('%s,"' % slot)
@@ -783,6 +788,8 @@ class NetworkVirtualization(Test):
                     if '1' in entry[2]:
                         logport = entry[1]
                         break
+        if not logport:
+            self.cancel("Could not get logical port id of active backing device")
         return logport
 
     def is_backing_device_active(self, slot):


### PR DESCRIPTION
Test should cancel if it cannot find a logical port of a backing device. Often
the test fails with a message like "logport was assigned before declaration".
This gives it a more descriptive message.

Signed-off-by: Cristobal Forno <cforno12@linux.ibm.com>