### PR TITLE
perf_genericevents - fix incorrect mem-loads/mem-stores values

### DIFF
--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -73,5 +73,5 @@ branch-load-misses = 0x400f6
 branch-loads = 0x4d05e
 dTLB-load-misses = 0x300fc
 iTLB-load-misses = 0x400fc
-mem-loads = 0x34340401e0
-mem-stores = 0x343c0401e0
+mem-loads = 0x35340401e0
+mem-stores = 0x353c0401e0


### PR DESCRIPTION
perf_genericevents test fails on a POWER10 machine running upstream kernel
due to mistmatch in values for mem-loads/mem-stores

  FAIL : Expected value is 0x34340401e0 but got0x35340401e0
  FILE in /sys/bus/event_source/devices/cpu/events is mem-loads

Fix the raw code values for mem-loads/mem-stores.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>