### PR TITLE
Revert "ndctl.py: Add dmesg check for each test"

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -29,7 +29,6 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils import distro
-from avocado.utils import dmesg
 from avocado.utils import build
 from avocado.utils import genio
 from avocado.utils import memory
@@ -38,7 +37,6 @@ from avocado.utils import pmem
 from avocado.utils.software_manager import SoftwareManager
 
 
-@dmesg.fail_on_dmesg(level=5)
 class NdctlTest(Test):
 
     """
@@ -195,7 +193,6 @@ class NdctlTest(Test):
         self.plib = pmem.PMem(self.ndctl, self.daxctl)
         if not self.plib.check_buses():
             self.cancel("Test needs atleast one region")
-        dmesg.clear_dmesg()
 
     @avocado.fail_on(pmem.PMemException)
     def test_bus_ids(self):


### PR DESCRIPTION
This reverts commit adc42ae6a0a7e2ee7a7ba103214c8fb67febec3b.

Some of the tests like initializing the namespace with unsupported
alignment will result in dmesg logs. We should either split them into
different Test class or support indicating dmesg fail_on_error
per test. Until then revert the change.

Signed-off-by: Aneesh Kumar K.V <aneesh.kumar@linux.ibm.com>