### PR TITLE
Add timeout support to tcpdump

### DIFF
--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -68,6 +68,7 @@ class TcpdumpTest(Test):
         self.peer_user = self.params.get("peer_user", default="root")
         self.peer_password = self.params.get("peer_password", '*',
                                              default="None")
+        self.timeout = self.params.get("TIMEOUT", default="600")
         self.mtu = self.params.get("mtu", default=1500)
         self.mtu_timeout = self.params.get("mtu_timeout", default=30)
         self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
@@ -117,7 +118,7 @@ class TcpdumpTest(Test):
         else:
             obj = process.SubProcess(cmd, verbose=False, shell=True)
             obj.start()
-        cmd = "tcpdump -i %s -n -c %s" % (self.iface, self.count)
+        cmd = "timeout %s tcpdump -i %s -n -c %s" % (self.timeout, self.iface, self.count)
         if self.option in ('host', 'src'):
             cmd = "%s %s %s" % (cmd, self.option, self.host_ip)
         elif self.option == "dst":

--- a/io/net/tcpdump.py.data/tcpdump-virt.yaml
+++ b/io/net/tcpdump.py.data/tcpdump-virt.yaml
@@ -5,6 +5,7 @@ peer_user:
 peer_password:
 host_ip:
 netmask:
+TIMEOUT:
 count: 100
 # interface packet drop accepted in percentage (eg 10 for 10%)
 drop_accepted: 10

--- a/io/net/tcpdump.py.data/tcpdump.yaml
+++ b/io/net/tcpdump.py.data/tcpdump.yaml
@@ -5,6 +5,7 @@ peer_user:
 peer_password:
 host_ip:
 netmask:
+TIMEOUT:
 count: 100
 # interface packet drop accepted in percentage (eg 10 for 10%)
 drop_accepted: 10

--- a/io/net/tcpdump.py.data/tcpdump_extended.yaml
+++ b/io/net/tcpdump.py.data/tcpdump_extended.yaml
@@ -5,6 +5,7 @@ peer_user:
 peer_password:
 host_ip:
 netmask:
+TIMEOUT:
 count: 100
 # interface packet drop accepted in percentage (eg 10 for 10%)
 drop_accepted: 10

--- a/io/net/tcpdump.py.data/tcpdump_extended_virt.yaml
+++ b/io/net/tcpdump.py.data/tcpdump_extended_virt.yaml
@@ -5,6 +5,7 @@ peer_user:
 peer_password:
 host_ip:
 netmask:
+TIMEOUT:
 count: 100
 # interface packet drop accepted in percentage (eg 10 for 10%)
 drop_accepted: 10


### PR DESCRIPTION
This commit makes it possible to set a timeout for tcpdump, and
adds a timeout to all of the default config files.

Signed-off-by: Jacob Root <otis@otisroot.com>
[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/6811068/job.log)
