### PR TITLE
libaio package name, required for fiotest, has changed in Sles

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -83,6 +83,8 @@ class FioTest(Test):
             pkg_list = ['libaio-dev']
             if fstype == 'btrfs':
                 pkg_list.append('btrfs-progs')
+        elif distro.detect().name is 'SuSE':
+            pkg_list = ['libaio1', 'libaio-devel']
         else:
             pkg_list = ['libaio', 'libaio-devel']
             if self.disk_type == 'nvdimm':


### PR DESCRIPTION
libaio is pre-required package to run the fio tool.
the name of this package has changed from libaio to libaio1
So modified the script to handle the same

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>