### PR TITLE
bug fix for find_device_id

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -726,7 +726,7 @@ class NetworkVirtualization(Test):
         """
         device = self.find_device(mac)
         device_id = process.system_output("ls -l /sys/class/net/ | \
-                                           grep %s | cut -d '/' -f \
+                                           grep -w %s | cut -d '/' -f \
                                            5" % device,
                                           shell=True).decode("utf-8").strip()
         return device_id


### PR DESCRIPTION
grep fails when there are interfaces like net1, vnet1
using -w option to grep for the whole word

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>