### PR TITLE
ras.py: Fix for rtas_event_code tool

### DIFF
--- a/ras/ras.py
+++ b/ras/ras.py
@@ -253,6 +253,6 @@ class RASTools(Test):
             'rtas')
         cmd_result = process.run(
             cmd, ignore_status=True, sudo=True, shell=True)
-        if cmd_result.exit_status != 17:
+        if cmd_result.exit_status not in [17, 13]:
             self.fail("rtas_event_decode tool: %s command failed in "
                       "verification" % cmd)


### PR DESCRIPTION
In Rhel9 rtas_event_code tool is failing so
changed the condition according to that

Signed-off-by: Shirisha Ganta <SHIRISHA.Ganta1@ibm.com>