### PR TITLE
Fix ERROR:Failed to fetch stress-1.0.4.tar.gz in memhotplug

### DIFF
--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -102,7 +102,7 @@ class MemStress(Test):
         smm = SoftwareManager()
         if not smm.check_installed('stress') and not smm.install('stress'):
             tarball = self.fetch_asset(
-                'https://fossies.org/linux/privat/stress-1.0.4.tar.gz')
+                'https://fossies.org/linux/privat/old/stress-1.0.4.tar.gz')
             archive.extract(tarball, self.teststmpdir)
             self.sourcedir = os.path.join(
                 self.teststmpdir, os.path.basename(tarball.split('.tar.')[0]))


### PR DESCRIPTION
This patch fixes ERROR - "Failed to fetch stress-1.0.4.tar.gz" by updating the URL to fetch stress-1.0.4.tar.gz

Signed-off-by: Geetika <geetika@linux.ibm.com>