### PR TITLE
bonnie.py: Multiple fixes to bonnie test code

### DIFF
--- a/io/disk/bonnie.py.data/bonnie.yaml
+++ b/io/disk/bonnie.py.data/bonnie.yaml
@@ -8,6 +8,8 @@
 
 # Valid options in avocado test are below:
 disk:
+raid_name: md127
+dir: /mnt
 uid-to-use: root
 number-to-stat: 10:100:10:1000
 data_size_to_pass: 0


### PR DESCRIPTION
Unstable test causing failures in automation and disrupting other tests in CI

1. Fixed to work for all the mux variants i.e device types
2. Fixed unclean test end after each test combination
3. Input mount point to run test on test disk instead of local dir
4. Get proper logical device names lv, md etc to match to user inputs
5. Clear the disk metata data before test start, causing raid to fail

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>