### PR TITLE
Enhancing the recovery check for pci_hotplug.py

### DIFF
--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -21,11 +21,14 @@ This test verifies that for supported slots.
 """
 
 import os
+import time
 import platform
 from avocado import Test
-from avocado.utils import wait
+from avocado.utils import wait, multipath
 from avocado.utils import linux_modules, genio, pci
 from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.network.interfaces import NetworkInterface
+from avocado.utils.network.hosts import LocalHost
 
 
 class PCIHotPlugTest(Test):
@@ -34,6 +37,8 @@ class PCIHotPlugTest(Test):
     PCI Hotplug can remove and add pci devices when the system is active.
     This test verifies that for supported slots.
     :param device: Name of the pci device
+    :param peer_ip: peer network adapter IP
+    :param count: Number of times the hotplug needs to perform
     """
 
     def setUp(self):
@@ -53,6 +58,7 @@ class PCIHotPlugTest(Test):
                 linux_modules.load_module("pnv_php")
         self.dic = {}
         self.device = self.params.get('pci_devices', default="")
+        self.peer_ip = self.params.get('peer_ip', default="")
         self.count = int(self.params.get('count', default='1'))
         if not self.device:
             self.cancel("PCI_address not given")
@@ -60,7 +66,7 @@ class PCIHotPlugTest(Test):
         smm = SoftwareManager()
         if not smm.check_installed("pciutils") and not smm.install("pciutils"):
             self.cancel("pciutils package is need to test")
-        self.end_devices = {}
+
         for pci_addr in self.device:
             if not os.path.isdir('/sys/bus/pci/devices/%s' % pci_addr):
                 self.cancel("%s not present in device path" % pci_addr)
@@ -68,14 +74,10 @@ class PCIHotPlugTest(Test):
             if not slot:
                 self.cancel("slot number not available for: %s" % pci_addr)
             self.dic[pci_addr] = slot
-            self.end_devices[pci_addr] = len(
-                pci.get_disks_in_pci_address(pci_addr))
-            self.end_devices[pci_addr] += len(
-                pci.get_nics_in_pci_address(pci_addr))
 
     def test(self):
         """
-        Creates namespace on the device.
+        Removes and adds back a PCI adapter based on pci_adress.
         """
         err_pci = []
         for pci_addr in self.device:
@@ -84,10 +86,12 @@ class PCIHotPlugTest(Test):
                     err_pci.append(pci_addr)
                 else:
                     self.log.info("%s removed successfully", pci_addr)
+                time.sleep(10)
                 if not self.hotplug_add(self.dic[pci_addr], pci_addr):
                     err_pci.append(pci_addr)
                 else:
                     self.log.info("%s added back successfully", pci_addr)
+                time.sleep(10)
         if err_pci:
             self.fail("following devices failed: %s" % ", ".join(err_pci))
 
@@ -110,7 +114,7 @@ class PCIHotPlugTest(Test):
 
     def hotplug_add(self, slot, pci_addr):
         """
-        Hot plug add operation
+        Hot plug add operation and recovery check
         """
         genio.write_file("/sys/bus/pci/slots/%s/power" % slot, "1")
 
@@ -124,20 +128,56 @@ class PCIHotPlugTest(Test):
 
         def is_recovered():
             """
-            Compares current endpoint devices in pci address with
-            `pre` value, and returns True if equals pre.
-            False otherwise.
+            Checks if the block device adapter is recovers all its disks/paths
+            properly after hotplug of adapter.
+            Returns True if all disks/paths back online after adapter added
+            Back, else False.
             """
-            post = len(pci.get_disks_in_pci_address(pci_addr))
-            post += len(pci.get_nics_in_pci_address(pci_addr))
-            self.log.debug("Pre: %d,  Post: %d",
-                           self.end_devices[pci_addr], post)
-            if post == self.end_devices[pci_addr]:
+            def is_path_online():
+                path_stat = list(multipath.get_path_status(curr_path))
+                if path_stat[0] != 'active' or path_stat[2] != 'ready':
+                    return False
                 return True
+
+            curr_path = ''
+            err_disks = []
+            if pci.get_pci_class_name(pci_addr) == 'fc_host':
+                disks = pci.get_disks_in_pci_address(pci_addr)
+                for disk in disks:
+                    curr_path = disk.split("/")[-1]
+                    self.log.info("curr_path=%s" % curr_path)
+                    if not wait.wait_for(is_path_online, timeout=10):
+                        self.log.info("%s failed to recover after add" % disk)
+                        err_disks.append(disk)
+
+            if err_disks:
+                self.log.info("few paths failed to recover : %s" % err_disks)
+                return False
+            return True
+
+        def net_recovery_check():
+            """
+            Checks if the network adapter fuctionality like ping/link_state,
+            after adapter added back.
+            Returns True on propper Recovery, False if not.
+            """
+            self.log.info("entering the net recovery check")
+            local = LocalHost()
+            iface = pci.get_interfaces_in_pci_address(pci_addr, 'net')
+            networkinterface = NetworkInterface(iface[0], local)
+            if wait.wait_for(networkinterface.is_link_up, timeout=120):
+                if networkinterface.ping_check(self.peer_ip, count=5) is None:
+                    self.log.info("inteface is up and pinging")
+                    return True
             return False
 
-        if not wait.wait_for(is_added, timeout=10):
-            return False
-        # Waiting for 10s per end device, for recovery.
-        return wait.wait_for(is_recovered,
-                             self.end_devices[pci_addr] * 10)
+        if wait.wait_for(is_added, timeout=30):
+            time.sleep(45)
+            if pci.get_pci_class_name(pci_addr) == 'net':
+                if wait.wait_for(net_recovery_check, timeout=30):
+                    return True
+                return False
+            else:
+                if wait.wait_for(is_recovered, timeout=30):
+                    return True
+        return False

--- a/io/pci/pci_hotplug.py.data/README.txt
+++ b/io/pci/pci_hotplug.py.data/README.txt
@@ -1,4 +1,5 @@
 PCI Hotplug can remove and add pci devices when the system is active.
+And checks their respective functionality after remove/add operation.
 This test verifies that for supported slots.
 This test needs to be run as root.
 
@@ -6,3 +7,6 @@ Inputs Needed (in multiplexer file):
 ------------------------------------
 pci_devices -       PCI devices, pass space separated pci devices "001b:62:00.0 001b:62:00.1"
 num_of_hotplug -   Specify number of times hotplug to be performed
+peer_ip -          if the hot_pluggable adapter is network type, then you have to provide with
+                   corresponding peer interface IP to check the ping functionality after the 
+                   adapter is added back. this is not required if adapter is not net.

--- a/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
+++ b/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
@@ -1,2 +1,3 @@
 pci_devices: ""
 count: 10
+peer_ip:


### PR DESCRIPTION
After a adapter is hot_pluged and addded it back,
respective disk recovery check was not there.
instead it has some premitive check which is not enough.
So changed the code to take care the recovery check properly for Fc adapter.
we can also do for other adapters too.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>