### PR TITLE
dbench.py: Unclean test end making setup unusable for other tests

### DIFF
--- a/io/disk/dbench.py.data/dbench.yaml
+++ b/io/disk/dbench.py.data/dbench.yaml
@@ -1,4 +1,5 @@
 disk:
+dir:
 setup:
     duration: !mux
         default:


### PR DESCRIPTION
1. Fixed to work for all the mux variants i.e device types
2. Fixed unclean test end after each test combination. added precleanup method
3. Input mount point to run test on test disk instead of local dir
4. Get proper logical device names lv, md etc to match to user inputs
5. Clear the disk metata data before test start, causing raid to fail

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>