### PR TITLE
pre clean up control files for ssh

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -68,7 +68,7 @@ class NetworkVirtualization(Test):
             self.cancel("LPAR Name not got from lparstat command")
         for root, dirct, files in os.walk("/root/.ssh"):
             for file in files:
-                if file.startswith("avocado-master-root"):
+                if file.startswith("avocado-master-"):
                     path = os.path.join(root, file)
                     os.remove(path)
         self.session_hmc = Session(self.hmc_ip, user=self.hmc_username,


### PR DESCRIPTION
make sure the file name is generic to clean up control
files for lpar session and also hmc session

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>