### PR TITLE
Fixed hmccmd issue and added PowerVM only support

### DIFF
--- a/dlpar/cpu_unit.py
+++ b/dlpar/cpu_unit.py
@@ -49,11 +49,11 @@ class CpuUnit(TestCase):
           1 - Shutdown the partition (shared);
           2 - Define dedicated partition with min, desired, max from config
         """
-        u_cmd = 'chsyscfg -r prof -m %s -p %s -i \
+        u_cmd = 'chsyscfg -r prof -m %s -i \
                 "lpar_name=%s,name=default_profile,proc_mode=shared, \
                 min_proc_units=%s,desired_proc_units=%s,max_proc_units=%s, \
                 min_procs=%s,desired_procs=%s,max_procs=%s,sharing_mode=%s" --force' % \
-                (linux_machine.machine,linux_machine.partition, \
+                (linux_machine.machine, \
                 linux_machine.name,self.min_proc_units,self.desired_proc_units, \
                 self.max_proc_units,self.min_procs,self.desired_procs, \
                 self.max_procs, self.sharing_mode)

--- a/dlpar/dedicated_cpu.py
+++ b/dlpar/dedicated_cpu.py
@@ -52,10 +52,10 @@ class DedicatedCpu(TestCase):
           1 - Shutdown the partition (dedicated);
           2 - Define dedicated partition with min, desired, max from config 
         """
-        u_cmd = 'chsyscfg -r prof -m %s -p %s -i \
+        u_cmd = 'chsyscfg -r prof -m %s -i \
                 "lpar_name=%s,name=default_profile,proc_mode=ded, \
                 min_procs=%s,desired_procs=%s,max_procs=%s,sharing_mode=keep_idle_procs" \
-                --force' % (linux_machine.machine,linux_machine.partition, \
+                --force' % (linux_machine.machine, \
                 linux_machine.name,self.min_procs,self.desired_procs,self.max_procs)
         self.log.info('DEBUG: Dedicated lpar setup %s' % u_cmd)
         self.hmc.sshcnx.run_command(u_cmd, False)

--- a/dlpar/dlpar_main.py
+++ b/dlpar/dlpar_main.py
@@ -19,13 +19,17 @@ import os
 
 from avocado import Test
 from avocado.utils import process
+from avocado import skipUnless
 
+IS_POWER_VM = 'pSeries' in open('/proc/cpuinfo', 'r').read()
 
 class DlparTests(Test):
 
     """
     Dlpar CPU/MEMORY  tests - ADD/REMOVE/MOVE
     """
+    @skipUnless(IS_POWER_VM,
+                "DLPAR test is supported only on PowerVM platform")
     def setUp(self):
         self.lpar_mode = self.params.get('mode', default='dedicated')
 

--- a/dlpar/memory.py
+++ b/dlpar/memory.py
@@ -48,11 +48,11 @@ class Memory(TestCase):
           1 - Shutdown the partition (shared);
           2 - Define memory profile with min, desired, max from config
         """
-        u_cmd = 'chsyscfg -r prof -m %s -p %s -i "lpar_name=%s,name=default_profile, \
+        u_cmd = 'chsyscfg -r prof -m %s -i "lpar_name=%s,name=default_profile, \
                 min_mem=%d,desired_mem=%d,max_mem=%d, \
                 min_num_huge_pages=0,desired_num_huge_pages=0, \
                 max_num_huge_pages=0" --force' % \
-                (linux_machine.machine,linux_machine.partition,linux_machine.name, \
+                (linux_machine.machine,linux_machine.name, \
                 self.min_mem,self.desired_mem,self.max_mem)
 
         self.log.info('DEBUG: Memory lpar setup %s' % u_cmd)


### PR DESCRIPTION
Fix has been added to take care of hmccmd for changing the profile and also added PowerVM only support for dlpar test runs.

Signed-off-by: Kalpana Shetty <kalshett@in.ibm.com>