### PR TITLE
Fixes for pexpect when wrapping a sendline-enabled command

### DIFF
--- a/dlpar/dlpar_api/api.py
+++ b/dlpar/dlpar_api/api.py
@@ -68,6 +68,9 @@ class MyPxssh(pxssh):
         # In some situations, with asynchronous commands, we might not get 
         # an answer right after we try to check the exit code. so in this
         # case, we need to wait and try again.
+        self.sendline("bind 'set enable-bracketed-paste off'")
+        self.expect('\r\n')
+        self.prompt()
         self.sendline(command)
         self.expect('\r\n')
         self.prompt()


### PR DESCRIPTION
sendline-enabled command resulted in extra escape sequences, fixed by disabling enable-bracketed-paste off.

Signed-off-by: Kalpana Shetty <kalshett@in.ibm.com>