### PR TITLE
Dlpar -w 0 option added

### DIFF
--- a/dlpar/cpu_unit.py
+++ b/dlpar/cpu_unit.py
@@ -212,7 +212,7 @@ class CpuUnit(TestCase):
         # Add the cpus
         a_cmd = 'chhwres -m ' + linux_machine.machine + \
                 ' -r proc -o a --procunits ' + str(quantity) + \
-                ' -p "' + linux_machine.partition + '"'
+                ' -p "' + linux_machine.partition + '"' + ' -w 0 '
         self.hmc.sshcnx.run_command(a_cmd)
         self.log.debug('Sleeping for %s seconds before proceeding' %
                        self.sleep_time)
@@ -245,7 +245,7 @@ class CpuUnit(TestCase):
         m_cmd = 'chhwres -m ' + linux_machine_1.machine + \
                 ' -r proc -o m --procunits ' + str(quantity) + \
                 ' -p "' + linux_machine_1.partition + '"' + \
-                ' -t "' + linux_machine_2.partition + '"'
+                ' -t "' + linux_machine_2.partition + '"' + ' -w 0 '
 
         self.hmc.sshcnx.run_command(m_cmd)
         self.log.debug('Sleeping for %s seconds before proceeding' %
@@ -279,7 +279,7 @@ class CpuUnit(TestCase):
         # Remove the cpus
         r_cmd = 'chhwres -m ' + linux_machine.machine + \
                 ' -r proc -o r --procunits ' + str(quantity) + \
-                ' -p "' + linux_machine.partition + '"'
+                ' -p "' + linux_machine.partition + '"' + ' -w 0 '
         self.hmc.sshcnx.run_command(r_cmd)
         self.log.debug('Sleeping for %s seconds before proceeding' %
                        self.sleep_time)

--- a/dlpar/dedicated_cpu.py
+++ b/dlpar/dedicated_cpu.py
@@ -143,7 +143,7 @@ class DedicatedCpu(TestCase):
             m_cmd = 'chhwres -m ' + linux_machine.machine + \
                     ' -r proc -o r --procs ' + \
                     str(curr_procs - curr_min_procs) + \
-                    ' -p "' + linux_machine.partition + '"'
+                    ' -p "' + linux_machine.partition + '"' + ' -w 0 '
             self.hmc.sshcnx.run_command(m_cmd, False)
 
             self.log.debug('Sleeping for %s seconds before proceeding' %
@@ -196,7 +196,7 @@ class DedicatedCpu(TestCase):
         # Add the cpus
         a_cmd = 'chhwres -m ' + linux_machine.machine + \
                 ' -r proc -o a --procs ' + str(quantity) + \
-                ' -p "' + linux_machine.partition + '"'
+                ' -p "' + linux_machine.partition + '"' + ' -w 0 '
         cmd_result = self.hmc.sshcnx.run_command(a_cmd)
         self.log.debug('Sleeping for %s seconds before proceeding' %
                        self.sleep_time)
@@ -231,7 +231,7 @@ class DedicatedCpu(TestCase):
         m_cmd = 'chhwres -m ' + linux_machine_1.machine + \
                 ' -r proc -o m --procs ' + str(quantity) + \
                 ' -p "' + linux_machine_1.partition + '"' + \
-                ' -t "' + linux_machine_2.partition + '"'
+                ' -t "' + linux_machine_2.partition + '"' + ' -w 0 '
         cmd_result = self.hmc.sshcnx.run_command(m_cmd)
         self.log.debug('Sleeping for %s seconds before proceeding' %
                        self.sleep_time)
@@ -260,7 +260,7 @@ class DedicatedCpu(TestCase):
         # Remove the cpus
         r_cmd = 'chhwres -m ' + linux_machine.machine + \
                 ' -r proc -o r --procs ' + str(quantity) + \
-                ' -p "' + linux_machine.partition + '"'
+                ' -p "' + linux_machine.partition + '"' + ' -w 0 '
         self.hmc.sshcnx.run_command(r_cmd)
         self.log.debug('Sleeping for %s seconds before proceeding' %
                        self.sleep_time)

--- a/dlpar/memory.py
+++ b/dlpar/memory.py
@@ -215,7 +215,8 @@ class Memory(TestCase):
 
         # Add the memory
         a_cmd = 'chhwres -m ' + linux_machine.machine + ' -r mem -o a -q ' + \
-                str(quantity) + ' -p "' + linux_machine.partition + '"'
+                str(quantity) + ' -p "' + linux_machine.partition + '"' + \
+                ' -w 0 '
         self.hmc.sshcnx.run_command(a_cmd)
 
         self.log.debug('Sleeping for %s seconds before proceeding' %
@@ -249,7 +250,8 @@ class Memory(TestCase):
 
         # Remove the memory
         r_cmd = 'chhwres -m ' + linux_machine.machine + ' -r mem -o r -q ' + \
-                str(quantity) + ' -p "' + linux_machine.partition + '"'
+                str(quantity) + ' -p "' + linux_machine.partition + '"' + \
+                ' -w 0 '
         self.hmc.sshcnx.run_command(r_cmd)
         self.log.debug('Sleeping for %s seconds before proceeding' %
                        self.sleep_time)
@@ -290,7 +292,7 @@ class Memory(TestCase):
         # Move the memory
         m_cmd = 'chhwres -m ' + linux_machine_1.machine + ' -r mem -o m -q ' + \
                 str(quantity) + ' -p "' + linux_machine_1.partition + \
-                ' -t "' + linux_machine_2.partition + '"'
+                ' -t "' + linux_machine_2.partition + '"' + ' -w 0 '
         self.hmc.sshcnx.run_command(m_cmd)
         self.log.debug('Going to sleep for %s s' % self.sleep_time)
         time.sleep(self.sleep_time)


### PR DESCRIPTION
Added -w 0 option to disable time limit for dlpar operation. This option is must for larger value add/remove/move operations.

Signed-off-by: Kalpana Shetty <kalshett@in.ibm.com>