### PR TITLE
ppc64_cpu_test: Configurable yaml option for loop count

### DIFF
--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -44,6 +44,8 @@ class PPC64Test(Test):
         if SoftwareManager().check_installed("powerpc-utils") is False:
             if SoftwareManager().install("powerpc-utils") is False:
                 self.cancel("powerpc-utils is not installing")
+        
+        self.loop = int(self.params.get('test_loop', default=100))
         self.smt_str = "ppc64_cpu --smt"
         # Dynamically set max SMT specified at boot time
         process.system("%s=on" % self.smt_str, shell=True)
@@ -158,7 +160,7 @@ class PPC64Test(Test):
         """
         Tests smt on/off in a loop
         """
-        for _ in range(1, 100):
+        for _ in range(1, self.loop):
             if process.system("%s=off && %s=on" % (self.smt_str, self.smt_str),
                               shell=True):
                 self.fail('SMT loop test failed')

--- a/cpu/ppc64_cpu_test.py.data/ppc64_cpu_test.yaml
+++ b/cpu/ppc64_cpu_test.py.data/ppc64_cpu_test.yaml
@@ -1,0 +1,1 @@
+test_loop : 10


### PR DESCRIPTION
ppc64_cpu_test use 100 as a count for loop test. On systems with large number
of processors it takes several minutes to complete the execution.

Add a configurable yaml option 'test_loop' for loop count.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>