### PR TITLE
nx-gzip: Fixes for compilation failure and indentation

### DIFF
--- a/nx_gzip/nx_gzip.py
+++ b/nx_gzip/nx_gzip.py
@@ -59,9 +59,9 @@ class NXGZipTests(Test):
         build different test builds
         '''
         if self.name.uid == 13:
-           test_dir = os.path.join(self.buldir, testdir_name)
+            test_dir = os.path.join(self.buldir, testdir_name)
         else:
-           test_dir = os.path.join(self.teststmpdir, testdir_name)
+            test_dir = os.path.join(self.teststmpdir, testdir_name)
         os.chdir(test_dir)
         testdir_dict = {
           "": "check",
@@ -312,11 +312,11 @@ class NXGZipTests(Test):
         match = next(
                 (ext for ext in [".zip", ".tar"] if ext in linux_src), None)
         if match:
-           tarball = self.fetch_asset("kselftest%s" % match,
-                                      locations=[linux_src], expire='1d')
-           archive.extract(tarball, self.teststmpdir)
+            tarball = self.fetch_asset("kselftest%s" % match,
+                                       locations=[linux_src], expire='1d')
+            archive.extract(tarball, self.teststmpdir)
         else:
-           git.get_repo(linux_src, destination_dir=self.teststmpdir)
+            git.get_repo(linux_src, destination_dir=self.teststmpdir)
         self.buldir = os.path.join(self.teststmpdir, self.output)
         self.build_tests(self.testdir)
 

--- a/nx_gzip/nx_gzip.py
+++ b/nx_gzip/nx_gzip.py
@@ -105,7 +105,8 @@ class NXGZipTests(Test):
         self.branch = self.params.get('git_branch', default='master')
         git.get_repo(self.url, branch=self.branch,
                      destination_dir=self.teststmpdir)
-        process.run('./configure', sudo=True, shell=True)
+        if self.branch == 'develop':
+            process.run('./configure', sudo=True, shell=True)
         os.chdir(self.teststmpdir)
         build.make(self.teststmpdir)
 


### PR DESCRIPTION
While using default 'master' branch of libnxz library code nx-gzip
test complains about missing configure script:
./configure: No such file or directory\n'\nadditional_info: None
configure script is only available with 'develop' branch.
    
Add a check for git branch to select correct build procedure.
Also fix indentation issues.    
Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>