### PR TITLE
toolchain/ltrace - Fix git repository url

### DIFF
--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -72,8 +72,8 @@ class Ltrace(Test):
                             package)
         run_type = self.params.get("type", default="upstream")
         if run_type == "upstream":
-            source = self.params.get('url', default="git@gitlab.com:cespedes/"
-                                     "ltrace.git")
+            source = self.params.get('url', default="https://gitlab.com/"
+                                     "cespedes/ltrace.git")
             git.get_repo(source, destination_dir=os.path.join(
                 self.workdir, 'ltrace'))
 

--- a/toolchain/ltrace.py.data/ltrace.yaml
+++ b/toolchain/ltrace.py.data/ltrace.yaml
@@ -1,6 +1,6 @@
 run_type: !mux
     upstream:
-        url: 'git@gitlab.com:cespedes/ltrace.git'
+        url: 'https://gitlab.com/cespedes/ltrace.git'
         type: 'upstream'
     distro:
         type: 'distro'


### PR DESCRIPTION
ltrace test fails to fetch ltrace source code and reports following error:

(1/1) toolchain/ltrace.py:Ltrace.test: ERROR: Command '/usr/bin/git fetch -q -f -u -t git@gitlab.com:cespedes/ltrace.git master:master' failed.\nstdout: b''\nstderr: b'git@gitlab.com: Permission denied (publickey,keyboard-interactive).\r\nfatal: Could not read from remote repository.\n\nPlease make sur... (0.61 s)
RESULTS  : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

Update the upstream url to point to https git repository.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>