### PR TITLE
fixed perf_genericevents.py

### DIFF
--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -51,12 +51,13 @@ class test_generic_events(Test):
             event_code = events_file.readline()
             val = self.generic_events.get(file, 9)
             raw_code = event_code.split('=', 2)[1].rstrip()
+            self.log.info('FILE in %s is %s' % (dir, file))
             if raw_code != val:
                 nfail += 1
-                self.log.warn('FAIL : Expected value is %s but got'
+                self.log.warn('FAIL : Expected value is %s but got '
                               '%s' % (val, raw_code))
-            self.log.info('FILE in %s is %s' % (dir, file))
-            self.log.info('PASS : Expected value: %s and got'
+            else:
+                self.log.info('PASS : Expected value: %s and got '
                           '%s' % (val, raw_code))
         if nfail != 0:
             self.fail('Failed to verify generic PMU event codes')


### PR DESCRIPTION
for failed events it was not showing event name,
added code to show event name in proper order

Signed-off-by: Disha Goel <disha.goel@ibm.com>