### PR TITLE
修改了bench_movepages.c文件

### DIFF
--- a/memory/numa_test.py.data/bench_movepages.c
+++ b/memory/numa_test.py.data/bench_movepages.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
         while ((c = getopt(argc, argv, "n:vh")) != -1) {
 		switch(c) {
 		case 'n':
-			nr_pages = strtoul(optarg, NULL, 10);
+			nr_pages = strtoul(optarg, NULL, 3);
 			/* Now update nr_pages using system page size */
 			nr_pages = nr_pages * hpage_size/page_size;
 			break;


### PR DESCRIPTION
Some operating systems currently have a pagesize of 64K,setting nr_page to 100 in the test_thp_compare test of the numa_test.py script will fail，when modifying bench_ movepages. when 10 in C file is 3, there will be no failure on 4K and 64K