### PR TITLE
toolchain/strace: Add support to run with distro as a target

### DIFF
--- a/toolchain/strace.py.data/strace.yaml
+++ b/toolchain/strace.py.data/strace.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        url: 'https://github.com/strace/strace.git'
+        type: 'upstream'
+    distro:
+        type: 'distro'


### PR DESCRIPTION
strace test supports upstream as the only target. 

Add a yaml file so that in addition to upstream, user can specify 
distro as a target. Default option is set to distro.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>