### PR TITLE
Gcc15

### DIFF
--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -87,7 +87,7 @@ class GCC(Test):
         ret = build.run_make(
             self.sourcedir, extra_args='check',
             process_kwargs={'ignore_status': True})
-        self.summary = ret.stdout.splitlines()
+        self.summary = ret.stdout.decode("utf-8").splitlines()
         for index, line in enumerate(self.summary):
             if "=== gcc Summary ===" in line:
                 self.get_summary(index + 2)

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -52,13 +52,12 @@ class GCC(Test):
                              'gmp-devel', 'glibc-devel', 'mpfr-devel',
                              'makeinfo', 'texinfo', 'mpc-devel'])
         else:
-            packages.extend(['glibc-static', 'autogen', 'guile',
-                             'guile-devel', 'libgo', 'libgo-devel',
-                             'libgo-static', 'elfutils-devel',
+            packages.extend(['glibc-static', 'elfutils-devel',
                              'texinfo-tex', 'texinfo', 'elfutils-libelf-devel',
                              'gmp-devel', 'mpfr-devel', 'libmpc-devel',
-                             'gcc-gnat', 'libgnat', 'zlib-devel',
-                             'gettext', 'libgcc', 'libgomp'])
+                             'zlib-devel', 'gettext', 'libgcc', 'libgomp'])
+            if dist.name == 'rhel8':
+                packages.extend(['autogen', 'guile', 'guile-devel'])
 
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
avocado run --test-runner runner gcc.py
Fetching asset from gcc.py:GCC.test

rhel8.6

JOB ID : 6c4e7494ff5c1f77b62f4d7aa68733d417a317e0
JOB LOG : /root/preeti4/avocado-fvt-wrapper/results/job-2022-02-21T08.55-6c4e749/job.log
(1/1) gcc.py:GCC.test: -FAIL: Few gcc tests failed,refer the log file (8050.81 s)
RESULTS : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML : /root/preeti4/avocado-fvt-wrapper/results/job-2022-02-21T08.55-6c4e749/results.html
JOB TIME : 8051.53 s

rhel9
root@ltcever87-lp9 toolchain]# avocado run --test-runner runner gcc.py
Fetching asset from gcc.py:GCC.test
JOB ID : cf80ac86673bb698c8c8f1eb7ad6a1b4c77d0703
JOB LOG : /preeti_new/avocado-fvt-wrapper/results/job-2022-02-23T02.27-cf80ac8/job.log
(1/1) gcc.py:GCC.test: CANCEL: Failed to install guile-devel required for this test. (1.35 s)
RESULTS : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML : /preeti_new/avocado-fvt-wrapper/results/job-2022-02-23T02.27-cf80ac8/results.html
JOB TIME : 14.74 s

tests will not pass, there are failures seen.
so to make test run above package is added

the changes applicable are for both RHEL8.6 and RHEL9