### PR TITLE
Gcc25

### DIFF
--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -52,18 +52,16 @@ class GCC(Test):
                              'gmp-devel', 'glibc-devel', 'mpfr-devel',
                              'makeinfo', 'texinfo', 'mpc-devel'])
         else:
-            packages.extend(['glibc-static', 'autogen', 'guile',
-                             'guile-devel', 'libgo', 'libgo-devel',
-                             'libgo-static', 'elfutils-devel',
+            packages.extend(['glibc-static', 'elfutils-devel',
                              'texinfo-tex', 'texinfo', 'elfutils-libelf-devel',
                              'gmp-devel', 'mpfr-devel', 'libmpc-devel',
-                             'gcc-gnat', 'libgnat', 'zlib-devel',
-                             'gettext', 'libgcc', 'libgomp'])
+                             'zlib-devel', 'gettext', 'libgcc', 'libgomp'])
+            if dist.name == 'rhel and (int(dist.version)==8 and int(dist.release >= 6))':
 
-        for package in packages:
-            if not smm.check_installed(package) and not smm.install(package):
-                self.cancel(
-                    "Failed to install %s required for this test." % package)
+                for package in packages:
+                    if not smm.check_installed(package) and not smm.install(package):
+                        self.cancel(
+                            "Failed to install %s required for this test." % package)
         tarball = self.fetch_asset('gcc.zip', locations=[
                                    'https://github.com/gcc-mirror/gcc/archive'
                                    '/master.zip'], expire='7d')

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -86,7 +86,7 @@ class GCC(Test):
         ret = build.run_make(
             self.sourcedir, extra_args='check',
             process_kwargs={'ignore_status': True})
-        self.summary = ret.stdout.splitlines()
+        self.summary = ret.stdout.decode("utf-8").splitlines()
         for index, line in enumerate(self.summary):
             if "=== gcc Summary ===" in line:
                 self.get_summary(index + 2)


### PR DESCRIPTION
Logs from RHEL8.6 and RHEL9 run attached

This PR address 2 issues
1) Packages removal 
below are the packages not supported for RHEL8
libgo', 'libgo-devel' 'libgo-static' 'gcc-gnat', 'libgnat'

below are the packages not supported for RHEL9
Autogen guile

2) This fix address issues as result parsing has errors due  to python3 

RUN from RHEL8.6
[root@ltcever60-lp15 toolchain]# avocado run --test-runner runner gcc.py
Fetching asset from gcc.py:GCC.test
JOB ID     : 0ade997a60863c411157d823fdc3df45cfe05a26
JOB LOG    : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-25T03.12-0ade997/job.log
 (1/1) gcc.py:GCC.test: FAIL: Few gcc tests failed,refer the log file (67.99 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-25T03.12-0ade997/results.html
JOB TIME   : 68.63 s

RUN from RHEL9
[root@ltcden4-lp3 toolchain]# avocado run --test-runner runner gcc.py
Fetching asset from gcc.py:GCC.test
JOB ID     : 5bf120f73a913ebe4febc42cc11ff00e6c7fbaf4
JOB LOG    : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-25T03.41-5bf120f/job.log
 (1/1) gcc.py:GCC.test: FAIL: Few gcc tests failed,refer the log file (19.32 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-25T03.41-5bf120f/results.html
JOB TIME   : 37.84 s

