### PR TITLE
script fix for exact sub_module match from config file for module_unload_load.py

### DIFF
--- a/io/driver/module_unload_load.py
+++ b/io/driver/module_unload_load.py
@@ -65,7 +65,7 @@ class ModuleLoadUnload(Test):
         config_path = os.path.join(os.path.abspath(''),
                                    "module_unload_load.py.data/config")
         for line in genio.read_all_lines(config_path):
-            if module in line:
+            if module == line.split('=')[0]:
                 return line.split('=')[-1]
 
     def flush_mpath(self, mdl):


### PR DESCRIPTION

current script checks the partial match for dependent modules from config file.
this is failing for closely same module names like 'nvme' and nvme_core.
So modified the script for exact match so that it fetches right dependent
sub_module

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>