### PR TITLE
Gcc01

### DIFF
--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -87,7 +87,7 @@ class GCC(Test):
         ret = build.run_make(
             self.sourcedir, extra_args='check',
             process_kwargs={'ignore_status': True})
-        self.summary = ret.stdout.splitlines()
+        self.summary = ret.stdout.decode("utf-8").splitlines()
         for index, line in enumerate(self.summary):
             if "=== gcc Summary ===" in line:
                 self.get_summary(index + 2)

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -52,13 +52,12 @@ class GCC(Test):
                              'gmp-devel', 'glibc-devel', 'mpfr-devel',
                              'makeinfo', 'texinfo', 'mpc-devel'])
         else:
-            packages.extend(['glibc-static', 'autogen', 'guile',
-                             'guile-devel', 'libgo', 'libgo-devel',
-                             'libgo-static', 'elfutils-devel',
+            packages.extend(['glibc-static', 'elfutils-devel',
                              'texinfo-tex', 'texinfo', 'elfutils-libelf-devel',
                              'gmp-devel', 'mpfr-devel', 'libmpc-devel',
-                             'gcc-gnat', 'libgnat', 'zlib-devel',
-                             'gettext', 'libgcc', 'libgomp'])
+                             'zlib-devel', 'gettext', 'libgcc', 'libgomp'])
+            if dist.name == 'rhel' and (int(dist.version)==8 and int(dist.release) >= 6):
+                packages.extend(['autogen', 'guile', 'guile-devel'])
 
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
Logs from RHEL8.6 and RHEL9 run attached

This PR address 2 issues

1. Packages removal 
below are the packages not supported for RHEL8
 libgo', 'libgo-devel' 'libgo-static' 'gcc-gnat', 'libgnat'

below are the packages not supported for RHEL9 
Autogen guile

2. This fix address issues as result parsing has errors due to python3

RUN from RHEL8.6
Fetching asset from gcc.py:GCC.test
JOB ID     : 5a278cedfcf6bc12edda4ce5a295380b55d58d38
JOB LOG    : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-31T03.13-5a278ce/job.log
 (1/1) gcc.py:GCC.test: FAIL: Few gcc tests failed,refer the log file (162.11 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-31T03.13-5a278ce/results.html
JOB TIME   : 162.58 s

RUN from RHEL9
Fetching asset from gcc.py:GCC.test
JOB ID     : f87c1ced1f70447f3cb9c380a3a3b55e44a74627
JOB LOG    : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-31T02.40-f87c1ce/job.log
 (1/1) gcc.py:GCC.test: FAIL: Few gcc tests failed,refer the log file (27.09 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/preeti/avocado-fvt-wrapper/results/job-2022-03-31T02.40-f87c1ce/results.html
JOB TIME   : 52.02 s