### PR TITLE
toolchain/gcc : Add support for distro as a target

### DIFF
--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -46,29 +46,49 @@ class GCC(Test):
                              'elfutils', 'autogen'])
             if dist.name == 'Ubuntu':
                 packages.extend(['texinfo', 'gnat'])
-        elif dist.name == 'SuSE':
+        elif dist.name.lower() == 'suse':
             packages.extend(['glibc-devel-static', 'zlib-devel', 'elfutils',
                              'libelf-devel', 'gcc-c++', 'isl-devel',
                              'gmp-devel', 'glibc-devel', 'mpfr-devel',
                              'makeinfo', 'texinfo', 'mpc-devel'])
+            if (int(dist.version) == 15 and int(dist.release) > 3):
+                packages.remove('isl-devel')
         else:
             packages.extend(['glibc-static', 'elfutils-devel',
                              'texinfo-tex', 'texinfo', 'elfutils-libelf-devel',
                              'gmp-devel', 'mpfr-devel', 'libmpc-devel',
-                             'zlib-devel', 'gettext', 'libgcc', 'libgomp'])
+                             'zlib-devel', 'gettext', 'libgcc', 'libgomp',
+                             'dblatex', 'doxygen', 'texlive-collection-latex',
+                             'python3-sphinx', 'systemtap-sdt-devel'])
         if dist.name == 'rhel' and (int(dist.version) == 8 and int(dist.release) >= 6):
-            packages.extend(['autogen', 'guile', 'guile-devel'])
+            packages.extend(['autogen', 'guile', 'guile-devel',
+                             'isl-devel', 'docbook5-style-xsl'])
 
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel(
                     "Failed to install %s required for this test." % package)
-        tarball = self.fetch_asset('gcc.zip', locations=[
-                                   'https://github.com/gcc-mirror/gcc/archive'
-                                   '/master.zip'], expire='7d')
-        archive.extract(tarball, self.workdir)
-        self.sourcedir = os.path.join(self.workdir, 'gcc-master')
-
+        run_type = self.params.get('type', default='distro')
+        if run_type == "upstream":
+            url = 'https://github.com/gcc-mirror/gcc/archive/master.zip'
+            tarball = self.fetch_asset('gcc.zip', locations=[url],
+                                       expire='7d')
+            archive.extract(tarball, self.workdir)
+            self.sourcedir = os.path.join(self.workdir, 'gcc-master')
+        elif run_type == "distro":
+            self.sourcedir = os.path.join(self.workdir, 'gcc-distro')
+            if not os.path.exists(self.sourcedir):
+                os.makedirs(self.sourcedir)
+            """
+            FIXME. On certain distros I have observed get_source()
+            API fails to populate source tree. This can be an
+            avocado utils issue. Explicitly fail this testcase
+            until it has been root caused.
+            """
+            if (int(dist.version) == 15 and int(dist.release) > 3):
+                self.fail('Test case is broken for this release')
+            else:
+                self.sourcedir = smm.get_source("gcc", self.sourcedir)
         os.chdir(self.sourcedir)
         process.run('./configure', ignore_status=True, sudo=True)
         build.make(self.sourcedir, ignore_status=True)

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -60,7 +60,8 @@ class GCC(Test):
                              'zlib-devel', 'gettext', 'libgcc', 'libgomp',
                              'dblatex', 'doxygen', 'texlive-collection-latex',
                              'python3-sphinx', 'systemtap-sdt-devel'])
-        if dist.name == 'rhel' and (int(dist.version) == 8 and int(dist.release) >= 6):
+        if dist.name == 'rhel' and \
+           (int(dist.version) == 8 and int(dist.release) >= 6):
             packages.extend(['autogen', 'guile', 'guile-devel',
                              'isl-devel', 'docbook5-style-xsl'])
 
@@ -94,6 +95,9 @@ class GCC(Test):
         build.make(self.sourcedir, ignore_status=True)
 
     def get_summary(self, index):
+        """
+        subroutine to print test result summary.
+        """
         with open(os.path.join(self.outputdir, 'gcc_summary'), 'a') as f_obj:
             while self.summary[index].startswith('#'):
                 f_obj.write('%s\n' % self.summary[index])

--- a/toolchain/gcc.py.data/gcc.yaml
+++ b/toolchain/gcc.py.data/gcc.yaml
@@ -1,0 +1,5 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'


### PR DESCRIPTION
gcc test case by default downloads latest upstream code and runs the
selftests that comes with it. There is no option to use gcc tests
bundled with source pacakge available in a Linux distribution release.

Add support for distro as a target via a yaml file.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>