### PR TITLE
bonding.py: ip address add fail if interface already configured

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -92,6 +92,7 @@ class Bonding(Test):
             for ipaddr, interface in zip(self.ipaddr, self.host_interfaces):
                 networkinterface = NetworkInterface(interface, self.localhost)
                 try:
+                    networkinterface.flush_ipaddr()
                     networkinterface.add_ipaddr(ipaddr, self.netmask)
                     networkinterface.save(ipaddr, self.netmask)
                 except Exception:
@@ -507,6 +508,7 @@ class Bonding(Test):
         for ipaddr, host_interface in zip(self.ipaddr, self.host_interfaces):
             networkinterface = NetworkInterface(host_interface, self.localhost)
             try:
+                networkinterface.flush_ipaddr()
                 networkinterface.add_ipaddr(ipaddr, self.netmask)
                 networkinterface.bring_up()
             except Exception:


### PR DESCRIPTION
    ip addr add command for given test interface is exiting with
    non zero exit code and failing the test, this patch will make
    sure old ip is deleted before configuring new ip
    
    Running 'ip addr add 115.10.10.197/24 dev enP49156p1s0'
    [stderr] RTNETLINK answers: File exists
    Command 'ip addr add 115.10.10.197/24 dev enP49156p1s0' finished with 2
    
    after fix
    Running 'ip addr flush dev enP49156p1s0'
    Command 'ip addr flush dev enP49156p1s0' finished with 0
    Running 'ip addr add 115.10.10.197/24 dev enP49156p1s0'
    Command 'ip addr add 115.10.10.197/24 dev enP49156p1s0' finished with 0
    
Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>