### PR TITLE
ras/vpa_MaxMem_check: Update logic to compare vpa data

### DIFF
--- a/ras/vpa_MaxMem_check.py
+++ b/ras/vpa_MaxMem_check.py
@@ -45,16 +45,15 @@ class Cpu_VpaData(Test):
         for line in output.splitlines():
             if 'MaxMem=' in line:
                 maxmem = line.split('=')[1].strip()
-        output = process.system_output('lscpu', shell=True, ignore_status=True)
-        for line in output.decode().splitlines():
-            if line.startswith('CPU'):
-                total_cpus = line.split(':')[1].strip()
+        possible_cpus = "/sys/devices/system/cpu/possible"
+        output = genio.read_file(possible_cpus).rstrip('\t\r\n\0')
+        total_cpus = output.split('-')[1].strip()
         output = process.system_output(
             'lparstat -i', shell=True, ignore_status=True)
         for line in output.decode().splitlines():
             if 'Maximum Memory' in line:
                 lmaxmem = line.split(':')[1].strip()
-        if ((cpu_count == int(total_cpus)) and (maxmem == lmaxmem)):
+        if ((cpu_count == int(total_cpus)+1) and (maxmem == lmaxmem)):
             self.log.info(
                 "Files are generated for all cpu's and maxmem values are same")
         else:

--- a/ras/vpa_MaxMem_check.py
+++ b/ras/vpa_MaxMem_check.py
@@ -30,7 +30,8 @@ class Cpu_VpaData(Test):
     checks for cpu files and MaxMem
     '''
 
-    @skipIf(IS_POWER_NV or IS_KVM_GUEST,  "This test is supported on PowerVM environment")
+    @skipIf(IS_POWER_NV or IS_KVM_GUEST,
+            "This test is supported on PowerVM environment")
     def setUp(self):
         detected_distro = distro.detect()
         if detected_distro.name not in ['rhel', 'SuSE']:
@@ -57,5 +58,5 @@ class Cpu_VpaData(Test):
             self.log.info(
                 "Files are generated for all cpu's and maxmem values are same")
         else:
-            self.fail(
-                "Files are not generated for all cpu's and maxmem values are not same")
+            self.fail("Files are not generated for all cpu's and"
+                      " maxmem values are not same")


### PR DESCRIPTION
On a logical partition(LPAR) running Linux, number of online logical processors
aren't necessarily same as number of possible/configured logical processors.
This data is dependent on how the LPAR has been configured(minimum vs
desired vs maximum possible in LPAR profile).

On a LPAR configured with 48 available logical processors but 128 maximum
logical processors, the test fails as lscpu returns 48 processors while vpa
data is available for 128 possible processors.
    
Current logic to compare vpa data relies on lscpu o/p which only captures
online processors data. Instead obtain possible cpus data via sysfs
and compare it with vpa data.
    
Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>