### PR TITLE
ras/lparnumascore: Update supported distro release check

### DIFF
--- a/ras/lparnumascore.py
+++ b/ras/lparnumascore.py
@@ -42,8 +42,7 @@ class lparnumascore(Test):
     @skipIf(IS_POWER_NV, "This test is supported on PowerVM environment")
     def setUp(self):
         det_dist = distro.detect()
-        if det_dist.name == 'SuSE' or det_dist.name \
-           == 'rhel' and int(det_dist.version) <= 8:
+        if det_dist.name == 'rhel' and int(det_dist.version) < 8:
             self.cancel("lparnumascore is not supported on %s" % det_dist.name)
         sm = SoftwareManager()
         if not sm.check_installed("powerpc-utils") and \

--- a/ras/lparnumascore.py
+++ b/ras/lparnumascore.py
@@ -27,14 +27,15 @@ class lparnumascore(Test):
     """
     lparnumascore display the NUMA affinity score for the running LPAR.
     The score is a number between 0 and 100. A score of 100 means that all the
-    resources are seen correctly, while a score of 0 means that all the resources
-    have been moved to different nodes. There is a dedicated score for
-    each resource type
+    resources are seen correctly, while a score of 0 means that all the
+    resource have been moved to different nodes. There is a dedicated score
+    for each resource type
     """
     is_fail = 0
 
     def run_cmd(self, cmd):
-        if (process.run(cmd, ignore_status=True, sudo=True, shell=True)).exit_status:
+        if (process.run(cmd, ignore_status=True, sudo=True,
+                        shell=True)).exit_status:
             self.is_fail += 1
         return
 


### PR DESCRIPTION
lparnumascore command is available for SuSE distro releases.
Remove the code restriction accordingly

Also fix code style warning.
    
Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>