### PR TITLE
updated the script to pick latest version

### DIFF
--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -48,8 +48,9 @@ class Valgrind(Test):
                 self.cancel('%s is needed for the test to be run' % package)
         run_type = self.params.get('type', default='upstream')
         if run_type == "upstream":
-            url = self.params.get('url', default="ftp://sourceware.org/pub/"
-                                  "valgrind/valgrind-3.18.1.tar.bz2")
+            url = "ftp://sourceware.org/pub/valgrind/"
+            version = self.params.get('version', default="3.18.1")
+            url = '%s/valgrind-%s.tar.bz2' % (url, version)
             tarball = self.fetch_asset(url)
             archive.extract(tarball, self.workdir)
             version = os.path.basename(tarball.split('.tar.')[0])

--- a/toolchain/valgrind.py.data/valgrind_source.yaml
+++ b/toolchain/valgrind.py.data/valgrind_source.yaml
@@ -1,6 +1,6 @@
 run_type: !mux
-    upstream:
-        url: 'ftp://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2'
-        type: 'upstream'
-    distro:
-        type: 'distro'
+   upstream:
+      version: '3.18.1'
+      type: 'upstream'
+   distro:
+      type: 'distro'


### PR DESCRIPTION
script is updated so that it can pick the latest valgrind  version automatically
whenever its available.

Signed-off-by: preeti thakur <preeti.thakur@in.ibm.com>

[root@ltcever87-lp6 toolchain]# avocado run --test-runner runner valgrind.py
Fetching asset from valgrind.py:Valgrind.test
JOB ID     : a23ac84f87a1ee57703a9af355ab0b81dc54b4f6
JOB LOG    : /root/preeti/avocado-fvt-wrapper/results/job-2022-04-20T08.14-a23ac84/job.log
 (1/1) valgrind.py:Valgrind.test:  PASS (1966.78 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/preeti/avocado-fvt-wrapper/results/job-2022-04-20T08.14-a23ac84/results.html
JOB TIME   : 1997.65 s
