### PR TITLE
check_perf_core_imc_availability

### DIFF
--- a/perf/perf_core_imc_non_zero_event.py
+++ b/perf/perf_core_imc_non_zero_event.py
@@ -52,6 +52,12 @@ class PerfCoreIMCNonZeroEvents(Test):
         process.run("ppc64_cpu --frequency -t 10 &", shell=True,
                     ignore_status=True, verbose=True, ignore_bg_processes=True)
 
+        output = process.run('perf list')
+        if 'core_imc' in output.stdout_text:
+            self.log.info('core_imc is present')
+        else:
+            self.cancel("core_imc not found")
+
     def parse_op(self, cmd):
         fail_count = 0
         output = process.system_output(cmd, ignore_status=True,


### PR DESCRIPTION
added code to check core imc events are available or not

Signed-off-by: Disha Goel <disha.goel@ibm.com>

[root@ltc-wcwsp3 perf]# avocado run --test-runner runner perf_core_imc_non_zero_event.py
JOB ID     : e7b0f3f0e1337739cd2f01b0f60ef4e32cd46d9b
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-04-21T05.42-e7b0f3f/job.log
 (1/2) perf_core_imc_non_zero_event.py:PerfCoreIMCNonZeroEvents.test_perf_cpm_cyc: PASS (11.07 s)
 (2/2) perf_core_imc_non_zero_event.py:PerfCoreIMCNonZeroEvents.test_perf_cpm_32mhz_cyc: PASS (10.88 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-04-21T05.42-e7b0f3f/results.html
JOB TIME   : 43.41 s

[root@lep8d perf]# avocado run --test-runner runner perf_core_imc_non_zero_event.py 
JOB ID     : e2597a19f35c843b74b284c0229b6119a96f1bd4
JOB LOG    : /home/siri/avocado-fvt-wrapper/results/job-2022-04-21T05.45-e2597a1/job.log
 (1/2) perf_core_imc_non_zero_event.py:PerfCoreIMCNonZeroEvents.test_perf_cpm_cyc: CANCEL: core_imc not found (6.67 s)
 (2/2) perf_core_imc_non_zero_event.py:PerfCoreIMCNonZeroEvents.test_perf_cpm_32mhz_cyc: CANCEL: core_imc not found (6.57 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 2
JOB HTML   : /home/siri/avocado-fvt-wrapper/results/job-2022-04-21T05.45-e2597a1/results.html
JOB TIME   : 14.92 s

[root@ltcden10-lp1 perf]# avocado run --test-runner runner perf_core_imc_non_zero_event.py
JOB ID     : 517315ea3d443967b1a68c531e4f73440269e683
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-04-21T15.21-517315e/job.log
 (1/2) perf_core_imc_non_zero_event.py:PerfCoreIMCNonZeroEvents.test_perf_cpm_cyc: SKIP: This test is for PowerNV
 (2/2) perf_core_imc_non_zero_event.py:PerfCoreIMCNonZeroEvents.test_perf_cpm_32mhz_cyc: SKIP: This test is for PowerNV
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 2 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-04-21T15.21-517315e/results.html
JOB TIME   : 8.66 s

[core_imc_cancel-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8553220/core_imc_cancel-job.log)
[core_imc_pass-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8553230/core_imc_pass-job.log)