### PR TITLE
Fixed out of index error.

### DIFF
--- a/cpu/producer_consumer.py
+++ b/cpu/producer_consumer.py
@@ -99,7 +99,7 @@ class Producer_Consumer(Test):
         for line in lines:
             if line.startswith('Consumer(0) :'):
                 print(line)
-                pattern = re.compile(r":    (.*?) iterations")
+                pattern = re.compile(r":\s(.*?) iterations")
                 iteration = pattern.findall(line)[0]
                 pattern = re.compile(r"time/iteration: (.*?) ns")
                 time_iter = pattern.findall(line)[0]


### PR DESCRIPTION
On sles15sp4 test is failing due to number of spaces mismatch, fixed this error.

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>