### PR TITLE
Patch address False alarm

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -87,7 +87,7 @@ class Stressng(Test):
         for line in str(result).splitlines():
             if 'error:' in line:
                 self.cancel(
-                    "Unsupported OS, Please check the build logs !!")
+                    "Build Failed, Please check the build logs for details !!")
         build.make(sourcedir, extra_args='install')
         clear_dmesg()
 


### PR DESCRIPTION
As recetly in SLES15-SP4 test case is failing and that is due to actual build failure
but while running it shows Unsupported OS and that give False positive as test case was
working earlier

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>