### PR TITLE
perf/perf_duplicate: Minor testcase fixes

### DIFF
--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -45,18 +45,18 @@ class PerfProbe(Test):
                 self.cancel('%s is needed for the test to be run' % package)
         self.fail_flag = False
 
-    def _check_duplicate_probe(self, output):
-        if 'select_task_rq_fair' in output and 'select_task_rq_fair_' in output:
+    def _check_duplicate_probe(self, outpt):
+        if 'select_task_rq_fair' in outpt and 'select_task_rq_fair_' in outpt:
             self.fail_flag = True
 
     def test_probe(self):
-        output = process.run("perf probe select_task_rq_fair:0", sudo=True)
-        output = output.stderr.decode("utf-8")
-        self._check_duplicate_probe(output)
-        output = genio.read_all_lines("/sys/kernel/debug/tracing/kprobe_events")
-        self._check_duplicate_probe(output)
+        outpt = process.run("perf probe select_task_rq_fair:0", sudo=True)
+        outpt = outpt.stderr.decode("utf-8")
+        self._check_duplicate_probe(outpt)
+        outpt = genio.read_all_lines("/sys/kernel/debug/tracing/kprobe_events")
+        self._check_duplicate_probe(outpt)
         if self.fail_flag:
-            self.fail("perf probe is placing multiple probe at the same location ")
+            self.fail("perf is placing multiple probes at the same location ")
 
     def tearDown(self):
         # Deleting all the probed events

--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -36,7 +36,7 @@ class PerfProbe(Test):
         elif 'rhel' in distro_name:
             deps.extend(['perf', 'kernel-debuginfo'])
         elif 'SuSE' in distro_name:
-            deps.extend(['perf', 'kernel-default-base-debuginfo'])
+            deps.extend(['perf', 'kernel-default-debuginfo'])
         else:
             self.cancel("Install the package for perf supported\
                       by %s" % distro_name)


### PR DESCRIPTION
perf/perf_duplicate: Fix code style warnings
    Rename output variable to fix code style warnings.
    Shorten the failure message as well to avoid code style warning.    
perf/perf_duplicate: Fix wrong package dependency
    Testcase has a wrong package dependecy on kernel-default-base-debuginfo.
    Change it to kernel-default-debuginfo.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>