### PR TITLE
Fix for Distro: NDCTL Upstream Test Failing issue.

### DIFF
--- a/memory/ndctl_selftest.py
+++ b/memory/ndctl_selftest.py
@@ -86,16 +86,6 @@ class NdctlTest(Test):
 
         self.sourcedir = self.teststmpdir
         os.chdir(self.sourcedir)
-
-        # TODO: remove patches once merged upstream
-        upstream_patch = self.fetch_asset("upstream.patch", locations=[
-            "https://patchwork.kernel.org/series/177255/mbox/"], expire='7d')
-
-        process.run('patch -p1 < %s' % upstream_patch, shell=True)
-        if detected_distro.arch in ["ppc64", "ppc64le"]:
-            process.run('patch -p1 < %s' %
-                        self.get_data('ppc.patch'), shell=True)
-
         process.run('./autogen.sh', sudo=True, shell=True)
         process.run(
             "./configure CFLAGS='-g -O2' --prefix=/usr "

--- a/memory/ndctl_selftest.py.data/ndctl_selftest.yaml
+++ b/memory/ndctl_selftest.py.data/ndctl_selftest.yaml
@@ -1,2 +1,2 @@
-url: "null"
-branch: "null"
+url:
+branch: 


### PR DESCRIPTION
Removed implementations for upstream.patch and ppc.patch.

Signed-off-by: Samir Mulani <samir@linux.vnet.ibm.com>