### PR TITLE
fix xfstest on pmem devices

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -26,7 +26,6 @@ import glob
 import re
 import shutil
 
-import avocado
 from avocado import Test
 from avocado.utils import process, build, git, distro, partition
 from avocado.utils import disk, data_structures, pmem
@@ -61,10 +60,8 @@ class Xfstests(Test):
         namespace_size = (namespace_size // size_align) * size_align
         return namespace_size
 
-    @avocado.fail_on(pmem.PMemException)
     def setup_nvdimm(self):
         self.logflag = self.params.get('logdev', default=False)
-
         self.plib = pmem.PMem()
         self.plib.enable_region()
         regions = sorted(self.plib.run_ndctl_list('-R'),
@@ -502,7 +499,7 @@ class Xfstests(Test):
         na_detail_re = re.compile(r'(\d{3})\s*(\[not run\])\s*(.*)')
         failed_re = re.compile(r'Failed \d+ of \d+ tests')
 
-        lines = output.decode("utf-8").split('\n')
+        lines = output.decode("ISO-8859-1").split('\n')
         result_line = lines[-3]
 
         error_msg = None

--- a/fs/xfstests.py.data/nvdimm.yaml
+++ b/fs/xfstests.py.data/nvdimm.yaml
@@ -7,7 +7,7 @@ fs_type: !mux
         fs: 'ext4'
         mkfs_opt: '-b 65536'
         test_range: "null"
-        exclude: "null"
+        exclude: "048"
         gen_exclude: "null"
         share_exclude: "null"
     fs_xfs:


### PR DESCRIPTION
fixed UnicodeDecodeError and PMemException on namespace destroy
added ext4/048 in exclude list

Signed-off-by: Disha Goel <disha.goel@ibm.com>

JOB ID     : bb5c562cbb6087b427f249dee672d5b0beeeedc2
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-04-27T23.13-bb5c562/job.log
 (1/2) xfstests.py:Xfstests.test;run-disk_type-fs_type-fs_ext4-7fa0:  FAIL: One or more tests failed. Please check the logs. (2215.96 s)
 (2/2) xfstests.py:Xfstests.test;run-disk_type-fs_type-fs_xfs-e0a0:  FAIL: One or more tests failed. Please check the logs. (8930.24 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 1 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-04-18T16.34-4cb50de/results.html
JOB TIME   : 11246.2 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8594308/job.log)