### PR TITLE
Increased the wait time and sleep time in the .yaml files

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -110,8 +110,8 @@ class Bonding(Test):
         self.bonding_masters_file = "%s/bonding_masters" % self.net_path
         self.peer_bond_needed = self.params.get("peer_bond_needed",
                                                 default=False)
-        self.peer_wait_time = self.params.get("peer_wait_time", default=5)
-        self.sleep_time = int(self.params.get("sleep_time", default=5))
+        self.peer_wait_time = self.params.get("peer_wait_time", default=20)
+        self.sleep_time = int(self.params.get("sleep_time", default=10))
         self.mtu = self.params.get("mtu", default=1500)
         for root, dirct, files in os.walk("/root/.ssh"):
             for file in files:

--- a/io/net/bonding.py.data/bonding.yaml
+++ b/io/net/bonding.py.data/bonding.yaml
@@ -23,6 +23,6 @@ peer_password: "********"
 bond_name: "bondtest"
 user_name: "root"
 peer_bond_needed: False 
-peer_wait_time: "10"
-sleep_time: "5"
+peer_wait_time: "20"
+sleep_time: "10"
 mtu: "1500"

--- a/io/net/bonding.py.data/bonding_mode0.yaml
+++ b/io/net/bonding.py.data/bonding_mode0.yaml
@@ -9,8 +9,8 @@ peer_password: "********"
 bond_name: "bondtest"
 user_name: "root"
 peer_bond_needed: False 
-peer_wait_time: "10"
-sleep_time: "5"
+peer_wait_time: "20"
+sleep_time: "10"
 mtu: !mux
     1500:
         mtu: "1500"

--- a/io/net/bonding.py.data/bonding_mode1.yaml
+++ b/io/net/bonding.py.data/bonding_mode1.yaml
@@ -9,8 +9,8 @@ peer_password: "********"
 bond_name: "bondtest"
 user_name: "root"
 peer_bond_needed: False 
-peer_wait_time: "10"
-sleep_time: "5"
+peer_wait_time: "20"
+sleep_time: "10"
 mtu: !mux
     1500:
         mtu: "1500"

--- a/io/net/bonding.py.data/bonding_mode4.yaml
+++ b/io/net/bonding.py.data/bonding_mode4.yaml
@@ -9,8 +9,8 @@ peer_password: "********"
 bond_name: "bondtest"
 user_name: "root"
 peer_bond_needed: False 
-peer_wait_time: "10"
-sleep_time: "5"
+peer_wait_time: "20"
+sleep_time: "10"
 mtu: !mux
     1500:
         mtu: "1500"

--- a/io/net/bonding.py.data/bonding_single.yaml
+++ b/io/net/bonding.py.data/bonding_single.yaml
@@ -9,6 +9,6 @@ peer_password: "********"
 bond_name: "bondtest"
 user_name: "root"
 peer_bond_needed: False 
-peer_wait_time: "10"
-sleep_time: "5"
+peer_wait_time: "20"
+sleep_time: "10"
 mtu: "1500"

--- a/io/net/bonding.py.data/bonding_virtual.yaml
+++ b/io/net/bonding.py.data/bonding_virtual.yaml
@@ -13,6 +13,6 @@ peer_password: "********"
 bond_name: "bondtest"
 user_name: "root"
 peer_bond_needed: False 
-peer_wait_time: "10"
-sleep_time: "5"
+peer_wait_time: "20"
+sleep_time: "10"
 mtu: "1500"


### PR DESCRIPTION
I have increased the Time required for the interfaces in Peer machine to come up and Generic Sleep time used in the test to 20 and 10 seconds respectively in the bonding yaml files
This is needed since it has been observerd that for interface ports of the different Network adapters we need more time to bring up their corresponding interfaces while executing bonding tests