### PR TITLE
fix-perf_genericevents-P10

### DIFF
--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -76,5 +76,5 @@ LLC-loads = 0x1340000001c040
 LLC-prefetches = 0x100000016080
 LLC-store-misses = 0x26880
 LLC-stores = 0x10000046080
-mem-loads = 0x34340401e0
-mem-stores = 0x343c0401e0
+mem-loads = 0x35340401e0
+mem-stores = 0x353c0401e0


### PR DESCRIPTION
replaced mem-loads and mem-stores with new values on P10
as per commit https://github.com/torvalds/linux/commit/66d9b7492887d34c711bc05b36c22438acba51b4

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

before fix:
avocado run --test-runner runner perf_genericevents.py
JOB ID     : 03ef5d881ddf80033266c8986ae078f9c47a1379
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-05-04T15.18-03ef5d8/job.log
 (1/1) perf_genericevents.py:test_generic_events.test: FAIL: Failed to verify generic PMU event codes (0.52 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-05-04T15.18-03ef5d8/results.html
JOB TIME   : 9.22 s

after fix:
avocado run --test-runner runner perf_genericevents.py
JOB ID     : adb651e6c843d0f3b7725b183a2c378887445d1b
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-05-04T15.25-adb651e/job.log
 (1/1) perf_genericevents.py:test_generic_events.test: PASS (0.64 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-05-04T15.25-adb651e/results.html
JOB TIME   : 9.57 s

[perf_genericevents-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8621329/perf_genericevents-job.log)
