### PR TITLE
kernel/kselftest: Remove dependency on libhugetlbfs package

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -80,6 +80,8 @@ class kselftest(Test):
                          'libhugetlbfs-devel'])
             dis_ver = int(detected_distro.version)
             if detected_distro.name == 'rhel' and dis_ver >= 9:
+                packages_remove = ['libhugetlbfs-devel']
+                deps = list(set(deps)-set(packages_remove))
                 deps.extend(['fuse3-devel'])
             else:
                 deps.extend(['fuse-devel'])


### PR DESCRIPTION
Newer Linux distribution releases no longer ship libhugetlbfs packages.
This breaks ksefltest.

Remove the dependency on this package with newer distributions.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>