### PR TITLE
kernel/kselftest: Add support to run subset of kernel selftests

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -50,13 +50,13 @@ class kselftest(Test):
         Resolve the packages dependencies and download the source.
         """
         smg = SoftwareManager()
-        self.test_type = self.params.get('test_type', default='-H')
-        self.Size_flag = self.params.get('Size', default='-s')
-        self.Dup_MM_Area = self.params.get('Dup_MM_Area', default='100')
         self.comp = self.params.get('comp', default='')
+        self.subtest = self.params.get('subtest', default='')
+        if self.comp == "vm" and self.subtest == "ksm_tests":
+            self.test_type = self.params.get('test_type', default='-H')
+            self.Size_flag = self.params.get('Size', default='-s')
+            self.Dup_MM_Area = self.params.get('Dup_MM_Area', default='100')
         self.run_type = self.params.get('type', default='upstream')
-        if self.comp:
-            self.comp = '-C %s' % self.comp
         detected_distro = distro.detect()
         deps = ['gcc', 'make', 'automake', 'autoconf', 'rsync']
 
@@ -133,10 +133,10 @@ class kselftest(Test):
                 self.buldir = "/usr/src/linux"
 
         self.sourcedir = os.path.join(self.buldir, self.testdir)
-        ksm_test_dir = self.sourcedir + "/vm/ksm_tests"
-        if not os.path.isfile(ksm_test_dir):
-            if build.make(self.sourcedir):
-                self.fail("Compilation failed, Please check the build logs")
+        if self.comp:
+            build_str = '-C %s' % self.comp
+        if build.make(self.sourcedir, extra_args='%s' % build_str):
+            self.fail("Compilation failed, Please check the build logs !!")
 
     def test(self):
         """
@@ -144,8 +144,16 @@ class kselftest(Test):
         """
         self.error = False
         kself_args = self.params.get("kself_args", default='')
-        build.make(self.sourcedir,
-                   extra_args='%s %s run_tests' % (kself_args, self.comp))
+        if self.subtest == "ksm_tests":
+            self.ksmtest()
+        else:
+            if self.subtest:
+                test_comp = self.comp + "/" + self.subtest
+            else:
+                test_comp = self.comp
+            build.make(self.sourcedir,
+                       extra_args='%s -C %s run_tests' %
+                       (kself_args, test_comp))
         for line in open(os.path.join(self.logdir, 'debug.log')).readlines():
             if self.run_type == 'upstream':
                 self.find_match(r'not ok (.*) selftests:(.*)', line)
@@ -169,7 +177,7 @@ class kselftest(Test):
         except process.CmdError as details:
             self.fail("Command %s failed: %s" % (cmd, details))
 
-    def test_kself(self):
+    def ksmtest(self):
         """
         Run the different ksm test types:
         Ex: -M (page merging)

--- a/kernel/kselftest.py.data/README
+++ b/kernel/kselftest.py.data/README
@@ -1,30 +1,110 @@
 This program runs the selftest available with the linux kernel source.
 Compile and run the tests available at /tools/testing/selftests
 
-Run test_kself:-
-Supported <test type>:
--M (page merging)
--Z (zero pages merging)
--N (merging of pages in different NUMA nodes)
--U (page unmerging)
--C evaluate the time required to break COW of merged pages.
--P evaluate merging time and speed.
-For this test, the size of duplicated memory area (in MiB) must be provided using -s option
--H evaluate merging time and speed of area allocated mostly with huge pages For this test, the size of duplicated memory area(in MiB)
-must be provided using -s option
+KSM Test Documentation :-
 
-Inside kernel/kselftest.py.data/ksmtest.yaml we have below sections:
-1. test_type   -> Kself supported test types.
-2. Size        -> Size of duplicated memory area(in MiB) must be provided using -s option.
-3. Dup_MM_Area -> Size of duplicated memory area (in MiB).
+  Supported <test type>:
+  -M (page merging)
+  -Z (zero pages merging)
+  -N (merging of pages in different NUMA nodes)
+  -U (page unmerging)
+  -C evaluate the time required to break COW of merged pages.
+  -P evaluate merging time and speed.
+     For this test, the size of duplicated memory area (in MiB) must be
+     provided using -s option.
+  -H evaluate merging time and speed of area allocated mostly with huge
+     pages. For this test, the size of duplicated memory area(in MiB)
+     must be provided using -s option
 
-To run the -P and -H test types, the user must pass the value as shown below
-Ex: test_type: "-H"
-    Size: "-s"
-    Dup_MM_Area: "100"
+kernel/kselftest.py.data/ksmtest.yaml contains YAML parameters that can
+be used to control ksm_tests behaviour. The following parameters are to
+be added under vm component. 
+1. subtest     -> To specify ksm_tests
+2. test_type   -> Kself supported test types.
+3. Size        -> Size of duplicated memory area(in MiB) must be provided using -s option.
+4. Dup_MM_Area -> Size of duplicated memory area (in MiB).
+
+To run ksm_tests with -P and -H test types, following section can be added to
+the YAML file
+    vm:
+        comp: "vm"
+        subtest: "ksm_tests"
+        test_type: "-H"
+        Size: "-s"
+        Dup_MM_Area: "100"
 Note: The value of Dup_MM_Area depends on the use case.
 
-To run the M-, -Z, -N, -U and -C test types, the user no need to pass the "Size" and "Dup_MM_Area" parameters.
-Ex: test_type: "-M"
-    Size: ""
-    Dup_MM_Area: ""
+To run with  -M, -Z, -N, -U and -C test types, there is no need to pass the
+"Size" and "Dup_MM_Area" parameters.
+Eample YAML section:
+    vm:
+        comp: "vm"
+        subtest: "ksm_tests"
+        test_type: "-M"
+        Size: ""
+        Dup_MM_Area: ""
+
+Following are few sample YAML inputs that can be used to control KSM and
+other kselftests
+
+To run only ksm_tests with upstream code:
+
+component: !mux
+    vm:
+        comp: "vm"
+        subtest: "ksm_tests"
+        test_type: "-H"
+        Size: "-s"
+        Dup_MM_Area: "100"
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"
+
+To run only a subset of powerpc specific selftests (alignment):
+
+component: !mux
+    power:
+        comp: "powerpc"
+        subtest: 'alignment'
+        kself_args: "summary=1"
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"
+
+To run both ksm_tests and alignment powerpc selftest:
+
+component: !mux
+    power:
+        comp: "powerpc"
+        subtest: "alignment"
+        kself_args: "summary=1"
+    vm:
+        comp: "vm"
+        subtest: "ksm_tests"
+        test_type: "-H"
+        Size: "-s"
+        Dup_MM_Area: "100"
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"
+
+To run entire powerpc specific selftests and ksm_tests:
+
+component: !mux
+    power:
+        comp: "powerpc"
+        kself_args: "summary=1"
+    vm:
+        comp: "vm"
+        subtest: "ksm_tests"
+        test_type: "-H"
+        Size: "-s"
+        Dup_MM_Area: "100"
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"
+

--- a/kernel/kselftest.py.data/kselftest_comp.yaml
+++ b/kernel/kselftest.py.data/kselftest_comp.yaml
@@ -6,42 +6,62 @@ run_type: !mux
         location: "https://github.com/torvalds/linux/archive/master.zip"
 component: !mux
     alignment:
-        comp: 'powerpc/alignment'
+        comp: 'powerpc'
+        subtest: 'alignment'
     benchmarks:
-        comp: 'powerpc/benchmarks'
+        comp: 'powerpc'
+        subtest: 'benchmarks'
     cache_shape:
-        comp: 'powerpc/cache_shape'
+        comp: 'powerpc'
+        subtest: 'cache_shape'
     copyloops:
-        comp: 'powerpc/copyloops'
+        comp: 'powerpc'
+        subtest: 'copyloops'
     dscr:
-       comp: 'powerpc/dscr'
+       comp: 'powerpc'
+       subtest: 'dscr'
     eeh:
-       comp: 'powerpc/eeh'
+       comp: 'powerpc'
+       subtest: 'eeh'
     math:
-       comp: 'powerpc/math'
+       comp: 'powerpc'
+       subtest: 'math'
     mm:
-       comp: 'powerpc/mm'
+       comp: 'powerpc'
+       subtest: 'mm'
     nx-gzip:
-       comp: 'powerpc/nx-gzip'
+       comp: 'powerpc'
+       subtest: 'nx-gzip'
     pmu:
-       comp: 'powerpc/pmu'
+       comp: 'powerpc'
+       subtest: 'pmu/ebb'
     primitives:
-       comp: 'powerpc/primitives'
+       comp: 'powerpc'
+       subtest: 'primitives'
     ptrace:
-       comp: 'powerpc/ptrace'
+       comp: 'powerpc'
+       subtest: 'ptrace'
     scripts:
-       comp: 'powerpc/scripts'
+       comp: 'powerpc'
+       subtest: 'scripts'
     security:
-       comp: 'powerpc/security'
+       comp: 'powerpc'
+       subtest: 'security'
     signal:
-       comp: 'powerpc/signal'
+       comp: 'powerpc'
+       subtest: 'signal'
     stringloops:
-       comp: 'powerpc/stringloops'
+       comp: 'powerpc'
+       subtest: 'stringloops'
     switch_endian:
-       comp: 'powerpc/switch_endian'
+       comp: 'powerpc'
+       subtest: 'switch_endian'
     syscalls:
-       comp: 'powerpc/syscalls'
+       comp: 'powerpc'
+       subtest: 'syscalls'
     tm:
-       comp: 'powerpc/tm'
+       comp: 'powerpc'
+       subtest: 'tm'
     vphn:
-       comp: 'powerpc/vphn'
+       comp: 'powerpc'
+       subtest: 'vphn'

--- a/kernel/kselftest.py.data/ksmtest.yaml
+++ b/kernel/kselftest.py.data/ksmtest.yaml
@@ -1,4 +1,7 @@
 component: !mux
+    vm:
+        comp: "vm"
+        subtest: "ksm_tests"
         test_type: ""
         Size: ""
         Dup_MM_Area: ""


### PR DESCRIPTION
commit 730a557eb457 added support to run ksm_tests which is a subset of
tools/testing/selftests/vm tests. As a side effect running any kernel selftest
also unconditionally pulled in  ksm test.

This 3 patch series introduces a "subtest" YAML key:value pair which can be
used to specify a subset of tests to be executed. This key:value pair parameter
is then used to detect if ksm_tests or any other sub test is to be executed.

[PATCH 1/3] kernel/kselftest: Add support to run subset of kernel selftests
[PATCH 2/3] Update component specific YAML file to reflect subtest
   Update component specific YAML file to reflect the added subtest key value
    pair.
[PATCH 3/3] kernel/kselftest: Update the documentation
    Update the documentation to reflect the usage of newly added subtest
    key value pair. This patch also adds few sample YAML option to control
    behaviour of ksm_test and other kernel selftests.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>