### PR TITLE
Use distro as a default target for toolchain component tests

### DIFF
--- a/toolchain/binutils.py
+++ b/toolchain/binutils.py
@@ -58,7 +58,7 @@ class Binutils(Test):
             needed_deps.extend(['build-essential'])
         for pkg in needed_deps:
             self.check_install(pkg)
-        run_type = self.params.get("type", default="upstream")
+        run_type = self.params.get("type", default="distro")
         # Extract - binutils
         # Source: https://ftp.gnu.org/gnu/binutils/binutils-2.26.tar.bz2
         if run_type == "upstream":

--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -48,7 +48,7 @@ class GDB(Test):
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("Fail to install %s required for this test." %
                             package)
-        test_type = self.params.get('type', default='upstream')
+        test_type = self.params.get('type', default='distro')
         if test_type == 'upstream':
             gdb_version = self.params.get('gdb_version', default='10.2')
             tarball = self.fetch_asset(

--- a/toolchain/glibc.py
+++ b/toolchain/glibc.py
@@ -34,7 +34,7 @@ class Glibc(Test):
         for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        run_type = self.params.get('type', default='upstream')
+        run_type = self.params.get('type', default='distro')
         if run_type == "upstream":
             url = 'https://github.com/bminor/glibc/archive/master.zip'
             tarball = self.fetch_asset("glibc.zip", locations=[url],

--- a/toolchain/libpfm.py
+++ b/toolchain/libpfm.py
@@ -41,7 +41,7 @@ class Libpfm(Test):
         for pkg in pkgs:
             if not softm.check_installed(pkg) and not softm.install(pkg):
                 self.cancel("%s is needed for the test to be run" % pkg)
-        test_type = self.params.get('type', default='upstream')
+        test_type = self.params.get('type', default='distro')
 
         if test_type == 'upstream':
             tarball = self.fetch_asset(

--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -70,7 +70,7 @@ class Ltrace(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel("Fail to install %s required for this test." %
                             package)
-        run_type = self.params.get("type", default="upstream")
+        run_type = self.params.get("type", default="distro")
         if run_type == "upstream":
             source = self.params.get('url', default="https://gitlab.com/"
                                      "cespedes/ltrace.git")

--- a/toolchain/papiTest.py
+++ b/toolchain/papiTest.py
@@ -36,7 +36,7 @@ class papitest(Test):
         for package in ['gcc', 'make']:
             if not softm.check_installed(package) and not softm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
-        test_type = self.params.get('type', default='upstream')
+        test_type = self.params.get('type', default='distro')
 
         if test_type == 'upstream':
             git.get_repo('https://github.com/arm-hpc/papi.git',

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -46,7 +46,7 @@ class Valgrind(Test):
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        run_type = self.params.get('type', default='upstream')
+        run_type = self.params.get('type', default='distro')
         if run_type == "upstream":
             url = "ftp://sourceware.org/pub/valgrind/"
             version = self.params.get('version', default="3.18.1")


### PR DESCRIPTION
A number of tests under toolchain directory has support for
both distro and upstream as a target (as a YAML input).

Lot of these toolchain tests have a dependency on compilers and
libraries installed on the system where they are executed.

In order to avoid test errors due to mismatch in levels being
tested vs what is available on the system, switch to using
distro as the default target for all the applicable tests.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>