### PR TITLE
toolchain/gcc: Fix docbook5 dependency

### DIFF
--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -63,7 +63,7 @@ class GCC(Test):
         if dist.name == 'rhel' and \
            (int(dist.version) == 8 and int(dist.release) >= 6):
             packages.extend(['autogen', 'guile', 'guile-devel',
-                             'isl-devel', 'docbook5-style-xsl'])
+                             'isl-devel', 'docbook-style-xsl'])
 
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
Gcc test case has a dependency on docbook package. The code assumed
docbook5-style-xsl package with RHEL 8.x.

RHEL 8.x ships docbook-style-xsl, fix the code accordingly.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>