### PR TITLE
Fix SoftwareManager import

### DIFF
--- a/cpu/cpuidle-latency.py
+++ b/cpu/cpuidle-latency.py
@@ -21,7 +21,7 @@ import shutil
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import build, distro, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Cpuidle_latency(Test):

--- a/cpu/cpupower_monitor.py
+++ b/cpu/cpupower_monitor.py
@@ -22,7 +22,7 @@ from avocado import skipIf
 from avocado.utils import archive
 from avocado.utils import build, distro
 from avocado.utils import process, cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class CpupowerMonitor(Test):

--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -22,7 +22,7 @@ import multiprocessing
 from random import randint
 from avocado import Test
 from avocado.utils import process, cpu, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 pids = []

--- a/cpu/dwh.py
+++ b/cpu/dwh.py
@@ -21,7 +21,7 @@ import shutil
 
 from avocado import Test
 from avocado.utils import process, build, memory, distro, cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Dwh(Test):

--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -28,7 +28,7 @@ from avocado.utils import archive
 from avocado.utils import distro
 from avocado.utils import process
 from avocado.utils import build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Ebizzy(Test):

--- a/cpu/em_cpufreq.py
+++ b/cpu/em_cpufreq.py
@@ -18,7 +18,7 @@ import platform
 from avocado import Test
 from avocado import skipIf
 from avocado.utils import process, distro, cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
 

--- a/cpu/em_cpuidle.py
+++ b/cpu/em_cpuidle.py
@@ -21,7 +21,7 @@ import platform
 from avocado import Test
 from avocado import skipIf
 from avocado.utils import process, distro, cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
 

--- a/cpu/em_cpupower.py
+++ b/cpu/em_cpupower.py
@@ -19,7 +19,7 @@ import platform
 from avocado import Test
 from avocado import skipIf
 from avocado.utils import process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 # TODO : Logic need to change when we have lib fix

--- a/cpu/em_quad_level_frequency_transitions.py
+++ b/cpu/em_quad_level_frequency_transitions.py
@@ -24,7 +24,7 @@ import re
 from avocado import Test
 from avocado.utils import process, distro, cpu, genio
 from avocado import skipIf
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' not in open('/proc/cpuinfo', 'r').read()
 

--- a/cpu/em_smt_folding_test.py
+++ b/cpu/em_smt_folding_test.py
@@ -22,7 +22,7 @@ from threading import Thread
 from avocado import Test
 from avocado.utils import archive, build
 from avocado.utils import process, cpu, distro, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class SmtFolding(Test):

--- a/cpu/linsched.py
+++ b/cpu/linsched.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, archive, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Linsched(Test):

--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import archive, build, process, distro, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Numactl(Test):

--- a/cpu/numatop.py
+++ b/cpu/numatop.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test, skipIf
 from avocado.utils import archive, build, process, distro, cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER10 = 'POWER10' in open('/proc/cpuinfo', 'r').read()
 

--- a/cpu/pmqa.py
+++ b/cpu/pmqa.py
@@ -21,7 +21,7 @@ import os
 from avocado import Test
 from avocado import skipIf
 from avocado.utils import process, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
 

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -24,7 +24,7 @@ from avocado.utils import process
 from avocado.utils import cpu
 from avocado.utils import distro
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from math import ceil
 
 

--- a/cpu/producer_consumer.py
+++ b/cpu/producer_consumer.py
@@ -22,7 +22,7 @@ import re
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import build, distro, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Producer_Consumer(Test):

--- a/cpu/pvr.py
+++ b/cpu/pvr.py
@@ -22,7 +22,7 @@ import configparser
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/cpu/schbench.py
+++ b/cpu/schbench.py
@@ -20,7 +20,7 @@ import re
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import build, distro, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Schbench(Test):

--- a/cpu/sensors.py
+++ b/cpu/sensors.py
@@ -21,7 +21,7 @@ Test for sensors command
 from avocado import Test
 from avocado import skipIf
 from avocado.utils import process, linux_modules, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 # TODO: Add possible errors of sensors command
 ERRORS = ['I/O error']

--- a/fs/blktests.py
+++ b/fs/blktests.py
@@ -18,7 +18,7 @@ import re
 
 from avocado import Test
 from avocado.utils import process, build, archive, genio, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Blktests(Test):

--- a/fs/filebench.py
+++ b/fs/filebench.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, archive, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Filebench(Test):

--- a/fs/flail.py
+++ b/fs/flail.py
@@ -18,7 +18,7 @@ import re
 
 from avocado import Test
 from avocado.utils import process, build, archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Flail(Test):

--- a/fs/fs-fuzz.py
+++ b/fs/fs-fuzz.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, archive, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class FsFuzz(Test):

--- a/fs/fsx.py
+++ b/fs/fsx.py
@@ -16,7 +16,7 @@
 import os
 from avocado import Test
 from avocado.utils import process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 
 

--- a/fs/pjdfstest.py
+++ b/fs/pjdfstest.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, archive, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Pjdfstest(Test):

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -30,7 +30,7 @@ from avocado import Test
 from avocado.utils import process, build, git, distro, partition
 from avocado.utils import disk, data_structures, pmem
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Xfstests(Test):

--- a/fuzz/fsfuzzer.py
+++ b/fuzz/fsfuzzer.py
@@ -24,7 +24,7 @@ import re
 
 from avocado import Test
 from avocado.utils import archive, build, distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Fsfuzzer(Test):

--- a/fuzz/trinity.py
+++ b/fuzz/trinity.py
@@ -20,7 +20,7 @@ import re
 
 from avocado import Test
 from avocado.utils import archive, build, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Trinity(Test):

--- a/generic/connectathon.py
+++ b/generic/connectathon.py
@@ -25,7 +25,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/generic/criu.py
+++ b/generic/criu.py
@@ -21,7 +21,7 @@ from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import process
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class CRIU(Test):

--- a/generic/cxl.py
+++ b/generic/cxl.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import build, git, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Cxl(Test):

--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -22,7 +22,7 @@ import os
 import time
 import shutil
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import build
 from avocado.utils import process, archive
 from avocado.utils import distro

--- a/generic/interbench.py
+++ b/generic/interbench.py
@@ -24,7 +24,7 @@ from avocado import Test
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build, disk, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Interbench(Test):

--- a/generic/ipistorm.py
+++ b/generic/ipistorm.py
@@ -23,7 +23,7 @@ import platform
 from avocado import Test
 from avocado import skipIf
 from avocado.utils import archive, build, cpu, genio, linux_modules, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo')
 

--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -26,7 +26,7 @@ from avocado.utils import build, distro, genio
 from avocado.utils import process, archive
 from avocado.utils.partition import Partition
 
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 def clear_dmesg():

--- a/generic/openblas.py
+++ b/generic/openblas.py
@@ -20,7 +20,7 @@ import re
 from avocado import Test
 from avocado.utils import build
 from avocado.utils import archive, process, cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/generic/service_check.py
+++ b/generic/service_check.py
@@ -24,7 +24,7 @@ from avocado.utils import process
 from avocado.utils.service import SpecificServiceManager
 from avocado.utils import distro
 from avocado.utils.wait import wait_for
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class service_check(Test):

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -20,7 +20,7 @@ import os
 import multiprocessing
 from avocado import Test
 from avocado.utils import process, build, archive, distro, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 def clear_dmesg():

--- a/generic/stress.py
+++ b/generic/stress.py
@@ -28,7 +28,7 @@ from avocado.utils import disk
 from avocado.utils import build
 from avocado.utils import memory
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Stress(Test):

--- a/generic/stressapptest.py
+++ b/generic/stressapptest.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, cpu, memory, process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class StressAppTest(Test):

--- a/generic/sysbench.py
+++ b/generic/sysbench.py
@@ -18,7 +18,7 @@ import os
 import shutil
 from avocado import Test
 from avocado.utils import process, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Sysbench(Test):

--- a/gpu/gpu.py
+++ b/gpu/gpu.py
@@ -18,7 +18,7 @@ import os
 import shutil
 from avocado import Test, skipUnless
 from avocado.utils import build, process, distro, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
 IS_POWER9 = 'POWER9' in open('/proc/cpuinfo', 'r').read()

--- a/io/common/distro_tools.py
+++ b/io/common/distro_tools.py
@@ -21,7 +21,7 @@ Test the different tools
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import pci
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class DisrtoTool(Test):

--- a/io/common/virtual_bind_unbind.py
+++ b/io/common/virtual_bind_unbind.py
@@ -23,7 +23,7 @@ from avocado.utils import genio
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import disk
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.process import CmdError
 from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.network.hosts import LocalHost

--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -32,7 +32,7 @@ from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils import process, distro
 from avocado.utils.partition import Partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
 
 

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -33,7 +33,7 @@ from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Dbench(Test):

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -29,7 +29,7 @@ from avocado.utils import genio
 from avocado.utils import distro
 from avocado.utils import multipath
 from avocado.utils.partition import Partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.process import CmdError
 from avocado.utils.partition import PartitionError
 

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -31,7 +31,7 @@ from avocado.utils import memory
 from avocado.utils import process, distro
 from avocado.utils import lv_utils
 from avocado.utils.partition import Partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
 
 

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -34,7 +34,7 @@ from avocado.utils import lv_utils
 from avocado.utils import process, distro
 from avocado.utils import softwareraid
 from avocado.utils.partition import Partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
 
 

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -31,7 +31,7 @@ from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils import process, distro
 from avocado.utils.partition import Partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
 
 

--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -21,7 +21,7 @@ HTX Test
 import os
 import time
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import build
 from avocado.utils import process, archive
 from avocado.utils import distro

--- a/io/disk/ioping.py
+++ b/io/disk/ioping.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, archive, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Ioping(Test):

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -37,7 +37,7 @@ from avocado.utils.partition import Partition
 from avocado.utils import data_structures
 from avocado.utils import astring
 from avocado.utils.partition import PartitionError
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 _LABELS = ['file_size', 'record_size', 'write', 'rewrite', 'read', 'reread',

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -30,7 +30,7 @@ from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils import build, distro
 from avocado.utils import process, archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
 

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -29,7 +29,7 @@ from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils import distro
 from avocado.utils import process, archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
 

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -32,7 +32,7 @@ import os
 
 import avocado
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import lv_utils
 from avocado.utils import distro
 from avocado.utils import disk

--- a/io/disk/multipath_test.py
+++ b/io/disk/multipath_test.py
@@ -29,7 +29,7 @@ from avocado.utils import distro, process
 from avocado.utils import multipath
 from avocado.utils import service
 from avocado.utils import wait
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class MultipathTest(Test):

--- a/io/disk/rawread.py
+++ b/io/disk/rawread.py
@@ -23,7 +23,7 @@ from avocado import Test
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Rawread(Test):

--- a/io/disk/scsi_add_remove.py
+++ b/io/disk/scsi_add_remove.py
@@ -21,7 +21,7 @@ This script will perform scsi add and remove test case
 import time
 from avocado import Test
 from avocado.utils import process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import multipath
 from avocado.utils import pci
 

--- a/io/disk/smartctl.py
+++ b/io/disk/smartctl.py
@@ -23,7 +23,7 @@ hard drives and solid-state drives
 """
 
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import process
 
 

--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -26,7 +26,7 @@ failure.
 """
 
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import softwareraid
 
 

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -31,7 +31,7 @@ from avocado.utils import disk
 from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils import process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
 

--- a/io/driver/driver_bind_test.py
+++ b/io/driver/driver_bind_test.py
@@ -24,7 +24,7 @@ import time
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import pci
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class DriverBindTest(Test):

--- a/io/driver/module_unload_load.py
+++ b/io/driver/module_unload_load.py
@@ -19,7 +19,7 @@ import time
 import os
 from avocado.utils import process
 from avocado.utils import linux_modules, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import pci
 from avocado import Test
 

--- a/io/genwqe/genwqetest.py
+++ b/io/genwqe/genwqetest.py
@@ -24,7 +24,7 @@ import time
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import download
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class GenWQETest(Test):

--- a/io/net/Network_config.py
+++ b/io/net/Network_config.py
@@ -20,7 +20,7 @@
 
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import process
 from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.network.hosts import LocalHost

--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -29,7 +29,7 @@ import fcntl
 import struct
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 from avocado.utils import process
 from avocado.utils import linux_modules

--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -24,7 +24,7 @@ This test needs to be run as root.
 
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.network.interfaces import NetworkInterface

--- a/io/net/htx_nic_devices.py
+++ b/io/net/htx_nic_devices.py
@@ -25,7 +25,7 @@ except ImportError:
 from avocado import Test
 from avocado.utils import distro
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import build
 from avocado.utils import archive
 from avocado.utils.process import CmdError

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -22,7 +22,7 @@ bandwidth on IP networks.
 import os
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import build
 from avocado.utils import archive
 from avocado.utils import process

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -21,7 +21,7 @@
 
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.ssh import Session
 from avocado.utils import process
 from avocado.utils import distro

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -16,7 +16,7 @@
 
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.network.interfaces import NetworkInterface

--- a/io/net/net_tools.py
+++ b/io/net/net_tools.py
@@ -23,7 +23,7 @@ import avocado
 from avocado import Test
 from avocado import skipUnless
 from avocado.utils import process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 release = "%s%s" % (distro.detect().name, distro.detect().version)
 

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -25,7 +25,7 @@ unidirectional throughput, and end-to-end latency.
 import os
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 from avocado.utils import build
 from avocado.utils import archive

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -25,7 +25,7 @@ import os
 import hashlib
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils import genio

--- a/io/net/sriov_device_test.py
+++ b/io/net/sriov_device_test.py
@@ -24,7 +24,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils.ssh import Session
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.network.hosts import LocalHost
 

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -25,7 +25,7 @@ from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils import archive
 from avocado.utils import build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.network.hosts import LocalHost, RemoteHost
 from avocado.utils import wait

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -23,7 +23,7 @@ workload profiles
 import os
 import netifaces
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 from avocado.utils import build
 from avocado.utils import archive

--- a/io/nvmf/nvmftest.py
+++ b/io/nvmf/nvmftest.py
@@ -26,7 +26,7 @@ import copy
 import time
 from avocado import Test
 from avocado.utils import process, linux_modules, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.ssh import Session
 from avocado.utils.process import CmdError
 import yaml

--- a/io/pci/EEH.py
+++ b/io/pci/EEH.py
@@ -26,7 +26,7 @@ from avocado.utils import pci
 from avocado.utils import genio
 from avocado.utils import distro
 from avocado.utils import dmesg
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 EEH_HIT = 0
 EEH_MISS = 1

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -26,7 +26,7 @@ from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils.ssh import Session
 from avocado.utils import pci
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.process import CmdError
 
 

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -26,7 +26,7 @@ import platform
 from avocado import Test
 from avocado.utils import wait, multipath
 from avocado.utils import linux_modules, genio, pci
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.network.hosts import LocalHost
 

--- a/io/pci/pci_info_lsvpd.py
+++ b/io/pci/pci_info_lsvpd.py
@@ -20,7 +20,7 @@ Needs to be run as root.
 """
 
 from avocado import Test
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import pci
 from avocado.utils import process
 

--- a/kernel/kernbench.py
+++ b/kernel/kernbench.py
@@ -28,7 +28,7 @@ from avocado.utils import process
 from avocado.utils import cpu
 from avocado.utils import distro
 from avocado.utils import archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Kernbench(Test):

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -23,7 +23,7 @@ from avocado import Test
 from avocado.utils import build, process
 from avocado.utils import distro
 from avocado.utils import archive, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class kselftest(Test):

--- a/kernel/livepatch.py
+++ b/kernel/livepatch.py
@@ -24,7 +24,7 @@ from avocado.utils import process
 from avocado.utils import linux_modules
 from avocado.utils import genio
 from avocado.utils import dmesg
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Livepatch(Test):

--- a/kernel/posixtest.py
+++ b/kernel/posixtest.py
@@ -24,7 +24,7 @@ from avocado import Test
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Posixtest(Test):

--- a/kernel/rmaptest.py
+++ b/kernel/rmaptest.py
@@ -24,7 +24,7 @@ import shutil
 
 from avocado import Test
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Rmaptest(Test):

--- a/kernel/tlbflush.py
+++ b/kernel/tlbflush.py
@@ -21,7 +21,7 @@ import json
 
 from avocado import Test
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Tlbflush(Test):

--- a/memory/eatmemory.py
+++ b/memory/eatmemory.py
@@ -20,7 +20,7 @@ from avocado.utils import build
 from avocado.utils import memory
 from avocado.utils import process
 from avocado.utils import archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class EatMemory(Test):

--- a/memory/fork_mem.py
+++ b/memory/fork_mem.py
@@ -20,7 +20,7 @@ import os
 import shutil
 from avocado import Test
 from avocado.utils import process, build, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Forkoff(Test):

--- a/memory/hugepage_sanity.py
+++ b/memory/hugepage_sanity.py
@@ -21,7 +21,7 @@ import shutil
 from avocado import Test
 from avocado import skipUnless
 from avocado.utils import process, build, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class HugepageSanity(Test):

--- a/memory/integrity.py
+++ b/memory/integrity.py
@@ -21,7 +21,7 @@ import shutil
 
 from avocado import Test
 from avocado.utils import process, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/memory/ksm_poison.py
+++ b/memory/ksm_poison.py
@@ -21,7 +21,7 @@ import shutil
 
 from avocado import Test
 from avocado.utils import process, build, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class KsmPoison(Test):

--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -29,7 +29,7 @@ from avocado.utils import git
 from avocado.utils import distro
 from avocado.utils import genio
 from avocado.utils import memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class LibHugetlbfs(Test):

--- a/memory/memcached.py
+++ b/memory/memcached.py
@@ -19,7 +19,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import memory
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Memcached(Test):

--- a/memory/memhog.py
+++ b/memory/memhog.py
@@ -21,7 +21,7 @@ import shutil
 import avocado
 from avocado import Test
 from avocado.utils import process, memory, distro, pmem, disk, partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class MemoHog(Test):

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -20,7 +20,7 @@ import platform
 import multiprocessing
 from avocado import Test
 from avocado.utils import process, memory, build, archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 MEM_PATH = '/sys/devices/system/memory'

--- a/memory/memory_api.py
+++ b/memory/memory_api.py
@@ -24,7 +24,7 @@ import os
 import shutil
 from avocado import Test
 from avocado.utils import process, build, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class MemorySyscall(Test):

--- a/memory/memtester.py
+++ b/memory/memtester.py
@@ -18,7 +18,7 @@
 import os
 from avocado import Test
 from avocado.utils import process, build, memory, archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Memtester(Test):

--- a/memory/migrate_pages.py
+++ b/memory/migrate_pages.py
@@ -21,7 +21,7 @@ import shutil
 
 from avocado import Test
 from avocado.utils import process, build, memory, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class MigratePages(Test):

--- a/memory/mm_subsystem.py
+++ b/memory/mm_subsystem.py
@@ -21,7 +21,7 @@ from avocado.utils import memory
 from avocado.utils import process
 from avocado.utils import git
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class MmSubsystemTest(Test):

--- a/memory/mprotect.py
+++ b/memory/mprotect.py
@@ -22,7 +22,7 @@ import shutil
 import avocado
 from avocado import Test
 from avocado.utils import process, build, memory, distro, pmem, partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Mprotect(Test):

--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -36,7 +36,7 @@ from avocado.utils import partition
 from avocado.utils import pmem
 from avocado.utils import git
 from avocado.utils.git import GitRepoHelper
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class NdctlTest(Test):

--- a/memory/ndctl_selftest.py
+++ b/memory/ndctl_selftest.py
@@ -21,7 +21,7 @@ import json
 
 from avocado import Test
 from avocado.utils import process, build, distro, git, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class NdctlTest(Test):

--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -22,7 +22,7 @@ import shutil
 from avocado import Test
 from avocado import skipIf
 from avocado.utils import process, build, memory, distro, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 SINGLE_NODE = len(memory.numa_nodes_with_memory()) < 2
 

--- a/memory/pmem_dm.py
+++ b/memory/pmem_dm.py
@@ -25,7 +25,7 @@ import avocado
 from avocado import Test
 from avocado.utils import process, archive, distro, build
 from avocado.utils import genio, pmem, disk, memory, partition
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PmemDeviceMapper(Test):

--- a/memory/pmem_dt_check.py
+++ b/memory/pmem_dt_check.py
@@ -30,7 +30,7 @@ from avocado.utils import build
 from avocado.utils import genio
 from avocado.utils import pmem
 from avocado.utils import cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class NdctlDeviceTreeCheck(Test):

--- a/memory/soft_dirty.py
+++ b/memory/soft_dirty.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class SoftDirtyBits(Test):

--- a/memory/stutter.py
+++ b/memory/stutter.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, archive, memory, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Stutter(Test):

--- a/memory/vatest.py
+++ b/memory/vatest.py
@@ -21,7 +21,7 @@ import shutil
 
 from avocado import Test
 from avocado.utils import process, build, memory, genio, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class VATest(Test):

--- a/nx_gzip/nx_gzip.py
+++ b/nx_gzip/nx_gzip.py
@@ -18,7 +18,7 @@ import os
 import shutil
 from avocado import Test, skipUnless
 from avocado.utils import build, process, distro, git, archive, memory
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()

--- a/perf/aiostress.py
+++ b/perf/aiostress.py
@@ -24,7 +24,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Aiostress(Test):

--- a/perf/blogbench.py
+++ b/perf/blogbench.py
@@ -17,7 +17,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.core import data_dir
 
 

--- a/perf/hackbench.py
+++ b/perf/hackbench.py
@@ -24,7 +24,7 @@ import json
 
 from avocado import Test
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Hackbench(Test):

--- a/perf/libunwind.py
+++ b/perf/libunwind.py
@@ -19,7 +19,7 @@ import re
 
 from avocado import Test
 from avocado.utils import archive, build, distro, process, cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Libunwind(Test):

--- a/perf/lmbench.py
+++ b/perf/lmbench.py
@@ -25,7 +25,7 @@ from avocado import Test
 from avocado.utils import archive
 from avocado.utils import process
 from avocado.utils import build, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Lmbench(Test):

--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -18,7 +18,7 @@ import os
 import platform
 from avocado import Test
 from avocado.utils import cpu, distro, memory, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class hv_24x7_all_events(Test):

--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -20,7 +20,7 @@ import re
 import platform
 from avocado import Test
 from avocado.utils import process, distro, cpu, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado import skipIf
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')

--- a/perf/perf_UDT_probes.py
+++ b/perf/perf_UDT_probes.py
@@ -19,7 +19,7 @@ import platform
 import shutil
 from avocado import Test
 from avocado.utils import distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfProbe(Test):

--- a/perf/perf_basic.py
+++ b/perf/perf_basic.py
@@ -19,7 +19,7 @@ import tempfile
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfBasic(Test):

--- a/perf/perf_bench.py
+++ b/perf/perf_bench.py
@@ -17,7 +17,7 @@
 import platform
 from avocado import Test
 from avocado.utils import distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class perf_bench(Test):

--- a/perf/perf_c2c.py
+++ b/perf/perf_c2c.py
@@ -19,7 +19,7 @@ import platform
 import tempfile
 from avocado import Test
 from avocado.utils import distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class perf_c2c(Test):

--- a/perf/perf_core_imc_non_zero_event.py
+++ b/perf/perf_core_imc_non_zero_event.py
@@ -19,7 +19,7 @@ from avocado import skipUnless
 from avocado.utils import process
 from avocado.utils import distro
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')
 

--- a/perf/perf_cpu_hotplug.py
+++ b/perf/perf_cpu_hotplug.py
@@ -18,7 +18,7 @@ import os
 import platform
 from avocado import Test
 from avocado.utils import cpu, dmesg, distro, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado import skipIf
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')

--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -17,7 +17,7 @@
 import platform
 from avocado import Test
 from avocado.utils import distro, genio, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfProbe(Test):

--- a/perf/perf_events_crash_test.py
+++ b/perf/perf_events_crash_test.py
@@ -19,7 +19,7 @@ import platform
 import os
 from avocado import Test
 from avocado.utils import archive, build, process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Perf_crashevent(Test):

--- a/perf/perf_events_test.py
+++ b/perf/perf_events_test.py
@@ -19,7 +19,7 @@ import platform
 import os
 from avocado import Test
 from avocado.utils import archive, build, process, distro, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Perf_subsystem(Test):

--- a/perf/perf_fuzzer.py
+++ b/perf/perf_fuzzer.py
@@ -19,7 +19,7 @@ import platform
 import os
 from avocado import Test
 from avocado.utils import archive, build, process, distro, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Perffuzzer(Test):

--- a/perf/perf_hv_gpci.py
+++ b/perf/perf_hv_gpci.py
@@ -17,7 +17,7 @@
 import platform
 from avocado import Test
 from avocado.utils import distro, process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class perf_hv_gpci(Test):

--- a/perf/perf_invalid_flag_test.py
+++ b/perf/perf_invalid_flag_test.py
@@ -17,7 +17,7 @@ import os
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfInvalid(Test):

--- a/perf/perf_metric.py
+++ b/perf/perf_metric.py
@@ -17,7 +17,7 @@
 import platform
 from avocado import Test
 from avocado.utils import distro, dmesg, genio, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')
 

--- a/perf/perf_nest_events.py
+++ b/perf/perf_nest_events.py
@@ -17,7 +17,7 @@
 import platform
 from avocado import Test
 from avocado.utils import cpu, distro, genio, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class nestEvents(Test):

--- a/perf/perf_nmem.py
+++ b/perf/perf_nmem.py
@@ -18,7 +18,7 @@ import re
 import platform
 from avocado import Test
 from avocado.utils import cpu, dmesg, distro, genio, linux_modules, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class perfNMEM(Test):

--- a/perf/perf_pcp.py
+++ b/perf/perf_pcp.py
@@ -16,7 +16,7 @@
 import os
 from avocado import Test
 from avocado.utils import cpu, distro, genio, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PCP(Test):

--- a/perf/perf_rawevents.py
+++ b/perf/perf_rawevents.py
@@ -19,7 +19,7 @@ import platform
 import shutil
 from avocado import Test
 from avocado.utils import cpu, distro, process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfRawevents(Test):

--- a/perf/perf_script_bug.py
+++ b/perf/perf_script_bug.py
@@ -20,7 +20,7 @@ import shutil
 import configparser
 from avocado import Test
 from avocado.utils import build, distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfProbe(Test):

--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -22,7 +22,7 @@ import tempfile
 from avocado import Test
 from avocado.utils import distro
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfSDT(Test):

--- a/perf/perf_uprobe.py
+++ b/perf/perf_uprobe.py
@@ -20,7 +20,7 @@ import shutil
 import tempfile
 from avocado import Test
 from avocado.utils import build, distro, process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PerfUprobe(Test):

--- a/perf/perf_watch_point.py
+++ b/perf/perf_watch_point.py
@@ -20,7 +20,7 @@ from avocado import Test
 from avocado import skipUnless
 from avocado.utils import archive
 from avocado.utils import cpu, build, distro, process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER8 = 'power8' in cpu.get_family()
 

--- a/perf/perfmon.py
+++ b/perf/perfmon.py
@@ -19,7 +19,7 @@ import os
 
 from avocado import Test
 from avocado.utils import process, build, git, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Perfmon(Test):

--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -18,7 +18,7 @@ import os
 import platform
 from avocado import Test
 from avocado.utils import archive, build, distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Perftool(Test):

--- a/perf/rt_tests.py
+++ b/perf/rt_tests.py
@@ -27,7 +27,7 @@ from avocado import Test
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/perf/tbench.py
+++ b/perf/tbench.py
@@ -25,7 +25,7 @@ from avocado import Test
 from avocado.utils import archive, cpu
 from avocado.utils import process
 from avocado.utils import build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class tbench(Test):

--- a/perf/trace.py
+++ b/perf/trace.py
@@ -19,7 +19,7 @@ import os
 
 from avocado import Test
 from avocado.utils import distro, process, archive, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Linuxtrace(Test):

--- a/perf/unixbench.py
+++ b/perf/unixbench.py
@@ -23,7 +23,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.core import data_dir
 
 

--- a/ras/ServiceReport.py
+++ b/ras/ServiceReport.py
@@ -18,7 +18,7 @@ import os
 from avocado import Test
 from avocado.utils import process, build
 from avocado.utils import archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class ServiceReport(Test):

--- a/ras/diag_encl.py
+++ b/ras/diag_encl.py
@@ -20,7 +20,7 @@ import xml.etree.ElementTree
 from avocado import Test, skipIf
 from avocado.utils import process, distro
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()
 

--- a/ras/errinjct.py
+++ b/ras/errinjct.py
@@ -15,7 +15,7 @@
 
 from avocado import Test
 from avocado.utils import process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado import skipIf
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')

--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Hwinfo(Test):

--- a/ras/kdump.py
+++ b/ras/kdump.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     raise ImportError('Could not import virttest')
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class KDUMP(Test):

--- a/ras/kdump_nfs.py
+++ b/ras/kdump_nfs.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     raise ImportError('Could not import virttest')
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class KDUMP(Test):

--- a/ras/kprobe.py
+++ b/ras/kprobe.py
@@ -22,7 +22,7 @@ from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import process
 from avocado.utils import linux_modules
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Kprobe(Test):

--- a/ras/kretprobe.py
+++ b/ras/kretprobe.py
@@ -20,7 +20,7 @@ from avocado import Test
 from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Kretprobe(Test):

--- a/ras/lparnumascore.py
+++ b/ras/lparnumascore.py
@@ -16,7 +16,7 @@
 
 from avocado import Test
 from avocado.utils import process, genio, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado import skipIf
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')

--- a/ras/lparstat.py
+++ b/ras/lparstat.py
@@ -17,7 +17,7 @@
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class lparstat(Test):

--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -17,7 +17,7 @@ from avocado import Test
 from avocado import skipIf
 from avocado.utils import process
 from avocado.utils import genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/ras/packages.py
+++ b/ras/packages.py
@@ -16,7 +16,7 @@
 
 from avocado import Test
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Package_check(Test):

--- a/ras/pstore.py
+++ b/ras/pstore.py
@@ -19,7 +19,7 @@ import os
 from avocado import Test
 from virttest import remote
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PSTORE(Test):

--- a/ras/ras.py
+++ b/ras/ras.py
@@ -19,7 +19,7 @@ from shutil import copyfile
 from avocado import Test
 from avocado.utils import process, distro
 from avocado import skipIf, skipUnless
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
 IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()

--- a/ras/ras_extended.py
+++ b/ras/ras_extended.py
@@ -19,7 +19,7 @@ import shutil
 from avocado import Test
 from avocado.utils import process, distro
 from avocado import skipIf
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
 IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()

--- a/ras/ras_tools.py
+++ b/ras/ras_tools.py
@@ -15,7 +15,7 @@
 
 from avocado import Test
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Ras_tools(Test):

--- a/ras/rtas_dbg.py
+++ b/ras/rtas_dbg.py
@@ -16,7 +16,7 @@
 
 from avocado import Test
 from avocado.utils import process, genio
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado import skipIf
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')

--- a/ras/servicelog.py
+++ b/ras/servicelog.py
@@ -20,7 +20,7 @@ import os
 from avocado import Test
 from avocado.utils import process
 from avocado.utils.service import ServiceManager
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class servicelog(Test):

--- a/ras/smtstate.py
+++ b/ras/smtstate.py
@@ -15,7 +15,7 @@
 
 from avocado import Test
 from avocado.utils import process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class smtstate_tool(Test):

--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -21,7 +21,7 @@ from avocado import Test
 from avocado import skipIf
 from avocado.utils import process
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Sosreport(Test):

--- a/ras/supportconfig.py
+++ b/ras/supportconfig.py
@@ -20,7 +20,7 @@ import shutil
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Supportconfig(Test):

--- a/ras/uprobe.py
+++ b/ras/uprobe.py
@@ -18,7 +18,7 @@ from avocado import Test
 from avocado.utils import genio
 from avocado.utils import distro
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Uprobe(Test):

--- a/security/annobin-tests.py
+++ b/security/annobin-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import build, distro, git, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class annobin(Test):

--- a/security/audit-tests.py
+++ b/security/audit-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Audit(Test):

--- a/security/cryptsetup-tests.py
+++ b/security/cryptsetup-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import build, distro, git, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class CryptSetup(Test):

--- a/security/evmctl-tests.py
+++ b/security/evmctl-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class EvmCtl(Test):

--- a/security/keyutils-tests.py
+++ b/security/keyutils-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import build, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class KeyUtils(Test):

--- a/security/krb5-tests.py
+++ b/security/krb5-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Krb5(Test):

--- a/security/libgcrypt-tests.py
+++ b/security/libgcrypt-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import build, distro, git, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class libgcrypt(Test):

--- a/security/libkcapi-tests.py
+++ b/security/libkcapi-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class LibKCAPI(Test):

--- a/security/libkmip-tests.py
+++ b/security/libkmip-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class libkmip(Test):

--- a/security/nettle-tests.py
+++ b/security/nettle-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Nettle(Test):

--- a/security/openssh-tests.py
+++ b/security/openssh-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class OpenSSH(Test):

--- a/security/openssl-tests.py
+++ b/security/openssl-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class OpenSSL(Test):

--- a/security/pam-tests.py
+++ b/security/pam-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PAM(Test):

--- a/security/seccomp-tests.py
+++ b/security/seccomp-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class SecComp(Test):

--- a/security/selinux-tests.py
+++ b/security/selinux-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, distro, linux
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class SELinux(Test):

--- a/security/xmlsec-tests.py
+++ b/security/xmlsec-tests.py
@@ -17,7 +17,7 @@
 import os
 from avocado import Test
 from avocado.utils import archive, build, distro, process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class XMLSec(Test):

--- a/toolchain/atlas.py
+++ b/toolchain/atlas.py
@@ -17,7 +17,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 from avocado.core import data_dir
 

--- a/toolchain/bcc.py
+++ b/toolchain/bcc.py
@@ -20,7 +20,7 @@ import os
 
 from avocado import Test
 from avocado.utils import archive, build, process, distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Bcc(Test):

--- a/toolchain/binutils.py
+++ b/toolchain/binutils.py
@@ -28,7 +28,7 @@ from avocado.utils import build
 from avocado.utils import process
 from avocado.utils import distro
 
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Binutils(Test):

--- a/toolchain/gcc.py
+++ b/toolchain/gcc.py
@@ -22,7 +22,7 @@ from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class GCC(Test):

--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -21,7 +21,7 @@ from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import distro
 from avocado.utils import process
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class GDB(Test):

--- a/toolchain/glibc.py
+++ b/toolchain/glibc.py
@@ -17,7 +17,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.core import data_dir
 
 

--- a/toolchain/gsl.py
+++ b/toolchain/gsl.py
@@ -18,7 +18,7 @@ import re
 import os
 from avocado import Test
 from avocado.utils import archive, process, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class GSL(Test):

--- a/toolchain/libpfm.py
+++ b/toolchain/libpfm.py
@@ -19,7 +19,7 @@ import os
 from avocado.utils import process
 from avocado import Test
 from avocado.utils import build, distro, archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Libpfm(Test):

--- a/toolchain/libvecpf.py
+++ b/toolchain/libvecpf.py
@@ -20,7 +20,7 @@ import re
 
 from avocado import Test
 from avocado.utils import build, archive
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Libvecpf(Test):

--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -28,7 +28,7 @@ from avocado.utils import process
 from avocado.utils import git
 from avocado.utils import distro
 
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Ltrace(Test):

--- a/toolchain/oprofile.py
+++ b/toolchain/oprofile.py
@@ -19,7 +19,7 @@ import os
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/toolchain/papiTest.py
+++ b/toolchain/papiTest.py
@@ -19,7 +19,7 @@ import os
 from avocado.utils import process
 from avocado import Test
 from avocado.utils import git, build
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class papitest(Test):

--- a/toolchain/power_time_base_bug.py
+++ b/toolchain/power_time_base_bug.py
@@ -18,7 +18,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class PowerTimeBaseBug(Test):

--- a/toolchain/strace.py
+++ b/toolchain/strace.py
@@ -19,7 +19,7 @@ import re
 
 from avocado import Test
 from avocado.utils import build, process, git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Strace(Test):

--- a/toolchain/systemtap.py
+++ b/toolchain/systemtap.py
@@ -23,7 +23,7 @@ from avocado import Test
 from avocado.utils import build
 from avocado.utils import process
 from avocado.utils import git
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
 
 

--- a/toolchain/valgrind.py
+++ b/toolchain/valgrind.py
@@ -18,7 +18,7 @@ from avocado.utils import process
 from avocado.utils import build
 from avocado.utils import archive
 from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Valgrind(Test):


### PR DESCRIPTION
software_manager/__init__.py is empty now (https://github.com/avocado-framework/avocado/commit/1b8360c7ffb0e6874eb4f9cdb9c593337482bbd4) so imports don't work.

Let's change them to match examples:

https://github.com/avocado-framework/avocado/commit/1b8360c7ffb0e6874eb4f9cdb9c593337482bbd4#diff-759aaf7d53119997ec7909dc4710a0ab2191335bcebd30347b0e03bc2f4c61b8