### PR TITLE
Fix confusing failure messages in ppc cpu tests launched on non-ppc arch

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -298,7 +298,8 @@ class cpustresstest(Test):
         Sets back SMT to original value as was before the test.
         Sets back cpu states to online
         """
-        process.system_output(
-            "ppc64_cpu --smt=off && ppc64_cpu --smt=on && ppc64_cpu --smt=%s"
-            % self.curr_smt, shell=True)
+        if hasattr(self, 'curr_smt'):
+            process.system_output(
+                "ppc64_cpu --smt=off && ppc64_cpu --smt=on && ppc64_cpu --smt=%s"
+                % self.curr_smt, shell=True)
         self.__online_cpus(totalcpus)

--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -169,6 +169,7 @@ class PPC64Test(Test):
         """
         Sets back SMT to original value as was before the test.
         """
-        process.system_output("%s=%s" % (self.smt_str,
-                                         self.curr_smt), shell=True)
-        process.system_output("dmesg")
+        if hasattr(self, 'smt_str'):
+            process.system_output("%s=%s" % (self.smt_str,
+                                             self.curr_smt), shell=True)
+            process.system_output("dmesg")


### PR DESCRIPTION
confusing message when running on other arch - such as 'PPC64Test object doesn't have curr_smt attribute'.

This comes from the fact that we cancel the test in the setUp routine before initializaing the variables but then we use these variables in the tearDown.

This commits fix ppc cpu tests to check necessary attributes before using them in the tearDown.

Signed-off-by: Denis Silakov <dsilakov@gmail.com>