### PR TITLE
fix xfstest userdel error

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -468,8 +468,8 @@ class Xfstests(Test):
 
     def tearDown(self):
         if self.detected_distro.name is not 'SuSE':
-            process.system('userdel 123456-fsgqa', sudo=True)
-            process.system('userdel fsgqa', sudo=True)
+            process.system('userdel -f 123456-fsgqa', sudo=True)
+            process.system('userdel -f fsgqa', sudo=True)
         else:
             process.system('userdel -r -f fsgqa', sudo=True)
             process.system('groupdel fsgqa', sudo=True)


### PR DESCRIPTION
fixed userdel error while running xfstests.py

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner xfstests.py -m xfstests.py.data/xfstests_ext4.yaml 
JOB ID     : fb82f1886d1220a568ab70274d2870758f3ae56f
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-05-25T17.59-fb82f18/job.log
 (1/1) xfstests.py:Xfstests.test;run-setup-fs_type-fs_ext4-loop_type-disk-e481: PASS (106.44 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-05-25T17.59-fb82f18/results.html
JOB TIME   : 115.42 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8771156/job.log)