### PR TITLE
Fix unclear failure messages when running tests on unsupported OS (Ubuntu)

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -1008,15 +1008,16 @@ class NdctlTest(Test):
 
     @avocado.fail_on(pmem.PMemException)
     def tearDown(self):
-        if self.part:
+        if hasattr(self, 'part') and self.part:
             self.part.unmount()
-        if self.disk:
+        if hasattr(self, 'disk') and self.disk:
             self.log.info("Removing the FS meta created on %s", self.disk)
             delete_fs = "dd if=/dev/zero bs=1M count=1024 of=%s" % self.disk
             if process.system(delete_fs, shell=True, ignore_status=True):
                 self.fail("Failed to delete filesystem on %s" % self.disk)
 
-        if not self.preserve_setup:
-            if self.plib.run_ndctl_list('-N'):
-                self.plib.destroy_namespace(force=True)
-            self.plib.disable_region()
+        if hasattr(self, 'preserve_setup') and not self.preserve_setup:
+            if hasattr(self, 'plib'):
+                if self.plib.run_ndctl_list('-N'):
+                    self.plib.destroy_namespace(force=True)
+                self.plib.disable_region()

--- a/memory/pmem_dm.py
+++ b/memory/pmem_dm.py
@@ -202,8 +202,9 @@ class PmemDeviceMapper(Test):
 
     @avocado.fail_on(pmem.PMemException)
     def tearDown(self):
-        self.part.unmount()
-        if not self.preserve_dm:
+        if hasattr(self, 'part'):
+            self.part.unmount()
+        if not self.preserve_dm and hasattr(self, 'plib'):
             process.system('dmsetup remove linear-pmem',
                            sudo=True, ignore_status=True)
             self.plib.destroy_namespace(force=True)

--- a/memory/pmem_dt_check.py
+++ b/memory/pmem_dt_check.py
@@ -171,5 +171,5 @@ class NdctlDeviceTreeCheck(Test):
 
     @avocado.fail_on(pmem.PMemException)
     def tearDown(self):
-        if self.plib:
+        if hasattr(self, 'plib') and self.plib:
             self.plib.disable_region()

--- a/ras/lparstat.py
+++ b/ras/lparstat.py
@@ -37,6 +37,8 @@ class lparstat(Test):
             package = "powerpc-utils"
         elif 'rhel' in detected_distro.name:
             package = "powerpc-utils-core"
+        else:
+            self.cancel('Unsupported OS %s' % detected_distro.name)
 
         if not sm.check_installed(package) and not sm.install(package):
             self.cancel("Failed to install %s" % package)

--- a/security/selinux-tests.py
+++ b/security/selinux-tests.py
@@ -35,6 +35,7 @@ class SELinux(Test):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         deps = ['gcc', 'make']
+        self.sourcedir = None
         if detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos',
                                     'redhat']:
             deps.extend(["perl-Test", "perl-Test-Harness", "perl-Test-Simple",
@@ -79,4 +80,5 @@ class SELinux(Test):
             self.fail("%s test(s) failed, please refer to the log" % count)
 
     def tearDown(self):
-        build.make(self.sourcedir, extra_args='-C policy unload')
+        if self.sourcedir:
+            build.make(self.sourcedir, extra_args='-C policy unload')


### PR DESCRIPTION
Some tests are only intended for RHEL / SLES, and produce confusing failure messagescaused by the fact that some variables are not initialized in setUp but used in the tearDown (so we get an missing attribute Exception instead of a clear statement about unsupported system).

Proposed solution is like the following:

- In memory/pmem* and ndctl, let's check if we have corresponding attributes set before trying to use them
- In selinux-tests, we can initiate the problematic variable to None in the beginning and then use it only if it is not empty
- ras/lparstat is just missing explicit test cancelation for the OS other than rhel/suse.

Signed-off-by: Denis Silakov <dsilakov@gmail.com>