### PR TITLE
enhance perftool

### DIFF
--- a/perf/perftool.py
+++ b/perf/perftool.py
@@ -60,27 +60,30 @@ class Perftool(Test):
         self.sourcedir = os.path.join(self.workdir,
                                       'perftool-testsuite-master')
 
-    def test(self):
+    def test_perf_test(self):
         '''
-        1.perf test :Does sanity tests and
-          execute the tests by calling each module
-        2.Build perftool Test
-          Source:
-          https://github.com/rfmvh/perftool-testsuite
+        perf test: Does sanity tests and
+        execute the tests by calling each module
         '''
         count = 0
-        # Built in perf test
         for string in process.run("perf test", ignore_status=True).stderr.decode("utf-8").splitlines():
             if 'FAILED' in string:
-                self.log.info("Test case failed is %s" % string)
+                count += 1
+                self.log.info(string)
+        if count > 0:
+            self.fail("%s Test failed" % count)
 
-        # perf testsuite
+    def test_perf_testsuite(self):
+        '''
+        Build perftool Test
+        Source: https://github.com/rfmvh/perftool-testsuite
+        '''
+        count = 0
         for line in build.run_make(self.sourcedir, extra_args='check',
                                    process_kwargs={'ignore_status': True}
                                    ).stdout.decode("utf-8").splitlines():
             if '-- [ FAIL ] --' in line:
                 count += 1
                 self.log.info(line)
-
         if count > 0:
             self.fail("%s Test failed" % count)


### PR DESCRIPTION
fixed perftool test case by spliting two tests
and showing correct status

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner perftool.py 
Fetching asset from perftool.py:Perftool.test_perf_test
Fetching asset from perftool.py:Perftool.test_perf_testsuite
JOB ID     : 3ddb12794843ac2f3dddf339aed7ebcb2b8d5757
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-05-25T22.49-3ddb127/job.log
 (1/2) perftool.py:Perftool.test_perf_test: FAIL: 2 Test failed (53.99 s)
 (2/2) perftool.py:Perftool.test_perf_testsuite: FAIL: 2 Test failed (303.74 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-05-25T22.49-3ddb127/results.html
JOB TIME   : 366.50 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8773645/job.log)