### PR TITLE
Avoid exceptions in tearDown of io and perf tests when canceling

### DIFF
--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -51,9 +51,9 @@ class DiskInfo(Test):
         """
         smm = SoftwareManager()
         pkg = ""
+        self.disk = self.params.get('disk', default=None)
         if 'ppc' not in platform.processor():
             self.cancel("Processor is not ppc64")
-        self.disk = self.params.get('disk', default=None)
         self.dirs = self.params.get('dir', default=self.workdir)
         self.fstype = self.params.get('fs', default='ext4')
         self.log.info("disk: %s, dir: %s, fstype: %s",

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -51,6 +51,7 @@ class FSMark(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
+        self.link = None
         smm = SoftwareManager()
         if raid_needed:
             if not smm.check_installed('mdadm') and not smm.install('mdadm'):

--- a/io/driver/driver_parameter.py
+++ b/io/driver/driver_parameter.py
@@ -38,6 +38,8 @@ class Moduleparameter(Test):
         get parameters
         """
         self.module = self.params.get('module', default=None)
+        if not self.module:
+            self.cancel("Please provide the Module name")
         interfaces = netifaces.interfaces()
         self.ifaces = self.params.get("interface")
         if self.ifaces not in interfaces:
@@ -157,9 +159,10 @@ class Moduleparameter(Test):
         Restore back the default Parameters
         """
         self.log.info("Restoring Default param")
-        linux_modules.unload_module(self.module)
-        linux_modules.load_module(self.module)
-        time.sleep(self.load_unload_sleep_time)
-        if linux_modules.module_is_loaded(self.module) is False:
-            self.fail("Cannot restore default values for Module : %s"
-                      % self.module)
+        if self.module:
+            linux_modules.unload_module(self.module)
+            linux_modules.load_module(self.module)
+            time.sleep(self.load_unload_sleep_time)
+            if linux_modules.module_is_loaded(self.module) is False:
+                self.fail("Cannot restore default values for Module : %s"
+                          % self.module)

--- a/io/driver/driver_parameter_block_device.py
+++ b/io/driver/driver_parameter_block_device.py
@@ -43,6 +43,8 @@ class Moduleparameter(Test):
         self.load_unload_sleep_time = 30
         self.error_modules = []
         self.uname = linux_modules.platform.uname()[2]
+        if not self.module:
+            self.cancel("Please provide the Module name")
         if not self.disk:
             self.cancel("Please provide the Disk name")
         if linux_modules.module_is_loaded(self.module) is False:
@@ -161,10 +163,11 @@ class Moduleparameter(Test):
         if self.mpath_enabled is True:
             if not wait.wait_for(self.is_mpath_flushed, timeout=90):
                 self.fail("multipath is in USE and cannot be flushed")
-        linux_modules.unload_module(self.module)
-        linux_modules.load_module(self.module)
-        time.sleep(self.load_unload_sleep_time)
-        if linux_modules.module_is_loaded(self.module) is False:
-            self.fail("Cannot restore default values for Module : %s"
-                      % self.module)
+        if self.module:
+            linux_modules.unload_module(self.module)
+            linux_modules.load_module(self.module)
+            time.sleep(self.load_unload_sleep_time)
+            if linux_modules.module_is_loaded(self.module) is False:
+                self.fail("Cannot restore default values for Module : %s"
+                          % self.module)
         self.log.info("Restore of default param is success")

--- a/io/net/sriov_device_test.py
+++ b/io/net/sriov_device_test.py
@@ -310,4 +310,5 @@ class NetworkSriovDevice(Test):
         return False
 
     def tearDown(self):
-        self.session.quit()
+        if hasattr(self, 'session'):
+            self.session.quit()

--- a/io/net/switch_test.py
+++ b/io/net/switch_test.py
@@ -38,6 +38,9 @@ class SwitchTest(Test):
         '''
         interfaces = netifaces.interfaces()
         interface = self.params.get("interface")
+        self.networkinterface = None
+        if not interface:
+            self.cancel("Please specify interface to be used")
         if interface not in interfaces:
             self.cancel("%s interface is not available" % interface)
         self.iface = interface
@@ -125,8 +128,9 @@ class SwitchTest(Test):
         '''
         unset ip address
         '''
-        self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        try:
-            self.networkinterface.restore_from_backup()
-        except Exception:
-            self.log.info("backup file not availbale, could not restore file.")
+        if self.networkinterface:
+            self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+            try:
+                self.networkinterface.restore_from_backup()
+            except Exception:
+                self.log.info("backup file not availbale, could not restore file.")

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -49,7 +49,10 @@ class TcpdumpTest(Test):
         self.option = self.params.get("option", default='')
         self.hbond = self.params.get("hbond", default=False)
         # Check if interface exists in the system
+        self.networkinterface = None
         interfaces = netifaces.interfaces()
+        if not self.iface:
+            self.cancel("Please specify interface to be used")
         if self.iface not in interfaces:
             self.cancel("%s interface is not available" % self.iface)
         if not self.peer_ip:
@@ -161,19 +164,20 @@ class TcpdumpTest(Test):
         '''
         unset ip for host interface
         '''
-        if self.networkinterface.set_mtu('1500', timeout=self.mtu_timeout) is not None:
-            self.cancel("Failed to set mtu in host")
-        try:
-            self.peer_networkinterface.set_mtu('1500', timeout=self.mtu_timeout)
-        except Exception:
-            self.peer_public_networkinterface.set_mtu('1500', timeout=self.mtu_timeout)
-        self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        try:
-            self.networkinterface.restore_from_backup()
-        except Exception:
-            self.networkinterface.remove_cfg_file()
-            self.log.info("backup file not availbale, could not restore file.")
-        if self.hbond:
-            self.networkinterface.restore_slave_cfg_file()
-        self.remotehost.remote_session.quit()
-        self.remotehost_public.remote_session.quit()
+        if self.networkinterface:
+            if self.networkinterface.set_mtu('1500', timeout=self.mtu_timeout) is not None:
+                self.cancel("Failed to set mtu in host")
+            try:
+                self.peer_networkinterface.set_mtu('1500', timeout=self.mtu_timeout)
+            except Exception:
+                self.peer_public_networkinterface.set_mtu('1500', timeout=self.mtu_timeout)
+            self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+            try:
+                self.networkinterface.restore_from_backup()
+            except Exception:
+                self.networkinterface.remove_cfg_file()
+                self.log.info("backup file not availbale, could not restore file.")
+            if self.hbond:
+                self.networkinterface.restore_slave_cfg_file()
+            self.remotehost.remote_session.quit()
+            self.remotehost_public.remote_session.quit()

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -51,6 +51,9 @@ class Uperf(Test):
                                              default="None")
         interfaces = netifaces.interfaces()
         self.iface = self.params.get("interface", default="")
+        self.networkinterface = None
+        if not self.iface:
+            self.cancel("Please specify interface to be used")
         if self.iface not in interfaces:
             self.cancel("%s interface is not available" % self.iface)
         self.ipaddr = self.params.get("host_ip", default="")
@@ -192,23 +195,24 @@ class Uperf(Test):
         """
         Killing Uperf process in peer machine
         """
-        self.obj.stop()
-        cmd = "pkill uperf; rm -rf /tmp/uperf-master"
-        output = self.session.cmd(cmd)
-        if not output.exit_status == 0:
-            self.fail("Either the ssh to peer machine machine\
-                       failed or uperf process was not killed")
-        if self.networkinterface.set_mtu('1500') is not None:
-            self.cancel("Failed to set mtu in host")
-        try:
-            self.peer_networkinterface.set_mtu('1500')
-        except Exception:
-            self.peer_public_networkinterface.set_mtu('1500')
-        self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
-        try:
-            self.networkinterface.restore_from_backup()
-        except Exception:
-            self.log.info("backup file not availbale, could not restore file.")
-        self.remotehost.remote_session.quit()
-        self.remotehost_public.remote_session.quit()
-        self.session.quit()
+        if self.networkinterface:
+            self.obj.stop()
+            cmd = "pkill uperf; rm -rf /tmp/uperf-master"
+            output = self.session.cmd(cmd)
+            if not output.exit_status == 0:
+                self.fail("Either the ssh to peer machine machine\
+                           failed or uperf process was not killed")
+            if self.networkinterface.set_mtu('1500') is not None:
+                self.cancel("Failed to set mtu in host")
+            try:
+                self.peer_networkinterface.set_mtu('1500')
+            except Exception:
+                self.peer_public_networkinterface.set_mtu('1500')
+            self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
+            try:
+                self.networkinterface.restore_from_backup()
+            except Exception:
+                self.log.info("backup file not availbale, could not restore file.")
+            self.remotehost.remote_session.quit()
+            self.remotehost_public.remote_session.quit()
+            self.session.quit()

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -43,6 +43,7 @@ class DlparPci(Test):
         Gather necessary test inputs.
         Test all services.
         '''
+        self.session = None
         self.install_packages()
         self.rsct_service_start()
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
@@ -371,4 +372,5 @@ class DlparPci(Test):
             self.fail("dlpar %s operation failed" % msg)
 
     def tearDown(self):
-        self.session.quit()
+        if self.session:
+            self.session.quit()

--- a/perf/perf_cpu_hotplug.py
+++ b/perf/perf_cpu_hotplug.py
@@ -59,6 +59,9 @@ class perf_cpu_hotplug(Test):
         processor_type = genio.read_file("/proc/cpuinfo")
 
         detected_distro = distro.detect()
+        # Offline cpu list during the test
+        self.cpu_off = []
+
         if 'ppc64' not in detected_distro.arch:
             self.cancel("Processor is not PowerPC")
         if 'POWER10' not in processor_type:
@@ -92,9 +95,6 @@ class perf_cpu_hotplug(Test):
         # Collect the cpu list
         self.online_cpus = cpu.online_list()
         self.log.info("Online CPU list: %s" % self.online_cpus)
-
-        # Offline cpu list during the test
-        self.cpu_off = []
 
         # Clear the dmesg to capture the delta at the end of the test.
         dmesg.clear_dmesg()

--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -40,6 +40,8 @@ class test_generic_events(Test):
             self.generic_events = dict(parser.items('POWER9'))
         elif 'POWER10' in cpu_info:
             self.generic_events = dict(parser.items('POWER10'))
+        else:
+            self.cancel("Processor is not supported: %s" % cpu_info)
 
     def test(self):
         nfail = 0

--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -127,6 +127,9 @@ class PerfSDT(Test):
         Setting up the env for SDT markers
         """
         smg = SoftwareManager()
+        self.libpthread = []
+        self.libc = []
+        self.temp_file = tempfile.NamedTemporaryFile().name
         detected_distro = distro.detect()
         if 'ppc' not in distro.detect().arch:
             self.cancel("Test supportd only on  ppc64 arch")
@@ -142,9 +145,6 @@ class PerfSDT(Test):
         for package in deps:
             if not smg.check_installed(package) and not smg.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        self.libpthread = []
-        self.libc = []
-        self.temp_file = tempfile.NamedTemporaryFile().name
 
     def test(self):
         self.add_library()


### PR DESCRIPTION
Now, depending on the test, we either init the variables used in tearDown before
the test cancel or check if we have necessary attribute before using it in tearDown.

Signed-off-by: Denis Silakov <dsilakov@gmail.com>