### PR TITLE
Sosreport fix 14

### DIFF
--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -54,9 +54,10 @@ class Sosreport(Test):
             sos_pkg = 'sos'
         else:
             self.cancel("sosreport is not supported on %s" % dist.name)
-        if not sm.check_installed(sos_pkg) and not sm.install(sos_pkg):
-            self.cancel(
-                "Package %s is missing and could not be installed" % sos_pkg)
+        for package in (sos_pkg, 'java'):
+            if not sm.check_installed(package) and not sm.install(package):
+                self.cancel(
+                    "Package %s is missing and could not be installed" % (package))
         if dist.name == "rhel":
             self.sos_cmd = "sos report"
             if dist.version <= "7" and dist.release <= "4":

--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -49,6 +49,7 @@ class Sosreport(Test):
         sm = SoftwareManager()
         if dist.name in ['Ubuntu', 'debian']:
             sos_pkg = 'sosreport'
+            self.sos_cmd = "sosreport"
         elif dist.name in ['rhel', 'centos', 'fedora']:
             sos_pkg = 'sos'
         else:
@@ -56,10 +57,10 @@ class Sosreport(Test):
         if not sm.check_installed(sos_pkg) and not sm.install(sos_pkg):
             self.cancel(
                 "Package %s is missing and could not be installed" % sos_pkg)
-        if dist.name == "rhel" and dist.version > "7" and dist.release >= "4":
+        if dist.name == "rhel":
             self.sos_cmd = "sos report"
-        else:
-            self.sos_cmd = "sosreport"
+            if dist.version <= "7" and dist.release <= "4":
+                self.sos_cmd = "sosreport"
 
     def test_short(self):
         """


### PR DESCRIPTION
# avocado run --test-runner runner sosreport.py -m sosreport.py.data/options.yaml
JOB ID     : 38a35f2d6fc40f3ec2eca994b90438d1a0316eb3
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2022-05-26T23.13-38a35f2/job.log
 (1/6) sosreport.py:Sosreport.test_short;run-ed60: PASS (131.76 s)
 (2/6) sosreport.py:Sosreport.test_user;run-ed60: PASS (439.14 s)
 (3/6) sosreport.py:Sosreport.test_plugins;run-ed60: PASS (135.37 s)
 (4/6) sosreport.py:Sosreport.test_others;run-ed60: PASS (208.82 s)
 (5/6) sosreport.py:Sosreport.test_archive;run-ed60: PASS (127.90 s)
 (6/6) sosreport.py:Sosreport.test_PPC;run-ed60: PASS (11.40 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2022-05-26T23.13-38a35f2/results.html
JOB TIME   : 1055.04 s
