### PR TITLE
fix perf_sdt_probe

### DIFF
--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -52,10 +52,10 @@ class PerfSDT(Test):
         self.libpthread = self.run_cmd_out("ldconfig -p")
         for line in str(self.libpthread).splitlines():
             if re.search('libpthread', line, re.IGNORECASE):
-                if '64' in line:
+                if 'lib64' in line:
                     self.libpthread = line.split(" ")[7]
             if re.search('libc.so', line, re.IGNORECASE):
-                if '64' in line:
+                if 'lib64' in line:
                     self.libc = line.split(" ")[7]
         if not self.libpthread:
             self.fail("Library %s not found" % self.libpthread)


### PR DESCRIPTION
fixes below error
no SDT markers available in the /usr/lib64/libpthread.so

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

on SLES15 SPx
localhost: # avocado run --test-runner runner perf_sdt_probe.py
JOB ID     : cc9e43bd861bbb131692a46c32c6f3d935639462
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-06-03T21.33-cc9e43b/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (7.18 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-06-03T21.33-cc9e43b/results.html
JOB TIME   : 32.56 s

on RHEL 9.x
avocado run --test-runner runner perf_sdt_probe.py
JOB ID     : 302ae2ddb3604e222ce673afb6daede74ea60511
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-06-03T17.38-302ae2d/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (5.10 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-06-03T17.38-302ae2d/results.html
JOB TIME   : 13.70 s

on RHEL 8.x
avocado run --test-runner runner perf_sdt_probe.py 
JOB ID     : 43e20372172204010a6834abbcc3d2bf3c6c2f07
JOB LOG    : /home/siri/avocado-fvt-wrapper/results/job-2022-06-03T11.00-43e2037/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (8.25 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/siri/avocado-fvt-wrapper/results/job-2022-06-03T11.00-43e2037/results.html
JOB TIME   : 9.86 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8834230/job.log)