### PR TITLE
memory/ndctl_selftest.py : Enabled the support for meson build

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -200,19 +200,20 @@ class NdctlTest(Test):
         self.reflink = '-m reflink=0'
         self.smm = SoftwareManager()
         if self.package == 'upstream':
-            # Skipping this for now, due to non-availibility of
-            # dependent packages.
-            if self.dist.name == 'SuSE' and int(self.dist.version) <= 15:
-                self.cancel("Cancelling the test due to "
-                            "non-availability of dependent packages.")
-
             deps.extend(['gcc', 'make', 'automake', 'autoconf'])
             if self.dist.name == 'SuSE':
-                deps.extend(['libtool',
-                             'libkmod-devel', 'libudev-devel', 'systemd-devel',
-                             'libuuid-devel-static', 'libjson-c-devel',
-                             'keyutils-devel', 'kmod-bash-completion',
-                             'bash-completion-devel'])
+                # Cancel this for now, due to non-availibility of
+                # dependent packages for suse versions below sles15sp3.
+                if self.dist.release < 3:
+                    self.cancel("Cancelling the test due to "
+                                "non-availability of dependent packages.")
+                else:
+                    deps.extend(['libtool', 'libkmod-devel', 'libudev-devel',
+                                 'systemd-devel', 'libuuid-devel-static',
+                                 'libjson-c-devel', 'keyutils-devel',
+                                 'kmod-bash-completion',
+                                 'bash-completion-devel'])
+
             elif self.dist.name == 'rhel':
                 deps.extend(['libtool', 'bash-completion', 'parted',
                              'kmod-devel', 'libuuid-devel', 'json-c-devel',

--- a/memory/ndctl_selftest.py.data/ndctl_selftest.yaml
+++ b/memory/ndctl_selftest.py.data/ndctl_selftest.yaml
@@ -1,2 +1,3 @@
-url:
-branch: 
+url: "https://github.com/pmem/ndctl.git"
+branch: "main"
+ndctl_project_version: '73'


### PR DESCRIPTION
This PR addresses the below changes - 

  1] Enabled meson build for ndctl
  2] Added ndctl version in yaml file
  3] Header file checks for iniparser.h
  4] Incorporated code changes of PR#2330 : https://github.com/avocado-framework-tests/avocado-misc-tests/pull/2330
  
  5] ndctl.py : removed a conditional check that was meant for SLES15