### PR TITLE
fix perf_pmu

### DIFF
--- a/perf/perf_pmu.py
+++ b/perf/perf_pmu.py
@@ -120,6 +120,7 @@ class PerfBasic(Test):
         sysfs_file = "/sys/devices/system/cpu/cpu0/"
 
         sysfs_dict = {"power8": ['mmcr0', 'mmcr1', 'mmcra'],
+                      "power8e": ['mmcr0', 'mmcr1', 'mmcra'],
                       "power9": ['mmcr0', 'mmcr1', 'mmcra'],
                       "power10": ['mmcr0', 'mmcr1', 'mmcr3', 'mmcra']}
 
@@ -192,7 +193,7 @@ class PerfBasic(Test):
             self.fail("sysfs events folder not found")
 
         if not os.path.isdir(base_dir + event_type):
-            self.fail("sysfs %s folder not found" % event_type)
+            self.cancel("sysfs %s folder not found" % event_type)
 
         sys_fs_events = os.listdir(os.path.join(base_dir, event_type, 'events'))
         if len(sys_fs_events) < 21:
@@ -226,7 +227,7 @@ class PerfBasic(Test):
             if pmu_type in entry:
                 sysfs_pmu_list.append(entry)
         if not len(sysfs_pmu_list):
-            self.fail("%s PMUs not found in sysfs" % pmu_type)
+            self.cancel("%s PMUs not found in sysfs" % pmu_type)
         return sysfs_pmu_list
 
     def _sysfs_pmu_cpumask(self, pmu_list):


### PR DESCRIPTION
replaced fail with cancel in case of events not found
added check for power8 powernv

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

before fix on P8 powernv:
avocado run --test-runner runner perf_pmu.py
JOB ID     : 53662188a16efe6929b6f844e7097cd1c07d6bdc
JOB LOG    : /home/siri/avocado-fvt-wrapper/results/job-2022-06-06T06.27-5366218/job.log
 (1/9) perf_pmu.py:PerfBasic.test_PMU_register: PASS (1.82 s)
 (2/9) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: ERROR: 'power8e' (1.53 s)
 (3/9) perf_pmu.py:PerfBasic.test_config_PPC_RTAS: SKIP: This test is for PowerVM
 (4/9) perf_pmu.py:PerfBasic.test_cpu_event_count: PASS (1.42 s)
 (5/9) perf_pmu.py:PerfBasic.test_hv_24x7_event_count: SKIP: This test is for PowerVM
 (6/9) perf_pmu.py:PerfBasic.test_imc_event_count: FAIL: sysfs core_imc folder not found (1.50 s)
 (7/9) perf_pmu.py:PerfBasic.test_thread_event_count: FAIL: sysfs thread_imc folder not found (1.52 s)
 (8/9) perf_pmu.py:PerfBasic.test_nest_cpumask: FAIL: nest_ PMUs not found in sysfs (1.53 s)
 (9/9) perf_pmu.py:PerfBasic.test_core_cpumask: FAIL: core_ PMUs not found in sysfs (1.54 s)
RESULTS    : PASS 2 | ERROR 1 | FAIL 4 | SKIP 2 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/siri/avocado-fvt-wrapper/results/job-2022-06-06T06.27-5366218/results.html
JOB TIME   : 15.51 s

after fix:
avocado run --test-runner runner perf_pmu.py
JOB ID     : 2b389fe440db805658d461945011ddf9a33940ab
JOB LOG    : /home/siri/avocado-fvt-wrapper/results/job-2022-06-06T13.03-2b389fe/job.log
 (1/9) perf_pmu.py:PerfBasic.test_PMU_register: PASS (1.90 s)
 (2/9) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: PASS (3.09 s)
 (3/9) perf_pmu.py:PerfBasic.test_config_PPC_RTAS: SKIP: This test is for PowerVM
 (4/9) perf_pmu.py:PerfBasic.test_cpu_event_count: PASS (1.45 s)
 (5/9) perf_pmu.py:PerfBasic.test_hv_24x7_event_count: SKIP: This test is for PowerVM
 (6/9) perf_pmu.py:PerfBasic.test_imc_event_count: CANCEL: sysfs core_imc folder not found (1.61 s)
 (7/9) perf_pmu.py:PerfBasic.test_thread_event_count: CANCEL: sysfs thread_imc folder not found (1.38 s)
 (8/9) perf_pmu.py:PerfBasic.test_nest_cpumask: CANCEL: nest_ PMUs not found in sysfs (1.59 s)
 (9/9) perf_pmu.py:PerfBasic.test_core_cpumask: CANCEL: core_ PMUs not found in sysfs (1.49 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 2 | WARN 0 | INTERRUPT 0 | CANCEL 4
JOB HTML   : /home/siri/avocado-fvt-wrapper/results/job-2022-06-06T13.03-2b389fe/results.html
JOB TIME   : 17.35 s

RHEL 9.x powervm
avocado run --test-runner runner perf_pmu.py 
JOB ID     : bd3802a6670740bdc6f449ac9674399cb7e244cf
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-06-03T22.29-bd3802a/job.log
 (1/9) perf_pmu.py:PerfBasic.test_PMU_register: PASS (0.55 s)
 (2/9) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: CANCEL: CONFIG_PMU_SYSFS not set. (0.44 s)
 (3/9) perf_pmu.py:PerfBasic.test_config_PPC_RTAS: PASS (0.76 s)
 (4/9) perf_pmu.py:PerfBasic.test_cpu_event_count: PASS (0.53 s)
 (5/9) perf_pmu.py:PerfBasic.test_hv_24x7_event_count: PASS (0.59 s)
 (6/9) perf_pmu.py:PerfBasic.test_imc_event_count: SKIP: This test is for PowerNV
 (7/9) perf_pmu.py:PerfBasic.test_thread_event_count: SKIP: This test is for PowerNV
 (8/9) perf_pmu.py:PerfBasic.test_nest_cpumask: SKIP: This test is for PowerNV
 (9/9) perf_pmu.py:PerfBasic.test_core_cpumask: SKIP: This test is for PowerNV
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 4 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-06-03T22.29-bd3802a/results.html
JOB TIME   : 13.71 s

SLES15 SPx powervm
avocado run --test-runner runner perf_pmu.py
JOB ID     : fea5dd45c9fc24a4b7e63f0537332e48f01b059f
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-06-07T02.33-fea5dd4/job.log
 (1/9) perf_pmu.py:PerfBasic.test_PMU_register: PASS (0.83 s)
 (2/9) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: PASS (0.84 s)
 (3/9) perf_pmu.py:PerfBasic.test_config_PPC_RTAS: PASS (1.02 s)
 (4/9) perf_pmu.py:PerfBasic.test_cpu_event_count: PASS (0.69 s)
 (5/9) perf_pmu.py:PerfBasic.test_hv_24x7_event_count: PASS (0.73 s)
 (6/9) perf_pmu.py:PerfBasic.test_imc_event_count: SKIP: This test is for PowerNV
 (7/9) perf_pmu.py:PerfBasic.test_thread_event_count: SKIP: This test is for PowerNV
 (8/9) perf_pmu.py:PerfBasic.test_nest_cpumask: SKIP: This test is for PowerNV
 (9/9) perf_pmu.py:PerfBasic.test_core_cpumask: SKIP: This test is for PowerNV
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 4 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-06-07T02.33-fea5dd4/results.html
JOB TIME   : 32.77 s

[perf_pmu-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8850719/perf_pmu-job.log)