### PR TITLE
usysattn/usysfault -l -s normal -t command failed to execute

### DIFF
--- a/ras/ras_tools.py
+++ b/ras/ras_tools.py
@@ -59,7 +59,7 @@ class Ras_tools(Test):
         value = self.params.get('usysattn_list', default=['-h', '-V', '-P'])
         for list_item in value:
             self.run_cmd('usysattn  %s ' % list_item)
-        loc_code = self.run_cmd_out("usysattn -P| awk '{print $1}'")
+        loc_code = self.run_cmd_out("usysattn -P| awk 'NR==1{print $1}'")
         self.run_cmd("usysattn -l %s -s normal -t" % loc_code)
         if self.fail_cmd:
             self.fail("%s command(s) failed to execute  "
@@ -70,7 +70,7 @@ class Ras_tools(Test):
         value = self.params.get('usysfault_list', default=['-h', '-V', '-P'])
         for list_item in value:
             self.run_cmd('usysfault  %s ' % list_item)
-        loc_code = self.run_cmd_out("usysfault -P | awk '{print $1}'")
+        loc_code = self.run_cmd_out("usysfault -P | awk 'NR==1{print $1}'")
         self.run_cmd("usysfault -l %s -s normal -t" % loc_code)
         if self.fail_cmd:
             self.fail("%s command(s) failed to execute  "


### PR DESCRIPTION
when we have multiple indicators on system, it is failing.
Modified the script to pick one indicator

Signed-off-by: Shirisha Ganta <SHIRISHA.Ganta1@ibm.com>