### PR TITLE
Packages.py:Added check for powerpc-utils-core package

### DIFF
--- a/ras/packages.py
+++ b/ras/packages.py
@@ -27,7 +27,7 @@ class Package_check(Test):
 
         self.sm = SoftwareManager()
         self.packages = self.params.get(
-            'packages', default=['powerpc-utils', 'ppc64-diag', 'lsvpd'])
+            'packages', default=['powerpc-utils', 'ppc64-diag', 'lsvpd', 'powerpc-utils-core'])
         if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
             self.packages.extend(['opal-prd'])
 

--- a/ras/packages.py.data/list.yaml
+++ b/ras/packages.py.data/list.yaml
@@ -1,3 +1,3 @@
-packages: ['powerpc-utils', 'ppc64-diag', 'lsvpd']
+packages: ['powerpc-utils', 'ppc64-diag', 'lsvpd', 'powerpc-utils-core']
 packages_rhel: ['lshw', 'librtas']
 packages_ubuntu: ['librtas2']


### PR DESCRIPTION
powerpc-utils is split into 2 packages powerpc-utils
and powerpc-utils-core

Signed-off-by: Shirisha Ganta <SHIRISHA.Ganta1@ibm.com>