### PR TITLE
perf/trace: add missing subtests to yaml file

### DIFF
--- a/perf/trace.py.data/README
+++ b/perf/trace.py.data/README
@@ -1,0 +1,12 @@
+Ftrace Unit Tests:
+
+This avocado based test invokes ftrace unit tests that are part of Linux kernel
+source. Content of trace.yaml matches the subdirectories under
+tools/testing/selftests/ftrace/test.d/
+
+While running this test on a Linux distribution based kernel make sure to
+enable appropriate sub-tests. Some sub-tests may not be available.
+
+Refer to following document for steps on how to run ftrace kselftests:
+https://www.kernel.org/doc/readme/tools-testing-selftests-ftrace-README
+

--- a/perf/trace.py.data/trace.yaml
+++ b/perf/trace.py.data/trace.yaml
@@ -8,13 +8,21 @@ config:
     ftest_types: !mux
         basic:
             args: '00basic'
+        direct:
+            args: 'direct'
+        dynevent:
+            args: 'dynevent'
         event:
             args: 'event'
         ftrace:
             args: 'ftrace'
         instances:
             args: 'instances'
-        trigger:
-            args: 'trigger'
         kprobe:
             args: 'kprobe'
+        preemptirq:
+            args: 'preemptirq'
+        tracer:
+            args: 'tracer'
+        trigger:
+            args: 'trigger'


### PR DESCRIPTION
Update YAML file to match with ftrace kselftest subtests available with upstream Linux kernel

Also add a README with pointer to upstream kernel ftrace kselftest documentation.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>