### PR TITLE
fix perf_sdt_probe

### DIFF
--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -51,7 +51,7 @@ class PerfSDT(Test):
         """
         self.libpthread = self.run_cmd_out("ldconfig -p")
         for line in str(self.libpthread).splitlines():
-            if re.search('libpthread', line, re.IGNORECASE):
+            if re.search('libpthread.so', line, re.IGNORECASE):
                 if 'lib64' in line:
                     self.libpthread = line.split(" ")[7]
             if re.search('libc.so', line, re.IGNORECASE):


### PR DESCRIPTION
fixes below error on RHEL 9.1
No SDT markers available in the /lib64/libpthread.so.0

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner perf_sdt_probe.py 
JOB ID     : c7b1c0030271008622204e45f95f1a286f85b85b
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-06-20T11.25-c7b1c00/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (5.86 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-06-20T11.25-c7b1c00/results.html
JOB TIME   : 17.49 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/8946012/job.log)