### PR TITLE
Fix for numa_test failing issue.

### DIFF
--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -116,11 +116,16 @@ class NumaTest(Test):
         """
         Test PFN's before and after offlining
         """
-        self.nr_pages = self.params.get(
-            'nr_pages', default=100)
-        os.chdir(self.teststmpdir)
-        self.log.info("Starting test...")
-        cmd = './bench_movepages -n %s' % self.nr_pages
-        ret = process.system(cmd, shell=True, sudo=True, ignore_status=True)
-        if ret != 0:
-            self.fail('Please check the logs for failure')
+        thp = "/sys/kernel/mm/transparent_hugepage/enable_thp_migration"
+        if os.path.isfile(thp):
+            self.nr_pages = self.params.get(
+                'nr_pages', default=100)
+            os.chdir(self.teststmpdir)
+            self.log.info("Starting test...")
+            cmd = './bench_movepages -n %s' % self.nr_pages
+            ret = process.system(
+                cmd, shell=True, sudo=True, ignore_status=True)
+            if ret != 0:
+                self.fail('Please check the logs for failure')
+        else:
+            self.cancel("THP migration is not enabled on the system")


### PR DESCRIPTION
Test case failed because some kernel builds were not enabled for THP migration. When the ARCH_ENABLE_THP_MIGRATION macro is set into the kernel configuration then only the system will support THP migration. Also, we can check if THP migration is supported on the current system using "enable_thp_migration". Also, THP migration is enabled and disabled via
/sys/kernel/mm/transparent_hugepage/enable_thp_migration file.

Signed-off-by: Samir Mulani <samir@linux.vnet.ibm.com>