### PR TITLE
Cleanup of slave interfaces after Deleting bond.

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -151,7 +151,7 @@ class Bonding(Test):
             self.session = Session(self.peer_public_ip, user=self.user,
                                    password=self.password)
         else:
-            self.session = Session(self.peer_first_ipinterface, user=self.user,
+            self.session = Session(self.peer_first_ipinterface[0], user=self.user,
                                    password=self.password)
 
         if not self.session.connect():
@@ -178,7 +178,7 @@ class Bonding(Test):
             self.remotehost = RemoteHost(self.peer_public_ip, self.user,
                                          password=self.password)
         else:
-            self.remotehost = RemoteHost(self.peer_first_ipinterface, self.user,
+            self.remotehost = RemoteHost(self.peer_first_ipinterface[0], self.user,
                                          password=self.password)
 
         if 'setup' in str(self.name.name):
@@ -213,7 +213,7 @@ class Bonding(Test):
             interface = self.host_interfaces[0]
         else:
             interface = self.bond_name
-        cmd = "ip addr show  | grep %s" % self.peer_first_ipinterface
+        cmd = "ip addr show  | grep %s" % self.peer_first_ipinterface[0]
         output = self.session.cmd(cmd)
         result = ""
         result = result.join(output.stdout.decode("utf-8"))
@@ -273,7 +273,7 @@ class Bonding(Test):
                                          self.bonding_masters_file)
             cmd += 'rmmod bonding;'
             cmd += 'ip addr add %s/%s dev %s;ip link set %s up;sleep 5;'\
-                   % (self.peer_first_ipinterface, self.net_mask[0],
+                   % (self.peer_first_ipinterface[0], self.net_mask[0],
                       self.peer_interfaces[0], self.peer_interfaces[0])
             output = self.session.cmd(cmd)
             if not output.exit_status == 0:
@@ -286,7 +286,7 @@ class Bonding(Test):
         # need some time for specific interface before ping
         time.sleep(10)
         cmd = "ping -I %s %s -c 5"\
-              % (self.bond_name, self.peer_first_ipinterface)
+              % (self.bond_name, self.peer_first_ipinterface[0])
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             return False
         return True
@@ -471,7 +471,7 @@ class Bonding(Test):
             for val in self.peer_interfaces:
                 cmd += 'ip link set %s up;' % val
             cmd += 'ip addr add %s/%s dev %s;ip link set %s up;sleep 5;'\
-                   % (self.peer_first_ipinterface, self.net_mask[0],
+                   % (self.peer_first_ipinterface[0], self.net_mask[0],
                       self.bond_name, self.bond_name)
             output = self.session.cmd(cmd)
             if not output.exit_status == 0:
@@ -527,6 +527,24 @@ class Bonding(Test):
                 networkinterface.restore_from_backup()
             except Exception:
                 self.log.info("backup file not availbale, could not restore file.")
+
+        if self.peer_bond_needed:
+            self.bond_remove("peer")
+            for ipaddr, interface in zip(self.peer_first_ipinterface,
+                                         self.peer_interfaces):
+                self.remotehost = RemoteHost(
+                                self.peer_public_ip, self.user,
+                                password=self.password)
+                peer_networkinterface = NetworkInterface(interface,
+                                                         self.remotehost)
+                try:
+                    peer_networkinterface.flush_ipaddr()
+                    peer_networkinterface.add_ipaddr(ipaddr, self.netmask)
+                    peer_networkinterface.bring_up()
+                except Exception:
+                    peer_networkinterface.save(ipaddr, self.netmask)
+                time.sleep(self.sleep_time)
+        self.error_check()
 
         detected_distro = distro.detect()
         if detected_distro.name == "rhel":


### PR DESCRIPTION
1. This patch makes sure the slave interfaces are cleaned up after deleting creating bond on peer lpar

2. To achieve this below commands are used in cleanup functions
ip addr flush dev interface-name
ip addr add ip-address/netmask dev interface-name
ip link set dev interface-name up

3. For flushing the ip address and making the interfaces up at peer lpar, public ip is used.
when bond interface is deleted and the slave ip's are flushed out , ssh connection will be lost and script gets stuck
To avoid this using public ip in cleanup to flush the addresses and make the interfaces up.

4. Removing "ifup and ifdown" commands, as ifup and if down are not supported in latest rhel9 versions. And using bringup() and bringdown() util finctions in cleanup.

Signed-off-by: Tasmiya Nalatwad <tasmiya@linux.vnet.ibm.com>