### PR TITLE
Remove allow_output_check deprecated option

### DIFF
--- a/io/disk/arcconf/arcconf_cntl_oper.py
+++ b/io/disk/arcconf/arcconf_cntl_oper.py
@@ -118,8 +118,7 @@ class Arcconftest(Test):
         """
         Function returns the output of a command
         """
-        val = process.run(cmd, shell=True, ignore_status=True,
-                          allow_output_check='stdout')
+        val = process.run(cmd, shell=True, ignore_status=True)
         if val.exit_status:
             self.fail("cmd %s Failed" % (cmd))
         return val.stdout.rstrip()

--- a/io/disk/arcconf/arcconf_drive_oper.py
+++ b/io/disk/arcconf/arcconf_drive_oper.py
@@ -148,8 +148,7 @@ class Arcconftest(Test):
         """
         Function returns the output of a command
         """
-        val = process.run(cmd, shell=True, ignore_status=True,
-                          allow_output_check='stdout')
+        val = process.run(cmd, shell=True, ignore_status=True)
         if val.exit_status:
             self.fail("cmd %s Failed" % (cmd))
         return val.stdout.rstrip()

--- a/io/disk/arcconf/arcconf_migration.py
+++ b/io/disk/arcconf/arcconf_migration.py
@@ -190,8 +190,7 @@ class Arcconftest(Test):
         """
         if cmd == 'OS':
             cmd = "lsscsi  | grep LogicalDrv | awk \'{print $7}\'"
-        val = process.run(cmd, shell=True, ignore_status=True,
-                          allow_output_check='stdout')
+        val = process.run(cmd, shell=True, ignore_status=True)
         if val.exit_status:
             self.fail("cmd %s Failed" % (cmd))
         return val.stdout.rstrip()

--- a/io/disk/arcconf/arcconf_raid_oper.py
+++ b/io/disk/arcconf/arcconf_raid_oper.py
@@ -225,7 +225,7 @@ class Arcconftest(Test):
         """
         Function returns the output of a command
         """
-        val = process.run(cmd, shell=True, allow_output_check='stdout')
+        val = process.run(cmd, shell=True)
         if val.exit_status:
             self.fail("cmd %s Failed" % (cmd))
         return val.stdout.rstrip()

--- a/memory/memory_api.py
+++ b/memory/memory_api.py
@@ -56,7 +56,7 @@ class MemorySyscall(Test):
     def test_memapi(self):
         os.chdir(self.teststmpdir)
         proc = process.SubProcess('./memory_api %s %s' % (self.memsize, self.induce_err),
-                                  shell=True, allow_output_check='both')
+                                  shell=True)
         proc.start()
         while proc.poll() is None:
             pass

--- a/perf/perf_core_imc_non_zero_event.py
+++ b/perf/perf_core_imc_non_zero_event.py
@@ -60,10 +60,10 @@ class PerfCoreIMCNonZeroEvents(Test):
 
     def parse_op(self, cmd):
         fail_count = 0
-        output = process.system_output(cmd, ignore_status=True,
-                                       allow_output_check='combined',
+        result = process.system_output(cmd, ignore_status=True,
                                        verbose=True, shell=True, sudo=True)
-        for line in output.decode().split('\n'):
+        output = result.stdout.decode() + result.stderr.decode()
+        for line in output.split('\n'):
             if 'time' not in line:
                 if int(line.strip().split()[1].replace(',', '')) == 0:
                     fail_count = fail_count + 1

--- a/perf/perf_metric.py
+++ b/perf/perf_metric.py
@@ -83,11 +83,11 @@ class perf_metric(Test):
     def _run_cmd(self, option):
         for line in self.list_of_metric_events:
             cmd = "perf stat %s %s sleep 1" % (option, line)
-            rc, output = process.getstatusoutput(cmd, ignore_status=True,
-                                                 shell=True, verbose=True,
-                                                 allow_output_check='combined')
+            rc, op = process.getstatusoutput(cmd, ignore_status=True,
+                                                 shell=True, verbose=True)
             # When the command failed, checking for expected failure or not.
             if rc:
+                output = op.stdout.decode() + op.stderr.decode()
                 found_imc = False
                 found_hv_24_7 = False
                 for ln in output.splitlines():

--- a/perf/perf_nmem.py
+++ b/perf/perf_nmem.py
@@ -147,8 +147,7 @@ class perfNMEM(Test):
                 rc, op = process.getstatusoutput('perf stat -e %s sleep 1'
                                                  % event, shell=True,
                                                  ignore_status=True,
-                                                 verbose=True,
-                                                 allow_output_check='combined')
+                                                 verbose=True)
                 if rc:
                     failed_event_list.append(event)
         if failed_event_list:
@@ -161,8 +160,7 @@ class perfNMEM(Test):
             rc, op = process.getstatusoutput("perf stat -e '{%s}' sleep 1" %
                                              ','.join(self.all_events[key]),
                                              shell=True, verbose=True,
-                                             ignore_status=True,
-                                             allow_output_check='combined')
+                                             ignore_status=True)
             if rc:
                 failed_events.append(self.all_events[key])
         if failed_events:
@@ -176,11 +174,11 @@ class perfNMEM(Test):
                 mix_events.append(self.all_events[keys][0])
             op = process.system_output("perf stat -e '{%s}' sleep 1"
                                        % (",".join(mix_events)), shell=True,
-                                       ignore_status=True,
-                                       allow_output_check='combined')
+                                       ignore_status=True)
             er_ln = "The events in group usually have to be from the same PMU"
+            output = op.stdout.decode() + op.stderr.decode()
             # Expecting failure with the string in 'er_ln'
-            if er_ln in op.decode():
+            if er_ln in output:
                 self.log.info("Expected failure with mixed events")
             else:
                 self.fail("Expected a failure but test pass.")

--- a/perf/perf_pmu.py
+++ b/perf/perf_pmu.py
@@ -134,10 +134,10 @@ class PerfBasic(Test):
             self.fail("Unable to read mmcr* files as super user.")
 
         self._create_temp_user()
-        output = process.system_output("su - test_pmu -c 'cat %smmcr*'"
+        result = process.system_output("su - test_pmu -c 'cat %smmcr*'"
                                        % sysfs_file, shell=True,
-                                       allow_output_check='combined',
-                                       ignore_status=True).decode()
+                                       ignore_status=True)
+        output = result.stdout.decode() + result.stderr.decode()
         self._remove_temp_user()
         if 'Permission denied' not in output:
             self.fail("Able to read mmcr* files as normal user.")


### PR DESCRIPTION
Newer versions of avocado (>v93.0) deprecated usage of
allow_output_check suboption in various process. api's.

Update various test cases which still use this suboption.
Remove this option wherever applicable. In cases where
both stdout & stderr is required build output
using stdout + stderr before processing.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>