### PR TITLE
fix compat mode perf_cpu_hotplug

### DIFF
--- a/perf/perf_cpu_hotplug.py
+++ b/perf/perf_cpu_hotplug.py
@@ -64,8 +64,11 @@ class perf_cpu_hotplug(Test):
 
         if 'ppc64' not in detected_distro.arch:
             self.cancel("Processor is not PowerPC")
-        if 'POWER10' not in processor_type:
-            self.cancel("Test is supported only on Power10")
+        for line in processor_type.splitlines():
+            if 'revision' in line:
+                self.rev = (line.split(':')[1])
+                if '0080' not in self.rev:
+                    self.cancel("Test is supported only on Power10")
 
         deps = ['gcc', 'make']
         if 'Ubuntu' in detected_distro.name:


### PR DESCRIPTION
added code to run script in compat mode instead of
power model using pvr value

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

before patch getting below error:
10:52:20 INFO    : Running: /usr/local/bin/avocado run --nrunner-max-parallel-tasks=1 /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_cpu_hotplug.py --force-job-id 9a147f41de859e1451670717ae82495667280e2e  --job-results-dir /home/avocado-fvt-wrapper/results
JOB ID     : 9a147f41de859e1451670717ae82495667280e2e
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-06-30T10.52-9a147f4/job.log
 (1/2) /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask: STARTED
 (1/2) /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask:  ERROR: 'perf_cpu_hotplug' object has no attribute 'cpu_off' (0.01 s)
 (2/2) /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off: STARTED
 (2/2) /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off:  ERROR: 'perf_cpu_hotplug' object has no attribute 'cpu_off' (0.01 s)
RESULTS    : PASS 0 | ERROR 2 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-06-30T10.52-9a147f4/results.html
JOB TIME   : 2.36 s

after patch:
JOB ID     : 43591e9c5083918aa9052b682f79d91f8c4bbd82
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-07-06T02.50-43591e9/job.log
 (1/2) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask: STARTED
 (1/2) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask: PASS (0.56 s)
 (2/2) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off: STARTED
 (2/2) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off: PASS (1.24 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-07-06T02.50-43591e9/results.html
JOB TIME   : 3.71 s

[perf_cpu_hotplug-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9052823/perf_cpu_hotplug-job.log)