### PR TITLE
security/libkmip: Couple of miscellaneous fixes

### DIFF
--- a/security/libkmip-tests.py
+++ b/security/libkmip-tests.py
@@ -47,7 +47,7 @@ class libkmip(Test):
         Running tests from libkmip
         '''
         count = 0
-        output = process.run("./tests", ignore_status=True, shell=True)
+        output = process.run("./bin/tests", ignore_status=True, shell=True)
         for line in output.stdout.decode().splitlines():
             if 'FAIL - ' in line:
                 count += 1

--- a/security/libkmip-tests.py
+++ b/security/libkmip-tests.py
@@ -47,9 +47,8 @@ class libkmip(Test):
         Running tests from libkmip
         '''
         count = 0
-        output = process.system_output("./tests", ignore_status=True,
-                                       allow_output_check='combined').decode()
-        for line in output.splitlines():
+        output = process.run("./tests", ignore_status=True, shell=True)
+        for line in output.stdout.decode().splitlines():
             if 'FAIL - ' in line:
                 count += 1
                 self.log.info(line)


### PR DESCRIPTION
security/libkmip: Remove deprecated allow_output_check switch
        Remove this switch to avoid test failure.
security/libkmip: Fix incorrect test execution
        libkmip selftests are invoked incorrectly using ./tests . Fix it accordingly

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>