### PR TITLE
README: Fix directory of stress test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,11 +7,11 @@ client tests repository, but it's not limited by that.
 
 Once you have the avocado installed, you can run the tests like below::
 
-    $ avocado run  avocado-misc-tests/perf/stress.py
+    $ avocado run  avocado-misc-tests/generic/stress.py
     JOB ID     : 0018adbc07c5d90d242dd6b341c87972b8f77a0b
     JOB LOG    : $HOME/avocado/job-results/job-2016-01-18T15.32-0018adb/job.log
     TESTS      : 1
-     (1/1) avocado-misc-tests/perf/stress.py:Stress.test: PASS (62.67 s)
+     (1/1) avocado-misc-tests/generic/stress.py:Stress.test: PASS (62.67 s)
     RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
     JOB HTML   : $HOME/avocado/job-results/job-2016-01-18T15.32-0018adb/html/results.html
     TIME       : 62.67 s
@@ -54,11 +54,11 @@ Note*
 * --test-runner runner  need to passed as avocado `run` command line as it default lagacy runner as most of the test in avocado misc test wrote in way to execute sequential manner so newer avocado (aka avocado 91 onwards we need to pass this option explicitly as implicit it uses nrunner)  
 exmaple can be like ::
 
-  # avocado run --test-runner runner avocado-misc-tests/perf/stress.py
+  # avocado run --test-runner runner avocado-misc-tests/generic/stress.py
   JOB ID     : 0018adbc07c5d90d242dd6b341c87972b8f77a0b
   JOB LOG    : $HOME/avocado/job-results/job-2021-11-12T10.32-001adw/job.log
   TESTS      : 1
-  (1/1) avocado-misc-tests/perf/stress.py:Stress.test: PASS (62.67 s)
+  (1/1) avocado-misc-tests/generic/stress.py:Stress.test: PASS (62.67 s)
   RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
   JOB HTML   : $HOME/avocado/job-results/job--2021-11-12T10.32-001adw//html/results.html
   TIME       : 69.67 s


### PR DESCRIPTION
stress.py moved from test/ to generic/ in commit cb5f9fac40b0,
so update the README so that a reader could successfully copy-paste
this example.

Signed-off-by: Russell Currey <ruscur@russell.cc>