### PR TITLE
updated script

### DIFF
--- a/toolchain/ltrace.py
+++ b/toolchain/ltrace.py
@@ -79,8 +79,6 @@ class Ltrace(Test):
 
             self.src_lt = os.path.join(self.workdir, "ltrace")
             os.chdir(self.src_lt)
-            process.run('patch -p1 < %s' % self.get_data('ltrace.patch'),
-                        shell=True)
         elif run_type == "distro":
             self.src_lt = os.path.join(self.workdir, "ltrace-distro")
             if not os.path.exists(self.src_lt):


### PR DESCRIPTION
removed patch as its not supported

Signed-off-by: preeti thakur <preeti.thakur@in.ibm.com>

the errors shown are specific to ltrace for which jira task is created

https://jsw.ibm.com/browse/LOP-4159

[root@ltcever60-lp15 toolchain]#  avocado run --test-runner runner ltrace.py
JOB ID     : c45de0753a03b156233c15875084132537ef6fd6
JOB LOG    : /root/Preeti/avocado-fvt-wrapper/results/job-2022-07-12T03.41-c45de07/job.log
 (1/1) ltrace.py:Ltrace.test:  [ 6405.626601] filt[54717]: unhandled signal 5 at 00007fffa7b4d464 nip 00007fffa7b4d464 lr 00007fffa7b4d464 code 1
[ 6406.854923] filt.pie[54770]: unhandled signal 5 at 00007fff9b6bd464 nip 00007fff9b6bd464 lr 00007fff9b6bd464 code 1
FAIL: 45 test(s) failed, check the log for details. (51.97 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/Preeti/avocado-fvt-wrapper/results/job-2022-07-12T03.41-c45de07/results.html
JOB TIME   : 52.46 s