### PR TITLE
fix perf_nmem

### DIFF
--- a/perf/perf_nmem.py
+++ b/perf/perf_nmem.py
@@ -230,6 +230,6 @@ class perfNMEM(Test):
         self.log.info("Current CPU: %s" % current_cpu)
         self._check_cpumask()
         # After confirming cpu got disabled, enable back
-        if current_cpu in online_cpus and disable_cpu != current_cpu:
+        if current_cpu not in online_cpus and disable_cpu != current_cpu:
             if cpu.online(disable_cpu):
                 self.fail("Can't online cpu %s" % disable_cpu)


### PR DESCRIPTION
fixed error in 9th subtest which was giving "Can't online cpu" error

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

before patch:
avocado run --test-runner runner perf_nmem.py
JOB ID     : 8370ffa23641f1f4d5bd82fac9f28353ac1e6d74
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-07-12T12.55-8370ffa/job.log
 (1/9) perf_nmem.py:perfNMEM.test_pmu_register_dmesg: PASS (1.17 s)
 (2/9) perf_nmem.py:perfNMEM.test_sysfs: PASS (1.13 s)
 (3/9) perf_nmem.py:perfNMEM.test_pmu_count: PASS (1.05 s)
 (4/9) perf_nmem.py:perfNMEM.test_all_events: PASS (18.18 s)
 (5/9) perf_nmem.py:perfNMEM.test_all_group_events: PASS (2.19 s)
 (6/9) perf_nmem.py:perfNMEM.test_mixed_events: CANCEL: With single PMU mixed events test is not possible. (1.12 s)
 (7/9) perf_nmem.py:perfNMEM.test_pmu_cpumask: PASS (1.12 s)
 (8/9) perf_nmem.py:perfNMEM.test_cpumask: PASS (1.13 s)
 (9/9) perf_nmem.py:perfNMEM.test_cpumask_cpu_off: FAIL: Can't online cpu 0 (1.92 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-07-12T12.55-8370ffa/results.html
JOB TIME   : 153.76 s

after patch:
avocado run --test-runner runner perf_nmem.py
JOB ID     : 5b0ff484012d733540b4ed98add5dd81aa54208a
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-07-12T12.59-5b0ff48/job.log
 (1/9) perf_nmem.py:perfNMEM.test_pmu_register_dmesg: PASS (1.18 s)
 (2/9) perf_nmem.py:perfNMEM.test_sysfs: PASS (1.11 s)
 (3/9) perf_nmem.py:perfNMEM.test_pmu_count: PASS (1.22 s)
 (4/9) perf_nmem.py:perfNMEM.test_all_events: PASS (18.21 s)
 (5/9) perf_nmem.py:perfNMEM.test_all_group_events: PASS (2.17 s)
 (6/9) perf_nmem.py:perfNMEM.test_mixed_events: CANCEL: With single PMU mixed events test is not possible. (1.17 s)
 (7/9) perf_nmem.py:perfNMEM.test_pmu_cpumask: PASS (1.17 s)
 (8/9) perf_nmem.py:perfNMEM.test_cpumask: PASS (1.17 s)
 (9/9) perf_nmem.py:perfNMEM.test_cpumask_cpu_off: PASS (1.50 s)
RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-07-12T12.59-5b0ff48/results.html
JOB TIME   : 45.24 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9095354/job.log)