### PR TITLE
fixing the way nvme_cli_selftest.py runs.

### DIFF
--- a/io/disk/ssd/nvme_cli_selftests.py
+++ b/io/disk/ssd/nvme_cli_selftests.py
@@ -77,7 +77,7 @@ class NVMeCliSelfTest(Test):
         """
         Runs the selftests on the device.
         """
-        res = process.run("nose2 --verbose %s" %
+        res = process.run("nose2 --verbose --start-dir tests %s" %
                           self.test, shell=True, ignore_status=True)
         res = [res.stdout.decode("utf-8"), res.stderr.decode("utf-8")]
         if any('FAILED' in line for line in res):

--- a/io/disk/ssd/nvme_cli_selftests.py.data/nvme_cli_selftests.yaml
+++ b/io/disk/ssd/nvme_cli_selftests.py.data/nvme_cli_selftests.yaml
@@ -1,5 +1,5 @@
-device: nvme0
-disk: /dev/nvme0n1
+device: 'nvme0'
+disk: '/dev/nvme0n1'
 test: !mux
     nvme_id_ctrl_test:
         test: nvme_id_ctrl_test
@@ -21,8 +21,6 @@ test: !mux
         test: nvme_flush_test
     nvme_test_io:
         test: nvme_test_io
-    nvme_writeuncor_test:
-        test: nvme_writeuncor_test
     nvme_get_features_test:
         test: nvme_get_features_test
     nvme_writezeros_test:


### PR DESCRIPTION
test was failing due to recent changes to the selftest.
so added the "--start-dir tests" so that it runs without any issue.
Also removed writeuncor test from yaml as it is not recommended
based on recent issues seen on nvme namespaces, i.e it disrupts the disk.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>