### PR TITLE
removing the no_fs support for disktest.py

### DIFF
--- a/io/disk/disktest.py.data/disktest.yaml
+++ b/io/disk/disktest.py.data/disktest.yaml
@@ -7,8 +7,6 @@ filesystem: !mux
         fs: 'xfs'
     btrfs:
         fs: 'btrfs'
-    no_fs:
-        fs: ''
 raid: !mux
     raid:
         raid: True


### PR DESCRIPTION
for larger size disks like nvme, this is utilizing the complete root space
to run the test when no_fs option is given and hence, OS will be left with
no space and other runs are failing. hence removing the no_fs support for
the disktest.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>