### PR TITLE
add ltp-fs.yaml

### DIFF
--- a/generic/ltp.py.data/ltp-fs.yaml
+++ b/generic/ltp.py.data/ltp-fs.yaml
@@ -1,0 +1,11 @@
+url: 'https://github.com/linux-test-project/ltp/archive/master.zip'
+skipfileurl: "null"
+runltp: !mux
+    fs:
+        args: '-f fs'
+    fs_perms_simple:
+        args: '-f fs_perms_simple'
+    fsx:
+        args: '-f fsx'
+    fs_bind:
+        args: '-f fs_bind'


### PR DESCRIPTION
added ltp-fs.yaml file to run ltp tests related to file system

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

[root@ltcrain108-lp1 generic]# avocado run --test-runner runner ltp.py -m ltp.py.data/ltp-fs.yaml
Fetching asset from ltp.py:LTP.test
Fetching asset from ltp.py:LTP.test
JOB ID     : 3bde13fae2af65b2139376a06c9537fc4a8f31b4
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2022-08-05T08.55-3bde13f/job.log
 (1/4) ltp.py:LTP.test;run-runltp-fs-b8b1: PASS (1386.32 s)
 (2/4) ltp.py:LTP.test;run-runltp-fs_perms_simple-2f68: PASS (139.40 s)
 (3/4) ltp.py:LTP.test;run-runltp-fsx-b11a: PASS (141.26 s)
 (4/4) ltp.py:LTP.test;run-runltp-fs_bind-d2ad: PASS (142.46 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2022-08-05T08.55-3bde13f/results.html
JOB TIME   : 1822.37 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9271094/job.log)