### PR TITLE
Cancelling the test distro_tools.py for -a option

### DIFF
--- a/io/common/distro_tools.py
+++ b/io/common/distro_tools.py
@@ -68,6 +68,8 @@ class DisrtoTool(Test):
         '''
         test all distro tools
         '''
+        if self.option == '-c pci -a':
+            self.cancel("-a option is not supported with lsslot")
         cmd = "%s %s" % (self.tool, self.option)
         result = process.run(cmd, shell=True, ignore_status=True)
 


### PR DESCRIPTION
option -a is not supported as of now. this will exit with non-zero
return code. And it is accepted as of now. So cancelling the test
for this option.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>