### PR TITLE
Block tests case fixes 

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -157,7 +157,7 @@ class Bonnie(Test):
         :rtype: str
         """
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(self.vgname, l_disk)
+        lv_utils.vg_create(self.vgname, l_disk, force=True)
         lv_utils.lv_create(self.vgname, self.lvname, lv_size)
         return '/dev/%s/%s' % (self.vgname, self.lvname)
 

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -141,7 +141,7 @@ class Dbench(Test):
         vgname = 'avocado_vg'
         lvname = 'avocado_lv'
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(vgname, l_disk)
+        lv_utils.vg_create(vgname, l_disk, force=True)
         lv_utils.lv_create(vgname, lvname, lv_size)
         return '/dev/mapper/%s-%s' % (vgname, lvname)
 

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -242,7 +242,7 @@ class FioTest(Test):
         :rtype: str
         """
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(self.vgname, l_disk)
+        lv_utils.vg_create(self.vgname, l_disk, force=True)
         lv_utils.lv_create(self.vgname, self.lvname, lv_size)
         return '/dev/%s/%s' % (self.vgname, self.lvname)
 

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -140,7 +140,7 @@ class FSMark(Test):
         :rtype: str
         """
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(self.vgname, l_disk)
+        lv_utils.vg_create(self.vgname, l_disk, force=True)
         lv_utils.lv_create(self.vgname, self.lvname, lv_size)
         return '/dev/%s/%s' % (self.vgname, self.lvname)
 

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -473,7 +473,7 @@ class IOZone(Test):
         if self.disk is not None:
             if self.disk in disk.get_disks():
                 if raid_needed:
-                    raid_name = '/dev/md/mdsraid'
+                    raid_name = '/dev/md/sraid'
                     self.create_raid(self.disk, raid_name)
                     self.raid_create = True
                     self.disk = raid_name

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -500,7 +500,7 @@ class IOZone(Test):
         vgname = 'avocado_vg'
         lvname = 'avocado_lv'
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(vgname, l_disk)
+        lv_utils.vg_create(vgname, l_disk, force=True)
         lv_utils.lv_create(vgname, lvname, lv_size)
         return '/dev/%s/%s' % (vgname, lvname)
 

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -143,7 +143,7 @@ class LtpFs(Test):
         :rtype: str
         """
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(self.vgname, l_disk)
+        lv_utils.vg_create(self.vgname, l_disk, force=True)
         lv_utils.lv_create(self.vgname, self.lvname, lv_size)
         return '/dev/%s/%s' % (self.vgname, self.lvname)
 

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -148,7 +148,7 @@ class LtpFs(Test):
         :rtype: str
         """
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(self.vgname, l_disk)
+        lv_utils.vg_create(self.vgname, l_disk, force=True)
         lv_utils.lv_create(self.vgname, self.lvname, lv_size)
         return '/dev/%s/%s' % (self.vgname, self.lvname)
 

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -135,7 +135,7 @@ class Lvsetup(Test):
         A volume group with given name is created in the ramdisk. It then
         creates a logical volume.
         """
-        lv_utils.vg_create(self.vg_name, self.device)
+        lv_utils.vg_create(self.vg_name, self.device, force=True)
         if not lv_utils.vg_check(self.vg_name):
             self.fail('Volume group %s not created' % self.vg_name)
         lv_utils.lv_create(self.vg_name, self.lv_name, self.lv_size)

--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -58,7 +58,7 @@ class SoftwareRaid(Test):
         spare_disks = self.params.get('spare_disks', default='').strip(" ")
         if spare_disks:
             spare_disks = spare_disks.split()
-        raid = self.params.get('raidname', default='/dev/md/mdsraid')
+        raid = self.params.get('raidname', default='/dev/md/sraid')
         metadata = str(self.params.get('metadata', default='1.2'))
         self.remove_add_disk = ''
         if raidlevel not in ['0', 'linear']:

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -130,7 +130,7 @@ class Tiobench(Test):
         :rtype: str
         """
         lv_size = lv_utils.get_device_total_space(l_disk) / 2330168
-        lv_utils.vg_create(self.vgname, l_disk)
+        lv_utils.vg_create(self.vgname, l_disk, force=True)
         lv_utils.lv_create(self.vgname, self.lvname, lv_size)
         return '/dev/%s/%s' % (self.vgname, self.lvname)
 


### PR DESCRIPTION
[1] changed md raid name same as other test
    dbench and software raid has mdsraid, changed to sraid
    as in line with all other disks tests using sraid

[2]  block tests are failing due to vgcreate hung
    sometimes vgcreate never completes waiting for 'y' input
    from userspace, so this patch made sure the vgcreate command
    is automatic

```
[stdlog] 2022-08-05 00:30:52,406 avocado.utils.process INFO | Command 'fdisk -l /dev/md/sraid' finished with 0 after 0.001004789s
[stdlog] 2022-08-05 00:30:52,406 avocado.utils.process INFO | Running 'vgdisplay avocado_vg'
[stdlog] 2022-08-05 00:30:52,417 avocado.utils.process DEBUG| [stderr]   Volume group "avocado_vg" not found
[stdlog] 2022-08-05 00:30:52,417 avocado.utils.process DEBUG| [stderr]
[stdlog] 2022-08-05 00:30:52,417 avocado.utils.process DEBUG| [stderr] Cannot process volume group avocado_vg
[stdlog] 2022-08-05 00:30:52,563 avocado.utils.process INFO | Command 'vgdisplay avocado_vg' finished with 5 after 0.156140223s
[stdlog] 2022-08-05 00:30:52,563 avocado.utils.lv_utils ERROR| Command 'vgdisplay avocado_vg' failed.
[stdlog] stdout: b''
[stdlog] stderr: b'  Volume group "avocado_vg" not found\n  Cannot process volume group avocado_vg\n'
[stdlog] additional_info: None
[stdlog] 2022-08-05 00:30:52,563 avocado.utils.process INFO | Running 'vgcreate avocado_vg /dev/md/sraid'
[stdlog] 2022-08-05 00:30:52,582 avocado.utils.process DEBUG| [stderr] WARNING: ext4 signature detected on /dev/md/sraid at offset 1080. Wipe it? [y/n]:
```