### PR TITLE
fix-perfsdtprobe

### DIFF
--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -18,6 +18,7 @@ import os
 import platform
 import re
 import tempfile
+import time
 
 from avocado import Test
 from avocado.utils import distro
@@ -72,6 +73,7 @@ class PerfSDT(Test):
         self.run_cmd(perf_add)
         if self.is_fail:
             self.fail("Unable to add %s to builid-cache" % self.libpthread)
+        time.sleep(10)
         # Add the libc.so.6 to perf
         perf_libc_add = "perf buildid-cache -v --add %s" % self.libc
         self.is_fail = 0


### PR DESCRIPTION
fixes error 'No SDT markers available' after adding probe event, not
listed in perf list immediately which resulted in failure

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner perf_sdt_probe.py
JOB ID     : 44c89e5fb4f3473dfecaef16b777bec38f9b82dd
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-08-08T22.51-44c89e5/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (11.97 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-08-08T22.51-44c89e5/results.html
JOB TIME   : 26.52 s
