### PR TITLE
IO : iperf local variable 'tput' referenced before assignment

### DIFF
--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -200,10 +200,12 @@ class Iperf(Test):
                 tput = int(line.split()[6])
             elif id in line and 'Gbits/sec' in line:
                 tput = int(float(line.split()[6])) * 1000
+            elif id in line and 'Kbits/sec' in line:
+                tput = int(float(line.split()[6])) / 1000
         if tput < (int(self.expected_tp) * speed) / 100:
             self.fail("FAIL: Throughput Actual - %s%%, Expected - %s%%"
                       ", Throughput Actual value - %s "
-                      % ((tput*100)/speed, self.expected_tp,
+                      % (round((tput*100)/speed, 4), self.expected_tp,
                          str(tput)+'Mb/sec'))
         for line in nping_result.stdout.decode("utf-8").splitlines():
             if 'Raw packets' in line:


### PR DESCRIPTION
When the iperf speed is in Kbits/sec the variable 'tput' was remained unassigned and test case was failing as there was no condition provided in code to handle this speed.

Action taken : Added and elif condition to capture the iperf speed in Kbits/sec and fail the test case with warning as the throughput will be less.

Signed-off-by: Tasmiya Nalatwad <tasmiya@linux.vnet.ibm.com>