### PR TITLE
perf/perf_script_bug: Add Ubuntu support

### DIFF
--- a/perf/perf_script_bug.py
+++ b/perf/perf_script_bug.py
@@ -15,6 +15,7 @@
 # Author: Shirisha <shiganta@in.ibm.com>
 
 import os
+import platform 
 import tempfile
 import shutil
 import configparser
@@ -38,6 +39,9 @@ class PerfProbe(Test):
         deps = ['gcc', 'make']
         if detected_distro.name in ['rhel', 'SuSE']:
             deps.extend(['perf'])
+        elif detected_distro.name in ['Ubuntu']:
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
         else:
             self.cancel("Install the package perf\
                       for %s" % detected_distro.name)

--- a/perf/perf_script_bug.py.data/probe.cfg
+++ b/perf/perf_script_bug.py.data/probe.cfg
@@ -2,3 +2,5 @@
 probepoint = 3
 [SuSE]
 probepoint = 3
+[Ubuntu]
+probepoint = 3


### PR DESCRIPTION
  Current perf_script_bug test code only supported with RHEL, SLES.
  So added Ubuntu support.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>