### PR TITLE
uperf compliation failed due to missing package

### DIFF
--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -76,7 +76,7 @@ class Uperf(Test):
         if detected_distro.name == "Ubuntu":
             pkgs.extend(["libsctp1", "libsctp-dev", "lksctp-tools"])
         elif detected_distro.name == "rhel":
-            pkgs.extend(["nmap"])
+            pkgs.extend(["nmap", "lksctp-tools-devel"])
         else:
             pkgs.extend(["lksctp-tools", "lksctp-tools-devel"])
         for pkg in pkgs:


### PR DESCRIPTION
include lksctp-tools-devel in the pkg list for
uperf to compile successfully on host and peer machines.

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>