### PR TITLE
add_ftrace_yaml

### DIFF
--- a/kernel/kselftest.py.data/ftracetest.yaml
+++ b/kernel/kselftest.py.data/ftracetest.yaml
@@ -1,0 +1,11 @@
+component: !mux
+    ftrace:
+        comp: 'ftrace'
+        kself_args: 'summary=1'
+
+run_type: !mux
+    distro:
+        type: 'distro'
+    upstream:
+        type: 'upstream'
+        location: 'https://github.com/torvalds/linux/archive/master.zip'


### PR DESCRIPTION
Add yaml file to run ftracetest with kselftests

Signed-off-by: Akanksha J N <akanksha@linux.ibm.com>

avocado run --test-runner runner kselftest.py -m kselftest.py.data/ftracetest.yaml 
Fetching asset from kselftest.py:kselftest.test
JOB ID     : 47c31a57ba03ad42b41e55f55387b3323eb9625c
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2022-09-14T01.56-47c31a5/job.log
 (1/2) kselftest.py:kselftest.test;run-component-ftrace-run_type-distro-7b46: FAIL: Testcase failed during selftests (106.06 s)
 (2/2) kselftest.py:kselftest.test;run-component-ftrace-run_type-upstream-2f43: FAIL: Testcase failed during selftests (408.99 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2022-09-14T01.56-47c31a5/results.html
JOB TIME   : 515.98 s
[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9564101/job.log)
