### PR TITLE
ras/vpa_MaxMem_check: Extend OS support

### DIFF
--- a/ras/vpa_MaxMem_check.py
+++ b/ras/vpa_MaxMem_check.py
@@ -37,15 +37,16 @@ class Cpu_VpaData(Test):
         if "ppc" not in os.uname()[4]:
             self.cancel("Test case is supported only on IBM Power Servers")
 
-        detected_distro = distro.detect()
-        if detected_distro.name not in ['rhel', 'SuSE']:
-            self.cancel("Test case is supported only on RHEL and SLES")
-
         sm = SoftwareManager()
+        detected_distro = distro.detect()
         if 'SuSE' in detected_distro.name:
             package = "powerpc-utils"
-        else:
+        elif 'rhel' in detected_distro.name:
             package = "powerpc-utils-core"
+        elif detected_distro.name in ['Ubuntu', 'debian']:
+            package = "powerpc-ibm-utils"
+        else:
+            self.cancel('Unsupported OS %s' % detected_distro.name)
 
         if not sm.check_installed(package) and not sm.install(package):
             self.cancel("Failed to install %s" % package)


### PR DESCRIPTION
This two patch series add support for Ubuntu OS
[Patch 1/2] ras/vpa_MaxMem_check: Add package dependeny
    Add a check to ensure lparstat utility is installed on the systems. This is in preparation for patch 2.
[Patch 2/2] ras/vpa_MaxMem_check: Add Ubuntu support
    Extend the support to include Ubuntu distribution.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>