### PR TITLE
fix_perf_24x7_domain_range

### DIFF
--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -109,7 +109,7 @@ class hv_24x7_all_events(Test):
         for line in self.list_of_hv_24x7_events:
             if line.startswith('HP') or line.startswith('CP'):
                 # Running for domain range from 1-6
-                for domain in range(1, 7):
+                for domain in range(2, 7):
                     for core in range(0, self.cores + 1):
                         events = "hv_24x7/%s,domain=%s,core=%s/" % \
                                  (line, domain, core)


### PR DESCRIPTION
some of the events were failing with domain value 1 
as per domain interface, updated domain range to start with 2 instead of 1 as we have condition to run chip events separately

1: Physical Chip
2: Physical Core
3: VCPU Home Core
4: VCPU Home Chip
5: VCPU Home Node
6: VCPU Remote Node

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner perf_24x7_all_events.py
JOB ID     : f23598aeab31443d8727cebaaf5284556a501867
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-09-15T19.47-f23598a/job.log
 (1/1) perf_24x7_all_events.py:hv_24x7_all_events.test_all_events: PASS (2971.15 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-09-15T19.47-f23598a/results.html
JOB TIME   : 3543.13 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9585610/job.log)