### PR TITLE
fix net.yaml to eliminate duplicate 'comp'

### DIFF
--- a/kernel/kselftest.py.data/net.yaml
+++ b/kernel/kselftest.py.data/net.yaml
@@ -4,7 +4,7 @@ component: !mux
         kself_args: 'summary=1'
 run_type: !mux
     distro:
-        comp: 'distro'
+        type: 'distro'
     upstream:
         type: 'upstream'
         location: 'https://github.com/torvalds/linux/archive/master.zip'


### PR DESCRIPTION
fixing ERROR: Multiple  leaves contain the key 'comp'; ['/run/component/net=>net', '/run/run_type/distro=>distro']

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>