### PR TITLE
kselftest.py: adding security.yaml

### DIFF
--- a/kernel/kselftest.py.data/security.yaml
+++ b/kernel/kselftest.py.data/security.yaml
@@ -1,0 +1,22 @@
+component: !mux
+    kexec:
+        comp: 'kexec'
+        kself_args: 'summary=1'
+    tpm2:
+        comp: 'tpm2'
+        kself_args: 'summary=1'
+    safesetid:
+        comp: 'safesetid'
+        kself_args: 'summary=1'
+    seccomp:
+        comp: 'seccomp'
+        kself_args: 'summary=1'
+    security:
+       comp: 'powerpc'
+       subtest: 'security'
+run_type: !mux
+    distro:
+        type: 'distro'
+    upstream:
+        type: 'upstream'
+        location: 'https://github.com/torvalds/linux/archive/master.zip'


### PR DESCRIPTION
Adding security.yaml with the following tests
kexec
tpm2
safesetid
seccomp
powerpc/security

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>