### PR TITLE
ltp.py: split security tests in to normal and stress

### DIFF
--- a/generic/ltp.py.data/ltp-security-stress.yaml
+++ b/generic/ltp.py.data/ltp-security-stress.yaml
@@ -1,0 +1,12 @@
+runltp: !mux
+    script: 'runltp'
+    net_stress.ipsec_dccp:
+        args: '-f net_stress.ipsec_dccp'
+    net_stress.ipsec_icmp:
+        args: '-f net_stress.ipsec_icmp'
+    net_stress.ipsec_sctp:
+        args: '-f net_stress.ipsec_sctp'
+    net_stress.ipsec_tcp:
+        args: '-f net_stress.ipsec_tcp'
+    net_stress.ipsec_udp:
+        args: '-f net_stress.ipsec_udp'

--- a/generic/ltp.py.data/ltp-security.yaml
+++ b/generic/ltp.py.data/ltp-security.yaml
@@ -1,21 +1,15 @@
 runltp: !mux
     script: 'runltp'
+    cap_bounds:
+        args: '-f cap_bounds'
+    crashme:
+        args: '-f crashme'
     crypto:
         args: '-f crypto'
     cve:
         args: '-f cve'
     ima:
         args: '-f ima'
-    net_stress.ipsec_dccp:
-        args: '-f net_stress.ipsec_dccp'
-    net_stress.ipsec_icmp:
-        args: '-f net_stress.ipsec_icmp'
-    net_stress.ipsec_sctp:
-        args: '-f net_stress.ipsec_sctp'
-    net_stress.ipsec_tcp:
-        args: '-f net_stress.ipsec_tcp'
-    net_stress.ipsec_udp:
-        args: '-f net_stress.ipsec_udp'
     securebits:
         args: '-f securebits'
     tpm_tools:


### PR DESCRIPTION
split the ltp security tests in to two categories
ltp-security.yaml: contains the security tests
ltp-security-stress.yaml: contains the security stress tests

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>