### PR TITLE
annobin-tests.py add distribution specific test cases

### DIFF
--- a/security/annobin-tests.py.data/annobin.yaml
+++ b/security/annobin-tests.py.data/annobin.yaml
@@ -1,0 +1,7 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+prefix: '/usr'
+url: "https://sourceware.org/git/annobin.git"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>