### PR TITLE
evmctl-tests.py: add distribution specific test cases

### DIFF
--- a/security/evmctl-tests.py.data/evmctl.yaml
+++ b/security/evmctl-tests.py.data/evmctl.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://sourceforge.net/projects/linux-ima/files/latest/download"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>