### PR TITLE
cryptsetup-tests.py: add distribution specific test cases

### DIFF
--- a/security/cryptsetup-tests.py.data/cryptsetup.yaml
+++ b/security/cryptsetup-tests.py.data/cryptsetup.yaml
@@ -1,0 +1,7 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+prefix: '/usr'
+url: "https://gitlab.com/cryptsetup/cryptsetup/"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>