### PR TITLE
krb5-tests.py: add distribution specific test cases

### DIFF
--- a/security/krb5-tests.py.data/krb5.yaml
+++ b/security/krb5-tests.py.data/krb5.yaml
@@ -1,0 +1,7 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+prefix: '/usr'
+url: "https://github.com/krb5/krb5/archive/master.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>