### PR TITLE
libgcrypt-tests.py: add distribution specific test cases

### DIFF
--- a/security/libgcrypt-tests.py
+++ b/security/libgcrypt-tests.py
@@ -34,33 +34,49 @@ class libgcrypt(Test):
         # Check for basic utilities
         smm = SoftwareManager()
         detected_distro = distro.detect()
-        deps = ['gcc', 'make']
-        if detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos']:
-            deps.extend(["autoconf", "automake", "libgpg-error-devel",
-                         "libgpg-error", "transfig"])
-        else:
+        deps = ['gcc', 'make', "autoconf", "automake", "libgpg-error-devel",
+                "libgpg-error"]
+        if detected_distro.name in ['rhel', 'fedora', 'centos']:
+            deps.extend(["transfig"])
+        elif 'Ubuntu' in detected_distro.name:
             self.cancel("Unsupported distro %s for libgcrypt package"
                         % detected_distro.name)
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        url = "https://dev.gnupg.org/source/libgcrypt.git"
-        git.get_repo(url, destination_dir=self.workdir)
-        os.chdir(self.workdir)
-        process.run("./autogen.sh")
-        process.run("./configure --enable-maintainer-mode")
-        if build.make(self.workdir):
-            # If the make fails then need to run make with -lpthread
-            build.run_make(self.workdir, extra_args="CFLAGS+=-lpthread",
-                           process_kwargs={"ignore_status": True})
+        run_type = self.params.get('type', default='upstream')
+        if run_type == "upstream":
+            default_url = "https://dev.gnupg.org/source/libgcrypt.git"
+            url = self.params.get('url', default=default_url)
+            git.get_repo(url, destination_dir=self.workdir)
+            os.chdir(self.workdir)
+            self.srcdir = self.workdir
+            process.run("./autogen.sh")
+            process.run("./configure --enable-maintainer-mode --disable-doc")
+            if build.make(self.workdir):
+                # If the make fails then need to run make with -lpthread
+                output = build.run_make(self.workdir,
+                                        extra_args="CFLAGS+=-lpthread",
+                                        process_kwargs={"ignore_status": True})
+                if output.exit_status:
+                    self.fail("'make' failed.")
+        elif run_type == "distro":
+            self.srcdir = os.path.join(self.workdir, "libgcrypt-distro")
+            if not os.path.exists(self.srcdir):
+                os.makedirs(self.srcdir)
+            self.srcdir = smm.get_source("libgcrypt", self.srcdir)
+            if not self.srcdir:
+                self.fail("libgcrypt source install failed.")
 
     def test(self):
         '''
         Running tests from libgcrypt
         '''
         count = 0
-        output = build.run_make(self.workdir, extra_args="check",
+        output = build.run_make(self.srcdir, extra_args="check",
                                 process_kwargs={"ignore_status": True})
+        if output.exit_status:
+            self.fail("'make check' failed.")
         for line in output.stdout_text.splitlines():
             if 'FAIL:' in line:
                 count += 1

--- a/security/libgcrypt-tests.py.data/libgcrypt.yaml
+++ b/security/libgcrypt-tests.py.data/libgcrypt.yaml
@@ -1,0 +1,7 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+prefix: '/usr'
+url: "https://dev.gnupg.org/source/libgcrypt.git"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>