### PR TITLE
libkcapi-tests.py: add distribution specific test cases

### DIFF
--- a/security/libkcapi-tests.py.data/test_name.yaml
+++ b/security/libkcapi-tests.py.data/test_name.yaml
@@ -13,3 +13,9 @@ test: !mux
         test_name: 'hasher-test.sh'
     kcapi-fuzz-test.sh:
         test_name: 'kcapi-fuzz-test.sh'
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://github.com/smuellerDD/libkcapi/archive/master.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>