### PR TITLE
libkmip-tests.py: add distribution specific test cases

### DIFF
--- a/security/libkmip-tests.py
+++ b/security/libkmip-tests.py
@@ -16,7 +16,7 @@
 
 import os
 from avocado import Test
-from avocado.utils import archive, build, process
+from avocado.utils import archive, build, distro, process
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -31,16 +31,31 @@ class libkmip(Test):
         '''
         # Check for basic utilities
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         for package in ['gcc', 'make', 'autoconf']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        url = "https://github.com/OpenKMIP/libkmip/archive/refs/heads/master.zip"
-        tarball = self.fetch_asset(url, expire='7d')
-        archive.extract(tarball, self.workdir)
-        self.sourcedir = os.path.join(self.workdir, 'libkmip-master')
-        if build.make(self.sourcedir):
-            self.fail("Failed to compile libkmip")
-        os.chdir(self.sourcedir)
+        run_type = self.params.get('type', default='upstream')
+        if run_type == "upstream":
+            default_url = ("https://github.com/OpenKMIP/libkmip/archive/"
+                           "refs/heads/master.zip")
+            url = self.params.get('url', default=default_url)
+            tarball = self.fetch_asset(url, expire='7d')
+            archive.extract(tarball, self.workdir)
+            self.srcdir = os.path.join(self.workdir, 'libkmip-master')
+            if build.make(self.srcdir):
+                self.fail("Failed to compile libkmip")
+        elif run_type == "distro":
+            if detected_distro.name in ['rhel', 'fedora', 'centos']:
+                self.cancel("For %s 'libkmip' package not available" %
+                            detected_distro.name)
+            self.srcdir = os.path.join(self.workdir, "libkmip-distro")
+            if not os.path.exists(self.srcdir):
+                os.makedirs(self.srcdir)
+            self.srcdir = smm.get_source("libkmip", self.srcdir)
+            if not self.srcdir:
+                self.fail("libkmip source install failed.")
+        os.chdir(self.srcdir)
 
     def test(self):
         '''

--- a/security/libkmip-tests.py.data/libkmip.yaml
+++ b/security/libkmip-tests.py.data/libkmip.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://github.com/OpenKMIP/libkmip/archive/refs/heads/master.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>