### PR TITLE
openssl-tests.py: add distribution specific test cases

### DIFF
--- a/security/openssl-tests.py.data/openssl.yaml
+++ b/security/openssl-tests.py.data/openssl.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://github.com/openssl/openssl/archive/master.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>