### PR TITLE
openssh-tests.py: add distribution specific test cases

### DIFF
--- a/security/openssh-tests.py.data/openssh.yaml
+++ b/security/openssh-tests.py.data/openssh.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://github.com/openssh/openssh-portable/archive/master.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>