### PR TITLE
nettle-tests.py: add distribution specific test cases

### DIFF
--- a/security/nettle-tests.py.data/README.txt
+++ b/security/nettle-tests.py.data/README.txt
@@ -1,0 +1,8 @@
+Nettle is a cryptographic library designed to fit easily in any context.
+This library is used by different Object Oriented Programming and by the other
+applications.
+
+More details available at:
+https://github.com/gnutls/nettle/
+
+This test case runs 'make check' from upstream and distribution.

--- a/security/nettle-tests.py.data/nettle.yaml
+++ b/security/nettle-tests.py.data/nettle.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://github.com/gnutls/nettle/archive/refs/heads/master.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>