### PR TITLE
seccomp-tests.py: add distribution specific test cases

### DIFF
--- a/security/seccomp-tests.py.data/seccomp.yaml
+++ b/security/seccomp-tests.py.data/seccomp.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://github.com/seccomp/libseccomp/archive/refs/heads/main.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>