### PR TITLE
xmlsec-tests.py: add distribution specific test cases

### DIFF
--- a/security/xmlsec-tests.py.data/xmlsec.yaml
+++ b/security/xmlsec-tests.py.data/xmlsec.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://github.com/lsh123/xmlsec/archive/master.zip"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>