### PR TITLE
keyutils-tests.py: add distribution specific test cases

### DIFF
--- a/security/keyutils-tests.py
+++ b/security/keyutils-tests.py
@@ -35,19 +35,33 @@ class KeyUtils(Test):
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        url = "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git"
-        git.get_repo(url, destination_dir=self.workdir)
+        run_type = self.params.get('type', default='upstream')
+        if run_type == "upstream":
+            def_url = ("https://git.kernel.org/pub/scm/linux/kernel/git/"
+                       "dhowells/keyutils.git")
+            url = self.params.get('url', default=def_url)
+            git.get_repo(url, destination_dir=self.workdir)
+            self.srcdir = os.path.join(self.workdir, 'tests')
+        elif run_type == "distro":
+            self.srcdir = os.path.join(self.workdir, "keyutils-distro")
+            if not os.path.exists(self.srcdir):
+                os.makedirs(self.srcdir)
+            self.srcdir = smm.get_source('keyutils', self.srcdir)
+            if not self.srcdir:
+                self.fail("keyutils source install failed.")
+            self.srcdir = os.path.join(self.srcdir, 'tests')
+        os.chdir(self.srcdir)
         os.environ['AUTOMATED'] = '1'
-        self.make_path = os.path.join(self.workdir, 'tests')
-        os.chdir(self.make_path)
 
     def test(self):
         '''
         Running tests from keyutils
         '''
         count = 0
-        output = build.run_make(self.make_path,
+        output = build.run_make(self.srcdir,
                                 process_kwargs={"ignore_status": True})
+        if output.exit_status:
+            self.fail("keyutils-tests.py: 'make check' failed.")
         for line in output.stdout_text.splitlines():
             if 'FAILED' in line:
                 count += 1

--- a/security/keyutils-tests.py.data/keyutils.yaml
+++ b/security/keyutils-tests.py.data/keyutils.yaml
@@ -1,0 +1,6 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'
+url: "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git"


### PR DESCRIPTION
Add distribution specific test cases.
With the support of yaml, can run distribution and upstream test cases.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.ibm.com>