### PR TITLE
ras_extended.py: compare ls_vdev output with lsblk

### DIFF
--- a/ras/ras_extended.py
+++ b/ras/ras_extended.py
@@ -105,6 +105,15 @@ class RASTools(Test):
         self.run_cmd("ls-vdev")
         self.run_cmd("ls-vdev -h")
         self.run_cmd("ls-vdev -V")
+        dev_name = self.run_cmd_out("ls-vdev").split()[1]
+        flag = True
+        for line in self.run_cmd_out("lsblk").splitlines():
+            if dev_name in line:
+                if dev_name == line.split()[0]:
+                    flag = False
+                    break;
+        if flag:
+            self.is_fail += 1
         if self.is_fail >= 1:
             self.fail("%s command(s) failed in ls-vdev tool "
                       "verification" % self.is_fail)


### PR DESCRIPTION
We are verifying the device by comparing ls-vdev and lsblk outputs, by adding a condition check

Signed-off-by: Shirisha Ganta <SHIRISHA.Ganta1@ibm.com>