### PR TITLE
ras/ras: Add support for upstream as a target

### DIFF
--- a/ras/ras.py
+++ b/ras/ras.py
@@ -72,10 +72,10 @@ class RASTools(Test):
         """
         self.log.info("===============Executing set_poweron_time tool test===="
                       "===========")
-        self.run_cmd("set_poweron_time -m")
-        self.run_cmd("set_poweron_time -h")
-        self.run_cmd("set_poweron_time -d m2")
-        self.run_cmd("set_poweron_time -t M6D15h12")
+        cmd_list = ["set_poweron_time -m", "set_poweron_time -h",
+                    "set_poweron_time -d m2", "set_poweron_time -t M6D15h12"]
+        for cmd in cmd_list:
+            self.run_cmd(cmd)
         self.error_check()
 
     @skipIf(IS_POWER_NV or IS_KVM_GUEST,
@@ -86,8 +86,9 @@ class RASTools(Test):
         """
         self.log.info("===============Executing sys_ident_tool test==========="
                       "====")
-        self.run_cmd("sys_ident -p")
-        self.run_cmd("sys_ident -s")
+        cmd_list = ["sys_ident -p", "sys_ident -s"]
+        for cmd in cmd_list:
+            self.run_cmd(cmd)
         self.error_check()
 
     def test3_lsmcode(self):
@@ -99,9 +100,9 @@ class RASTools(Test):
         self.run_cmd("vpdupdate")
         if 'FW' not in self.run_cmd_out("lsmcode"):
             self.fail("lsmcode command failed in verification")
-        self.run_cmd("lsmcode -A")
-        self.run_cmd("lsmcode -v")
-        self.run_cmd("lsmcode -D")
+        cmd_list = ["lsmcode -A", "lsmcode -v", "lsmcode -D"]
+        for cmd in cmd_list:
+            self.run_cmd(cmd)
         path_db = self.run_cmd_out("find /var/lib/lsvpd/ -iname vpd.db"
                                    " | head -1")
         if path_db:
@@ -129,10 +130,10 @@ class RASTools(Test):
         if lcpu_count:
             lcpu_count = int(lcpu_count)
             if lcpu_count >= 2:
-                self.run_cmd("drmgr -c cpu -r 1")
-                self.run_cmd("lparstat")
-                self.run_cmd("drmgr -c cpu -a 1")
-                self.run_cmd("lparstat")
+                cmd_list = ["drmgr -c cpu -r 1", "drmgr -c cpu -a 1"]
+                for cmd in cmd_list:
+                    self.run_cmd(cmd)
+                    self.run_cmd("lparstat")
         self.error_check()
 
     def test5_lsprop(self):
@@ -171,11 +172,10 @@ class RASTools(Test):
         """
         self.log.info("===============Executing lsvio tool test============="
                       "==")
-        self.run_cmd("lsvio -h")
-        self.run_cmd("lsvio -v")
-        self.run_cmd("lsvio -s")
-        self.run_cmd("lsvio -e")
-        self.run_cmd("lsvio -d")
+        cmd_list = [" -h", " -v", " -s", " -e", " -d"]
+        for cmd in cmd_list:
+            cmd_str = "lsvio" + cmd
+            self.run_cmd(cmd_str)
         self.error_check()
 
     def test8_nvram(self):
@@ -184,10 +184,11 @@ class RASTools(Test):
         """
         self.log.info("===============Executing nvram tool test============="
                       "==")
-        self.run_cmd("nvram --help")
-        self.run_cmd("nvram --partitions")
-        self.run_cmd("nvram --print-config -p common")
-        self.run_cmd("nvram --dump common --verbose")
+        cmd_list = [" --help", " --print-config -p common",
+                    " --partitions", " --dump common --verbose"]
+        for cmd in cmd_list:
+            cmd_str = "nvram" + cmd
+            self.run_cmd(cmd_str)
         self.error_check()
 
     @skipIf(IS_POWER_NV, "Skipping test in PowerNV platform")

--- a/ras/ras.py
+++ b/ras/ras.py
@@ -235,13 +235,13 @@ class RASTools(Test):
                       " test===============")
         self.log.info("1 - Injecting event")
         rtas_file = self.get_data('rtas')
-        self.run_cmd("/usr/sbin/rtas_errd -d -f %s" % rtas_file)
+        self.run_cmd("rtas_errd -d -f %s" % rtas_file)
         self.log.info("2 - Checking if the event was dumped to /var/log/"
                       "platform")
         self.run_cmd("cat /var/log/platform")
         myplatform_file = os.path.join(self.outputdir, 'myplatformfile')
         my_log = os.path.join(self.outputdir, 'mylog')
-        self.run_cmd("/usr/sbin/rtas_errd -d -f %s -p %s -l %s" %
+        self.run_cmd("rtas_errd -d -f %s -p %s -l %s" %
                      (rtas_file, myplatform_file, my_log))
         self.run_cmd("cat %s" % myplatform_file)
         self.run_cmd("cat %s" % my_log)

--- a/ras/ras.py
+++ b/ras/ras.py
@@ -13,6 +13,7 @@
 #
 # Copyright: 2016 IBM
 # Author: Pavithra <pavrampu@linux.vnet.ibm.com>
+# Author: Sachin Sant <sachinp@linux.ibm.com>
 
 import os
 from shutil import copyfile
@@ -48,6 +49,9 @@ class RASTools(Test):
     @skipUnless("ppc" in distro.detect().arch,
                 "supported only on Power platform")
     def setUp(self):
+        """
+        Prepare the system for test run
+        """
         sm = SoftwareManager()
         for package in ("ppc64-diag", "powerpc-utils", "lsvpd", "ipmitool"):
             if not sm.check_installed(package) and not sm.install(package):
@@ -60,7 +64,8 @@ class RASTools(Test):
                                      ignore_status=True,
                                      sudo=True).decode("utf-8").strip()
 
-    @skipIf(IS_POWER_NV or IS_KVM_GUEST, "This test is not supported on KVM guest or PowerNV platform")
+    @skipIf(IS_POWER_NV or IS_KVM_GUEST,
+            "This test is not supported on KVM guest or PowerNV platform")
     def test1_set_poweron_time(self):
         """
         set_poweron_time schedules the power on time
@@ -73,7 +78,8 @@ class RASTools(Test):
         self.run_cmd("set_poweron_time -t M6D15h12")
         self.error_check()
 
-    @skipIf(IS_POWER_NV or IS_KVM_GUEST, "This test is not supported on KVM guest or PowerNV platform")
+    @skipIf(IS_POWER_NV or IS_KVM_GUEST,
+            "This test is not supported on KVM guest or PowerNV platform")
     def test2_sys_ident_tool(self):
         """
         sys_ident provides unique system identification information
@@ -201,11 +207,13 @@ class RASTools(Test):
                                      "tail -1 | cut -d' ' -f1")
         if disk_name:
             self.run_cmd("ofpathname %s" % disk_name)
-            of_name = self.run_cmd_out("ofpathname %s" % disk_name).split(':')[0]
+            of_name = self.run_cmd_out("ofpathname %s" %
+                                       disk_name).split(':')[0]
             self.run_cmd("ofpathname -l %s" % of_name)
         self.error_check()
 
-    @skipIf(IS_POWER_NV or IS_KVM_GUEST, "This test is not supported on KVM guest or PowerNV platform")
+    @skipIf(IS_POWER_NV or IS_KVM_GUEST,
+            "This test is not supported on KVM guest or PowerNV platform")
     def test11_rtas_ibm_get_vpd(self):
         """
         rtas_ibm_get_vpd gives vpd data
@@ -248,7 +256,10 @@ class RASTools(Test):
 
     @skipIf(IS_POWER_NV, "This test is not supported on PowerNV platform")
     def test13_rtas_event_decode(self):
-        self.log.info("===============Executing rtas_event_decode tool test===="
+        """
+        Verify RTAS event data using rtas_event_decode
+        """
+        self.log.info("==============Executing rtas_event_decode tool test===="
                       "===========")
         cmd = "rtas_event_decode -w 500 -dv -n 2302 < %s" % self.get_data(
             'rtas')

--- a/ras/ras.py.data/ras.yaml
+++ b/ras/ras.py.data/ras.yaml
@@ -1,0 +1,8 @@
+run_type: !mux
+    upstream:
+        ppcutils_url: 'https://github.com/ibm-power-utilities/powerpc-utils/archive/refs/heads/master.zip'
+        lsvpd_url: 'https://github.com/power-ras/lsvpd/archive/refs/heads/master.zip'
+        ppcdiag_url: 'https://github.com/power-ras/ppc64-diag/archive/refs/heads/master.zip'
+        type: 'upstream'
+    distro:
+        type: 'distro'


### PR DESCRIPTION
This four patch series adds support for upstream as a target.
[patch 1/4] ras/ras.py: Code style fixes
[patch 2/4] ras/ras.py: Code refactor to avoid repetitive commands
Patches 1 and 2 contain minor fixes and code restructure.
[patch 3/4] ras/ras.py: Don't use absolute path for rtas_errd
Patch 3 is in prep for patch 4.
[patch 4/4] ras/ras.py: Add support for upstream as target
Patch 4 adds support for upstream as a target.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>