### PR TITLE
Add rhel-9 distro check to cancel the test

### DIFF
--- a/memory/migrate_pages.py
+++ b/memory/migrate_pages.py
@@ -51,6 +51,8 @@ class MigratePages(Test):
                         'Node list with memory: %s' % nodes)
 
         dist = distro.detect()
+        if (dist.name == 'rhel' and dist.version == '9'):
+            self.cancel("libhugetlbfs is not available RHEL 9.x onwards")
         pkgs = ['gcc', 'make']
         if dist.name in ["Ubuntu", 'debian']:
             pkgs.extend(['libpthread-stubs0-dev',

--- a/memory/migrate_pages.py
+++ b/memory/migrate_pages.py
@@ -50,18 +50,23 @@ class MigratePages(Test):
             self.cancel('Test requires two numa nodes to run.'
                         'Node list with memory: %s' % nodes)
 
-        dist = distro.detect()
-        if (dist.name == 'rhel' and dist.version == '9'):
-            self.cancel("libhugetlbfs is not available RHEL 9.x onwards")
+        self.dist = distro.detect()
         pkgs = ['gcc', 'make']
-        if dist.name in ["Ubuntu", 'debian']:
+        if self.dist.name in ["Ubuntu", 'debian']:
             pkgs.extend(['libpthread-stubs0-dev',
                          'libnuma-dev', 'libhugetlbfs-dev'])
-        elif dist.name in ["centos", "rhel", "fedora"]:
-            pkgs.extend(['numactl-devel', 'libhugetlbfs-devel'])
-        elif dist.name == "SuSE":
+        elif self.dist.name in ["centos", "rhel", "fedora"]:
+            if (self.dist.name == 'rhel' and self.dist.version == '9'):
+                self.log.info("libhugetlbfs is not available RHEL 9.x onwards,\
+                                so tests related to hugepage will be cancelled")
+                pkgs.extend(['numactl-devel'])
+            else:
+                pkgs.extend(['numactl-devel', 'libhugetlbfs-devel'])
+                exp_cmd = "export HAVE_HUGETLB_HEADER"
+                process.system(exp_cmd, shell=True, sudo=True, ignore_status=True)
+        elif self.dist.name == "SuSE":
             pkgs.extend(['libnuma-devel'])
-            if dist.version >= 15:
+            if self.dist.version >= 15:
                 pkgs.extend(['libhugetlbfs-devel'])
             else:
                 pkgs.extend(['libhugetlbfs-libhugetlb-devel'])
@@ -88,9 +93,14 @@ class MigratePages(Test):
         cmd = './node_move_pages -n %s' % self.nr_chunks
 
         if self.hpage:
-            cmd += ' -h'
-            if self.hpage_commit:
-                cmd += ' -o'
+           if (self.dist.name == 'rhel' and self.dist.version == '9'):
+               if self.hpage_commit:
+                  self.cancel("Hugepage(over commit) tests are cancelled on RHEL-9")
+               self.cancel("Hugepage tests are cancelled on RHEL-9")
+           else:
+              cmd += ' -h'
+              if self.hpage_commit:
+                 cmd += ' -o'
         elif self.thp:
             cmd += ' -t'
 

--- a/memory/migrate_pages.py.data/Makefile
+++ b/memory/migrate_pages.py.data/Makefile
@@ -1,7 +1,11 @@
 all : node_move_pages
 
 node_move_pages : node_move_pages.c
-	gcc node_move_pages.c -o $@ -lhugetlbfs -lnuma
+ifdef HAVE_HUGETLB_HEADER
+        gcc node_move_pages.c -o $@ -lhugetlbfs -lnuma
+else
+        gcc node_move_pages.c -o $@ -lnuma
+endif
 
 clean :
 	rm node_move_pages

--- a/memory/migrate_pages.py.data/node_move_pages.c
+++ b/memory/migrate_pages.py.data/node_move_pages.c
@@ -329,30 +329,31 @@ int main(int argc, char *argv[])
                 case 'n':
 			chunks = strtoul(optarg, NULL, 10);
                         break;
-                case 'o':
-#ifdef HAVE_HUGETLB_HEADER
-			overcommit = 1;
-#else			
-                        overcommit = 0;
-#endif			
-			break;
-
-		case 't':
+                case 't':
 			thp = 1;
                         break;
-                case 'h':
 #ifdef HAVE_HUGETLB_HEADER
+               case 'o':
+
+                         overcommit = 1;
+                         break;
+
+
+		case 'h':
+
 			hugepage = 1;
 			pagesize = gethugepagesize();
 			/* Using 1% of system memory for hugepages*/
         		memory = (total_mem) / 100;
-#else
-			hugepage = 0 ;
-#endif		       	
-			break;
-                default:
-                        errmsg("%s [-n <no-of-chunks] [-t fot THP] [-o for hugepage-overcommit] [-h for hugepage]\n", argv[0]);
                         break;
+#endif
+                default:
+#ifndef HAVE_HUGETLB_HEADER
+			errmsg("%s [-n <no-of-chunks] [-t fot THP] \n", argv[0]);
+#else
+			errmsg("%s [-n <no-of-chunks] [-t fot THP] [-o for hugepage-overcommit] [-h for hugepage]\n", argv[0]);
+#endif                        
+			break;
                 }
         }
 	if ((hugepage && thp) || (thp && overcommit))

--- a/memory/migrate_pages.py.data/node_move_pages.c
+++ b/memory/migrate_pages.py.data/node_move_pages.c
@@ -6,7 +6,9 @@
 #include <fcntl.h>
 #include <numa.h>
 #include <numaif.h>
+#ifdef HAVE_HUGETLB_HEADER
 #include <hugetlbfs.h>
+#endif
 
 #define PATTERN		0xff
 #define PAGE_SHIFT 12
@@ -328,17 +330,26 @@ int main(int argc, char *argv[])
 			chunks = strtoul(optarg, NULL, 10);
                         break;
                 case 'o':
+#ifdef HAVE_HUGETLB_HEADER
 			overcommit = 1;
-                        break;
-                case 't':
+#else			
+                        overcommit = 0;
+#endif			
+			break;
+
+		case 't':
 			thp = 1;
                         break;
                 case 'h':
+#ifdef HAVE_HUGETLB_HEADER
 			hugepage = 1;
 			pagesize = gethugepagesize();
 			/* Using 1% of system memory for hugepages*/
         		memory = (total_mem) / 100;
-                        break;
+#else
+			hugepage = 0 ;
+#endif		       	
+			break;
                 default:
                         errmsg("%s [-n <no-of-chunks] [-t fot THP] [-o for hugepage-overcommit] [-h for hugepage]\n", argv[0]);
                         break;


### PR DESCRIPTION
  RHEL-9 distro does not provide libhugetlbfs packages.
  Distro check is added to cancel the tests.

Signed-off-by: Saurabh Singh <Saurabh.Singh2@amd.com>