### PR TITLE
We don't use mlx5_fpga_tools sub module

### DIFF
--- a/io/driver/module_unload_load.py.data/config
+++ b/io/driver/module_unload_load.py.data/config
@@ -1,5 +1,5 @@
 mlx4_core=mlx4_en mlx4_ib
-mlx5_core=mlx5_fpga_tools mlx5_ib
+mlx5_core=mlx5_vdpa mlx5_ib
 xhci_hcd=xhci_pci
 qla2xxx=multipath
 lpfc=multipath


### PR DESCRIPTION
mlx_fpga tool allows the user to burn and update a new FPGA image on Mellanox Innova adapter cards

On IBM Power box we don't support Mellanox Innova adapter cards

As per the bug 192581 we don't need to check this module in the testcase

Signed-off-by: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>