### PR TITLE
memory/transparent_hugepages*.py: Add THP support check based on sysf…

### DIFF
--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -24,7 +24,7 @@ from avocado.core import data_dir
 from avocado.utils.partition import Partition
 
 
-PAGESIZE = '4096' in str(memory.get_page_size())
+THP_PATH = os.path.exists("/sys/kernel/mm/transparent_hugepage")
 
 
 class Thp(Test):
@@ -36,7 +36,8 @@ class Thp(Test):
     :avocado: tags=memory,privileged,hugepage
     '''
 
-    @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipIf(not THP_PATH, "No THP support in the kernel,\
+            make sure that the kernel configured with THP support")
     @skipUnless('Hugepagesize' in dict(memory.meminfo),
                 "Hugepagesize not defined in kernel.")
     def setUp(self):

--- a/memory/transparent_hugepages_defrag.py
+++ b/memory/transparent_hugepages_defrag.py
@@ -28,7 +28,7 @@ from avocado.core import data_dir
 from avocado.utils.partition import Partition
 
 
-PAGESIZE = '4096' in str(memory.get_page_size())
+THP_PATH = os.path.exists("/sys/kernel/mm/transparent_hugepage")
 
 
 class ThpDefrag(Test):
@@ -40,7 +40,8 @@ class ThpDefrag(Test):
     :avocado: tags=memory,privileged,hugepage
     '''
 
-    @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipIf(not THP_PATH, "No THP support in the kernel,\
+            make sure that the kernel configured with THP support")
     @skipUnless('Hugepagesize' in dict(memory.meminfo),
                 "Hugepagesize not defined in kernel.")
     def setUp(self):

--- a/memory/transparent_hugepages_swapping.py
+++ b/memory/transparent_hugepages_swapping.py
@@ -25,7 +25,7 @@ from avocado.core import data_dir
 from avocado.utils.partition import Partition
 
 
-PAGESIZE = '4096' in str(memory.get_page_size())
+THP_PATH = os.path.exists("/sys/kernel/mm/transparent_hugepage")
 
 
 class ThpSwapping(Test):
@@ -36,7 +36,8 @@ class ThpSwapping(Test):
     :avocado: tags=memory,privileged,hugepage
     '''
 
-    @skipIf(PAGESIZE, "No THP support for kernel with 4K PAGESIZE")
+    @skipIf(not THP_PATH, "No THP support in the kernel,\
+            make sure that the kernel configured with THP support")
     @skipUnless('Hugepagesize' in dict(memory.meminfo),
                 "Hugepagesize not defined in kernel.")
     def setUp(self):


### PR DESCRIPTION
…s "transparent_hugepage" path

  Current test code uses PAGE SIZE to determine whether THP is supported or not. This doesn't work when we have
  platform with different PAGESIZE (like x86 with 4K).

  The better way is to check, if the sysfs "transparent_hugepage" path exists; i.e check for the path
   "/sys/kernel/mm/transparent_hugepage" and skip the test if path doesn't exists.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>