### PR TITLE
add perf_sched

### DIFF
--- a/perf/perf_sched.py
+++ b/perf/perf_sched.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2022 IBM
+# Author: Disha Goel <disgoel@linux.vnet.ibm.com>
+
+import os
+import platform
+import tempfile
+from avocado import Test
+from avocado.utils import distro, process, dmesg
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class perf_sched(Test):
+
+    """
+    Tests perf sched and it's options with all
+    possible flags with the help of yaml file
+    :avocado: tags=perf,sched
+    """
+
+    def setUp(self):
+        '''
+        Install the basic packages to support perf
+        '''
+
+        # Check for basic utilities
+        smm = SoftwareManager()
+        detected_distro = distro.detect()
+        self.distro_name = detected_distro.name
+
+        deps = ['gcc', 'make']
+        if 'Ubuntu' in self.distro_name:
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
+        elif 'debian' in detected_distro.name:
+            deps.extend(['linux-perf'])
+        elif self.distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
+            deps.extend(['perf'])
+        else:
+            self.cancel("Install the package for perf supported \
+                         by %s" % detected_distro.name)
+        for package in deps:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+
+        # Creating temporary file to collect the perf.data
+        self.temp_file = tempfile.NamedTemporaryFile().name
+
+        # Getting the parameters from yaml file
+        self.optname = self.params.get('name', default='')
+        self.option = self.params.get('option', default='')
+
+        # Clear the dmesg by that we can capture delta at the end of the test
+        dmesg.clear_dmesg()
+
+    def run_cmd(self, cmd):
+        try:
+            process.run(cmd, ignore_status=False, sudo=True)
+        except process.CmdError as details:
+            self.fail("Command %s failed: %s" % (cmd, details))
+
+    def test_sched(self):
+        if self.optname == "timehist":
+            if self.option in ["-k", "--vmlinux", "--kallsyms"]:
+                if 'rhel' in self.distro_name:
+                    self.option = self.option + " /boot/vmlinuz-" + platform.uname()[2]
+                elif 'SuSE' in self.distro_name:
+                    self.option = self.option + " /boot/vmlinux-" + platform.uname()[2]
+
+        record_cmd = "perf sched record -o %s ls" % self.temp_file
+        self.run_cmd(record_cmd)
+        report_cmd = "perf sched -i %s %s %s" % (self.temp_file, self.optname,
+                                                 self.option)
+        self.run_cmd(report_cmd)
+        dmesg.collect_errors_dmesg(['WARNING: CPU:', 'Oops', 'Segfault',
+                                    'soft lockup', 'Unable to handle'])
+
+    def tearDown(self):
+        # Delete the temporary file
+        if os.path.isfile(self.temp_file):
+            process.run('rm -f %s' % self.temp_file)

--- a/perf/perf_sched.py.data/perf_sched.yaml
+++ b/perf/perf_sched.py.data/perf_sched.yaml
@@ -1,0 +1,79 @@
+subsystem: !mux
+    latency:
+        name: latency
+    script:
+        name: script
+    replay:
+        name: replay
+    map:
+        name: map
+        variants: !mux
+            compact:
+                option: --compact
+            cpus:
+                option: --cpus 0
+            color-cpus:
+                option: --color-cpus 0
+            color-pids:
+                option: --color-pids 10
+    timehist:
+        name: timehist
+        variants: !mux
+            call-graph:
+                option: -g
+            call-graph_full:
+                option: --call-graph
+            max-stack:
+                option: --max-stack 2
+            cpu:
+                option: -C 0
+            cpu_full:
+                option: --cpu 0
+            pid:
+                option: -p 10
+            pid_full:
+                option: --pid 10
+            tid:
+                option: -t 10
+            tid_full:
+                option: --tid 10
+            summary:
+                option: -s
+            summary_full:
+                option: --summary
+            with-summary:
+                option: -S
+            with-summary_full:
+                option: --with-summary
+            symfs:
+                option: --symfs=/sys/devices/
+            cpu-visual:
+                option: -V
+            cpu-visual_full:
+                option: --cpu-visual
+            wakeups:
+                option: -w
+            wakeups_full:
+                option: --wakeups
+            migrations:
+                option: -M
+            migrations_full:
+                option: --migrations
+            next:
+                option: -n
+            next_full:
+                option: --next
+            idle-hist:
+                option: -I
+            idle-hist_full:
+                option: --idle-hist
+            time:
+                option: --time 10
+            state:
+                option: --state
+            vmlinux:
+                option: -k
+            vmlinux_full:
+                option: --vmlinux
+            kallsyms:
+                option: --kallsyms


### PR DESCRIPTION
added perf_sched.py testcase which tests perf sched and it's options with all possible flags with the help of yaml file

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner perf_sched.py -m perf_sched.py.data/perf_sched.yaml 
JOB ID     : a52b2bbed1c5b092a69d89c6dfcf487586c33c4c
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-10-27T05.10-a52b2bb/job.log
 (01/36) sched.py:perf_sched.test_sched;run-subsystem-latency-1953: PASS (3.66 s)
 (02/36) sched.py:perf_sched.test_sched;run-subsystem-script-1269: PASS (3.78 s)
 (03/36) sched.py:perf_sched.test_sched;run-subsystem-replay-9bfb: PASS (6.73 s)
 (04/36) sched.py:perf_sched.test_sched;run-subsystem-map-variants-compact-1ddc: PASS (3.63 s)
 (05/36) sched.py:perf_sched.test_sched;run-subsystem-map-variants-cpus-860b: PASS (3.69 s)
 (06/36) sched.py:perf_sched.test_sched;run-subsystem-map-variants-color-cpus-bf2a: PASS (3.63 s)
 (07/36) sched.py:perf_sched.test_sched;run-subsystem-map-variants-color-pids-16d7: PASS (3.56 s)
 (08/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph-f285: PASS (3.80 s)
 (09/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph_full-f3b8: PASS (3.77 s)
 (10/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-max-stack-2e8b: PASS (3.77 s)
 (11/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-10f5: PASS (3.76 s)
 (12/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu_full-ba63: PASS (3.73 s)
 (13/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-pid-efda: PASS (3.77 s)
 (14/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-pid_full-00fc: PASS (3.67 s)
 (15/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-tid-e7e2: PASS (3.83 s)
 (16/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-tid_full-39c5: PASS (3.75 s)
 (17/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary-a1ad: PASS (3.74 s)
 (18/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary_full-6ab1: PASS (3.69 s)
 (19/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-with-summary-82c8: PASS (3.71 s)
 (20/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-with-summary_full-5e4b: PASS (3.65 s)
 (21/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-symfs-fd98: PASS (3.86 s)
 (22/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-visual-4afb: PASS (3.69 s)
 (23/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-visual_full-09ea: PASS (3.78 s)
 (24/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-wakeups-c719: PASS (3.72 s)
 (25/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-wakeups_full-bd47: PASS (3.75 s)
 (26/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-migrations-6ae9: PASS (3.69 s)
 (27/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-migrations_full-388b: PASS (3.69 s)
 (28/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-next-521e: PASS (3.87 s)
 (29/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-next_full-4bcf: PASS (3.86 s)
 (30/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-idle-hist-721f: PASS (3.63 s)
 (31/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-idle-hist_full-3648: PASS (3.90 s)
 (32/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-time-9875: PASS (3.76 s)
 (33/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-state-91c9: PASS (3.72 s)
 (34/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-vmlinux-83d4: PASS (3.68 s)
 (35/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-vmlinux_full-26ca: PASS (3.64 s)
 (36/36) sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-kallsyms-0889: PASS (3.88 s)
RESULTS    : PASS 36 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-10-27T05.10-a52b2bb/results.html
JOB TIME   : 150.89 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9878401/job.log)