### PR TITLE
perf/perf_genericevents.py: Add generic events for AMD platform

### DIFF
--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -78,3 +78,23 @@ LLC-store-misses = 0x26880
 LLC-stores = 0x10000046080
 mem-loads = 0x35340401e0
 mem-stores = 0x353c0401e0
+
+[AMD16h]
+cpu-cycles = 0x76
+instructions = 0xc0
+cache-references = 0x077d
+cache-misses = 0x077e
+branch-instructions = 0xc2
+branch-misses = 0xc3
+stalled-cycles-frontend = 0xd0
+stalled-cycles-backend = 0xd1
+
+[AMD17h]
+cpu-cycles = 0x76
+instructions = 0xc0
+cache-references = 0xff60
+cache-misses = 0x0964
+branch-instructions = 0xc2
+branch-misses = 0xc3
+stalled-cycles-frontend = 0x0287
+stalled-cycles-backend = 0x0187


### PR DESCRIPTION
   Perf generic events test case has been updated to add AMD 16h, 17h family default generic events.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>