### PR TITLE
Remove master file cleanup code and use utils

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -132,11 +132,6 @@ class Bonding(Test):
         self.peer_wait_time = self.params.get("peer_wait_time", default=5)
         self.sleep_time = int(self.params.get("sleep_time", default=5))
         self.mtu = self.params.get("mtu", default=1500)
-        for root, dirct, files in os.walk("/root/.ssh"):
-            for file in files:
-                if file.startswith("avocado-master-"):
-                    path = os.path.join(root, file)
-                    os.remove(path)
         self.ib = False
         if self.host_interface[0:2] == 'ib':
             self.ib = True
@@ -154,6 +149,7 @@ class Bonding(Test):
             self.session = Session(self.peer_first_ipinterface[0], user=self.user,
                                    password=self.password)
 
+        self.session.cleanup_master()
         if not self.session.connect():
             '''
             LACP bond interface takes some time to get it to ping peer after it

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -65,11 +65,6 @@ class NetworkTest(Test):
         self.netmask = self.params.get("netmask", default="")
         self.ip_config = self.params.get("ip_config", default=True)
         self.hbond = self.params.get("hbond", default=False)
-        for root, dirct, files in os.walk("/root/.ssh"):
-            for file in files:
-                if file.startswith("avocado-master-root"):
-                    path = os.path.join(root, file)
-                    os.remove(path)
         local = LocalHost()
         if self.hbond:
             self.networkinterface = NetworkInterface(self.iface, local, if_type='Bond')
@@ -95,6 +90,7 @@ class NetworkTest(Test):
         if 'scp' or 'ssh' in str(self.name.name):
             self.session = Session(self.peer, user=self.peer_user,
                                    password=self.peer_password)
+            self.session.cleanup_master()
             if not self.session.connect():
                 self.cancel("failed connecting to peer")
         self.remotehost = RemoteHost(self.peer, self.peer_user,

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -66,13 +66,9 @@ class NetworkVirtualization(Test):
         self.lpar = self.get_partition_name("Partition Name")
         if not self.lpar:
             self.cancel("LPAR Name not got from lparstat command")
-        for root, dirct, files in os.walk("/root/.ssh"):
-            for file in files:
-                if file.startswith("avocado-master-"):
-                    path = os.path.join(root, file)
-                    os.remove(path)
         self.session_hmc = Session(self.hmc_ip, user=self.hmc_username,
                                    password=self.hmc_pwd)
+        self.session_hmc.cleanup_master()
         if not self.session_hmc.connect():
             self.cancel("failed connecting to HMC")
         cmd = 'lssyscfg -r sys  -F name'
@@ -440,6 +436,7 @@ class NetworkVirtualization(Test):
 
         self.session = Session(self.vios_ip, user=self.vios_user,
                                password=self.vios_pwd)
+        self.session.cleanup_master()
         if not wait.wait_for(self.session.connect, timeout=30):
             self.fail("Failed connecting to VIOS")
 


### PR DESCRIPTION
Some case of interuption causes unclean master files, to clean the old code is removed and used cleanup_master utill

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>