### PR TITLE
fix perf_c2c vmlinux path

### DIFF
--- a/perf/perf_c2c.py
+++ b/perf/perf_c2c.py
@@ -17,7 +17,7 @@
 import os
 import platform
 from avocado import Test
-from avocado.utils import distro, process
+from avocado.utils import distro, process, dmesg
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -68,15 +68,7 @@ class perf_c2c(Test):
 
         # Clear the dmesg, by that we can capture the delta at the end of the
         # test.
-        process.run("dmesg -C", sudo=True)
-
-    def verify_dmesg(self):
-        self.whiteboard = process.system_output("dmesg").decode("utf-8")
-        pattern = ['WARNING: CPU:', 'Oops',
-                   'Segfault', 'soft lockup', 'Unable to handle']
-        for fail_pattern in pattern:
-            if 'fail_pattern' in self.whiteboard:
-                self.fail("Test Failed : %s in dmesg" % fail_pattern)
+        dmesg.clear_dmesg()
 
     def run_cmd(self, cmd):
         try:
@@ -106,7 +98,8 @@ class perf_c2c(Test):
         report_cmd = "perf c2c report %s" % self.report
         self.run_cmd(report_cmd)
         # Verify dmesg
-        self.verify_dmesg()
+        dmesg.collect_errors_dmesg(['WARNING: CPU:', 'Oops', 'Segfault',
+                                    'soft lockup', 'Unable to handle'])
 
     def tearDown(self):
         # Delete the temporary file

--- a/perf/perf_c2c.py.data/record_report.yaml
+++ b/perf/perf_c2c.py.data/record_report.yaml
@@ -46,9 +46,9 @@ report: !mux
         input_full:
                 report_method: --input
         vmlinux:
-                report_method: -k /boot/vmlinux
+                report_method: -k
         vmlinux_full:
-                report_method: --vmlinux /boot/vmlinux
+                report_method: --vmlinux
         node-info:
                 report_method: -N
         node-info_full:


### PR DESCRIPTION
With earlier versions -k & --vmlinux works with any provided input which is fixed in rhel 9.1. Starting rhel 9.1 we need to pass exact vmlinux path with -k & --vmlinux report option. Fixed script to take correct path and store c2c report in perf.data file. This change works fine in older releases also.

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner perf_c2c.py -m perf_c2c.py.data/record_report.yaml
JOB ID     : 53388269137ac47a82b353412d928d271aaa3264
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-11-01T16.32-5338826/job.log
 (001/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-coalesce-ec55: PASS (1.68 s)
 (002/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-coalesce_full-6412: PASS (1.65 s)
 (003/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-display-lcl-8b9f: PASS (1.69 s)
 (004/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-display-rmt-aff7: PASS (1.66 s)
 (005/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-display-lcl_full-7fbc: PASS (1.69 s)
 (006/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-display-rmt_full-2b2d: PASS (1.68 s)
 (007/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-force-66c5: PASS (1.66 s)
 (008/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-force_full-46bb: PASS (1.70 s)
 (009/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-graph-4a63: PASS (1.70 s)
 (010/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-graph_full-4984: PASS (1.68 s)
 (011/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-input-2970: PASS (1.63 s)
 (012/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-input_full-c880: PASS (1.69 s)
 (013/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-vmlinux-715d: PASS (1.71 s)
 (014/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-vmlinux_full-72eb: PASS (1.69 s)
 (015/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-node-info-40df: PASS (1.73 s)
 (016/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-node-info_full-6c15: PASS (1.69 s)
 (017/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-full-symbols-3fad: PASS (1.77 s)
 (018/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-no-source-d2c3: PASS (1.65 s)
 (019/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-show-all-e38d: PASS (1.66 s)
 (020/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-stats-28f8: PASS (1.65 s)
 (021/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-stdio-6e26: PASS (1.68 s)
 (022/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-coalesce-159f: PASS (1.63 s)
 (023/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-coalesce_full-4a6f: PASS (1.71 s)
 (024/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-display-lcl-92e9: PASS (1.70 s)
 (025/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-display-rmt-b660: PASS (1.74 s)
 (026/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-display-lcl_full-bf71: PASS (1.68 s)
 (027/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-display-rmt_full-f298: PASS (1.67 s)
 (028/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-force-8cf2: PASS (1.66 s)
 (029/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-force_full-3723: PASS (1.72 s)
 (030/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-graph-3995: PASS (1.72 s)
 (031/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-graph_full-f830: PASS (1.72 s)
 (032/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-input-89f0: PASS (1.68 s)
 (033/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-input_full-1e5a: PASS (1.65 s)
 (034/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-vmlinux-3dd4: PASS (1.64 s)
 (035/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-vmlinux_full-0aec: PASS (1.72 s)
 (036/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-node-info-1fef: PASS (1.67 s)
 (037/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-node-info_full-320d: PASS (1.74 s)
 (038/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-full-symbols-652f: PASS (1.69 s)
 (039/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-no-source-9d3d: PASS (1.71 s)
 (040/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-show-all-eaa6: PASS (1.73 s)
 (041/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-stats-cde3: PASS (1.76 s)
 (042/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__load_full-report-stdio-2801: PASS (1.67 s)
 (043/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-coalesce-ba36: PASS (1.68 s)
 (044/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-coalesce_full-7b38: PASS (1.76 s)
 (045/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-display-lcl-e633: PASS (1.67 s)
 (046/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-display-rmt-d966: PASS (1.69 s)
 (047/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-display-lcl_full-9c0b: PASS (1.69 s)
 (048/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-display-rmt_full-e1e2: PASS (1.73 s)
 (049/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-force-eb82: PASS (1.68 s)
 (050/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-force_full-1a9f: PASS (1.67 s)
 (051/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-graph-cb66: PASS (1.69 s)
 (052/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-graph_full-eb62: PASS (1.66 s)
 (053/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-input-b6eb: PASS (1.66 s)
 (054/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-input_full-cbe0: PASS (1.68 s)
 (055/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-vmlinux-a58c: PASS (1.70 s)
 (056/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-vmlinux_full-1fd0: PASS (1.69 s)
 (057/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-node-info-0b06: PASS (1.69 s)
 (058/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-node-info_full-d6e7: PASS (1.70 s)
 (059/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-full-symbols-534c: PASS (1.65 s)
 (060/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-no-source-9087: PASS (1.69 s)
 (061/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-show-all-2b5f: PASS (1.72 s)
 (062/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-stats-4a42: PASS (1.73 s)
 (063/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_store-report-stdio-d38d: PASS (1.72 s)
 (064/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-coalesce-e43b: PASS (1.65 s)
 (065/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-coalesce_full-8717: PASS (1.68 s)
 (066/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-display-lcl-e65a: PASS (1.69 s)
 (067/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-display-rmt-5aea: PASS (1.70 s)
 (068/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-display-lcl_full-9970: PASS (1.70 s)
 (069/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-display-rmt_full-8edd: PASS (1.68 s)
 (070/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-force-cf21: PASS (1.70 s)
 (071/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-force_full-5666: PASS (1.65 s)
 (072/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-graph-acb7: PASS (1.72 s)
 (073/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-graph_full-0ae8: PASS (1.73 s)
 (074/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-input-8117: PASS (1.66 s)
 (075/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-input_full-0678: PASS (1.71 s)
 (076/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-vmlinux-1d05: PASS (1.65 s)
 (077/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-vmlinux_full-d523: PASS (1.69 s)
 (078/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-node-info-0fca: PASS (1.74 s)
 (079/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-node-info_full-3e5a: PASS (1.64 s)
 (080/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-full-symbols-b68d: PASS (1.69 s)
 (081/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-no-source-c660: PASS (1.63 s)
 (082/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-show-all-1bbe: PASS (1.65 s)
 (083/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-stats-79f8: PASS (1.70 s)
 (084/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event__store_full-report-stdio-24b4: PASS (1.67 s)
 (085/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-coalesce-d478: PASS (1.69 s)
 (086/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-coalesce_full-f305: PASS (1.68 s)
 (087/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-display-lcl-4b81: PASS (1.70 s)
 (088/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-display-rmt-6e39: PASS (1.71 s)
 (089/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-display-lcl_full-316d: PASS (1.68 s)
 (090/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-display-rmt_full-92ba: PASS (1.71 s)
 (091/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-force-95bd: PASS (1.66 s)
 (092/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-force_full-2e53: PASS (1.73 s)
 (093/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-graph-2ac6: PASS (1.69 s)
 (094/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-graph_full-abed: PASS (1.69 s)
 (095/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-input-dfd0: PASS (1.72 s)
 (096/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-input_full-be7b: PASS (1.72 s)
 (097/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-vmlinux-9140: PASS (1.69 s)
 (098/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-vmlinux_full-5bf5: PASS (1.68 s)
 (099/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-node-info-6124: PASS (1.68 s)
 (100/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-node-info_full-a74a: PASS (1.63 s)
 (101/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-full-symbols-4c88: PASS (1.66 s)
 (102/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-no-source-357b: PASS (1.69 s)
 (103/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-show-all-c3b1: PASS (1.72 s)
 (104/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-stats-bae7: PASS (1.67 s)
 (105/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel-report-stdio-443f: PASS (1.68 s)
 (106/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-coalesce-8b30: PASS (1.74 s)
 (107/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-coalesce_full-c377: PASS (1.69 s)
 (108/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-display-lcl-e78e: PASS (1.70 s)
 (109/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-display-rmt-dd0d: PASS (1.67 s)
 (110/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-display-lcl_full-fd7a: PASS (1.66 s)
 (111/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-display-rmt_full-2e24: PASS (1.65 s)
 (112/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-force-825f: PASS (1.70 s)
 (113/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-force_full-8d4b: PASS (1.68 s)
 (114/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-graph-c956: PASS (1.67 s)
 (115/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-graph_full-703b: PASS (1.75 s)
 (116/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-input-0af0: PASS (1.66 s)
 (117/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-input_full-5295: PASS (1.71 s)
 (118/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-vmlinux-77f4: PASS (1.68 s)
 (119/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-vmlinux_full-fb31: PASS (1.69 s)
 (120/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-node-info-956e: PASS (1.72 s)
 (121/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-node-info_full-6ad7: PASS (1.75 s)
 (122/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-full-symbols-ec0e: PASS (1.70 s)
 (123/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-no-source-98ab: PASS (1.69 s)
 (124/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-show-all-6349: PASS (1.74 s)
 (125/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-stats-6743: PASS (1.67 s)
 (126/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_kernel_full-report-stdio-c391: PASS (1.67 s)
 (127/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-coalesce-2658: PASS (1.70 s)
 (128/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-coalesce_full-8760: PASS (1.72 s)
 (129/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-display-lcl-a309: PASS (1.66 s)
 (130/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-display-rmt-824b: PASS (1.68 s)
 (131/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-display-lcl_full-57ae: PASS (1.64 s)
 (132/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-display-rmt_full-31ee: PASS (1.74 s)
 (133/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-force-d13e: PASS (1.70 s)
 (134/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-force_full-ee62: PASS (1.66 s)
 (135/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-graph-55d4: PASS (1.71 s)
 (136/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-graph_full-6988: PASS (1.69 s)
 (137/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-input-6bd5: PASS (1.60 s)
 (138/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-input_full-2f89: PASS (1.75 s)
 (139/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-vmlinux-076c: PASS (1.72 s)
 (140/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-vmlinux_full-49a3: PASS (1.68 s)
 (141/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-node-info-8746: PASS (1.73 s)
 (142/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-node-info_full-3a67: PASS (1.66 s)
 (143/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-full-symbols-eed4: PASS (1.74 s)
 (144/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-no-source-60da: PASS (1.66 s)
 (145/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-show-all-b0db: PASS (1.69 s)
 (146/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-stats-e2a1: PASS (1.75 s)
 (147/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency-report-stdio-6540: PASS (1.72 s)
 (148/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-coalesce-d191: PASS (1.71 s)
 (149/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-coalesce_full-3099: PASS (1.72 s)
 (150/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-display-lcl-fed8: PASS (1.73 s)
 (151/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-display-rmt-3805: PASS (1.74 s)
 (152/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-display-lcl_full-3783: PASS (1.66 s)
 (153/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-display-rmt_full-3c29: PASS (1.62 s)
 (154/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-force-69cf: PASS (1.68 s)
 (155/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-force_full-07b5: PASS (1.67 s)
 (156/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-graph-f616: PASS (1.74 s)
 (157/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-graph_full-2cd3: PASS (1.68 s)
 (158/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-input-7fbb: PASS (1.68 s)
 (159/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-input_full-8aaf: PASS (1.65 s)
 (160/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-vmlinux-c883: PASS (1.64 s)
 (161/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-vmlinux_full-2bd2: PASS (1.71 s)
 (162/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-node-info-f556: PASS (1.65 s)
 (163/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-node-info_full-2170: PASS (1.68 s)
 (164/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-full-symbols-4527: PASS (1.69 s)
 (165/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-no-source-81c5: PASS (1.68 s)
 (166/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-show-all-06dd: PASS (1.79 s)
 (167/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-stats-bd18: PASS (1.68 s)
 (168/210) perf_c2c.py:perf_c2c.test_c2c;run-record-latency_full-report-stdio-c696: PASS (1.70 s)
 (169/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-coalesce-d1b1: PASS (1.65 s)
 (170/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-coalesce_full-be0d: PASS (1.65 s)
 (171/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-display-lcl-bc4c: PASS (1.62 s)
 (172/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-display-rmt-7069: PASS (1.60 s)
 (173/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-display-lcl_full-de7a: PASS (1.64 s)
 (174/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-display-rmt_full-18a5: PASS (1.69 s)
 (175/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-force-6187: PASS (1.66 s)
 (176/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-force_full-b501: PASS (1.67 s)
 (177/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-graph-62f4: PASS (1.66 s)
 (178/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-graph_full-e3a2: PASS (1.65 s)
 (179/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-input-ebf3: PASS (1.66 s)
 (180/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-input_full-a943: PASS (1.69 s)
 (181/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-vmlinux-15da: PASS (1.73 s)
 (182/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-vmlinux_full-f325: PASS (1.62 s)
 (183/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-node-info-0d40: PASS (1.63 s)
 (184/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-node-info_full-1aeb: PASS (1.69 s)
 (185/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-full-symbols-dcee: PASS (1.66 s)
 (186/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-no-source-47b3: PASS (1.61 s)
 (187/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-show-all-1a19: PASS (1.60 s)
 (188/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-stats-a165: PASS (1.62 s)
 (189/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user-report-stdio-979c: PASS (1.63 s)
 (190/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-coalesce-d2ec: PASS (1.67 s)
 (191/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-coalesce_full-7b20: PASS (1.67 s)
 (192/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-display-lcl-6262: PASS (1.67 s)
 (193/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-display-rmt-ba40: PASS (1.63 s)
 (194/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-display-lcl_full-caa6: PASS (1.64 s)
 (195/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-display-rmt_full-2088: PASS (1.63 s)
 (196/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-force-d8d3: PASS (1.63 s)
 (197/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-force_full-90b8: PASS (1.70 s)
 (198/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-graph-7dbd: PASS (1.65 s)
 (199/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-graph_full-9cb0: PASS (1.63 s)
 (200/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-input-bf6b: PASS (1.70 s)
 (201/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-input_full-71fc: PASS (1.65 s)
 (202/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-vmlinux-7ebf: PASS (1.59 s)
 (203/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-vmlinux_full-ce05: PASS (1.65 s)
 (204/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-node-info-3935: PASS (1.69 s)
 (205/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-node-info_full-cd94: PASS (1.64 s)
 (206/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-full-symbols-f752: PASS (1.66 s)
 (207/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-no-source-9ada: PASS (1.67 s)
 (208/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-show-all-97a4: PASS (1.66 s)
 (209/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-stats-c483: PASS (1.65 s)
 (210/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-stdio-97a2: PASS (1.65 s)
RESULTS    : PASS 210 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-11-01T16.32-5338826/results.html
JOB TIME   : 365.64 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9909991/job.log)