### PR TITLE
ibv_xsrq_pingpong maximum allowed number of -n option value is 8192

### DIFF
--- a/io/net/infiniband/ib_pingpong.py.data/ib_pingpong_infiniband.yaml
+++ b/io/net/infiniband/ib_pingpong.py.data/ib_pingpong_infiniband.yaml
@@ -17,8 +17,8 @@ Test: !mux
         ext_test_opt: -s 524288,-s 524288 -n 10000,-s 524288 -n 100000,-q 32,-e -s 524288 -n 10000 -q 32
     xsrq_pingpong:
         tool: ibv_xsrq_pingpong
-        test_opt: -s 1024,basic,-n 100000,-e,-l 2,-m 1024
-        ext_test_opt: -s 524288,-s 524288 -n 10000,-s 524288 -n 100000,-e -s 524288 -n 10000
+        test_opt: -s 1024,basic,-n 8192,-e,-l 2,-m 1024
+        ext_test_opt: -s 524288,-s 524288 -n 8192,-s 524288 -n 8192,-e -s 524288 -n 8192
 parameters:
     ext_flag: "1"
     interface: "ib0"

--- a/io/net/infiniband/ib_pingpong.py.data/ib_pingpong_roce.yaml
+++ b/io/net/infiniband/ib_pingpong.py.data/ib_pingpong_roce.yaml
@@ -17,8 +17,8 @@ Test: !mux
         ext_test_opt: -s 524288,-s 524288 -n 10000,-s 524288 -n 100000,-q 32,-e -s 524288 -n 10000 -q 32
     xsrq_pingpong:
         tool: ibv_xsrq_pingpong
-        test_opt: -s 1024,basic,-n 100000,-e,-l 2,-m 1024
-        ext_test_opt: -s 524288,-s 524288 -n 10000,-s 524288 -n 100000,-e -s 524288 -n 10000
+        test_opt: -s 1024,basic,-n 8192,-e,-l 2,-m 1024
+        ext_test_opt: -s 524288,-s 524288 -n 8192,-s 524288 -n 8192,-e -s 524288 -n 8192
 parameters:
     ext_flag: "1"
     interface: "ib0"


### PR DESCRIPTION
Any number beyond this range will fail

Please use value less than or equal to 8192 for your test

Signed-off-by: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>