### PR TITLE
SRIOV: check MAC addr mismatch with OS

### DIFF
--- a/io/net/sriov_device_test.py
+++ b/io/net/sriov_device_test.py
@@ -159,6 +159,8 @@ class NetworkSriovDevice(Test):
             if not self.list_device(mac):
                 self.fail("failed to list logical device after add operation")
             device = self.find_device(mac)
+            if not device:
+                self.fail("MAC address differs in linux")
             networkinterface = NetworkInterface(device, self.local)
             networkinterface.add_ipaddr(ipaddr, netmask)
             networkinterface.bring_up()


### PR DESCRIPTION
Added a check to make sure the device mac addr
is not changed across hmc and Linux OS

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>