### PR TITLE
Fix HTX test case as RHEL9 onwards test does not support upstream ver…

### DIFF
--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -75,7 +75,7 @@ class HtxTest(Test):
         self.mdt_file = self.params.get('mdt_file', default='mdt.mem')
         self.time_limit = int(self.params.get('time_limit', default=2))
         self.time_unit = self.params.get('time_unit', default='m')
-        self.run_type = self.params.get('run_type', default='git')
+        self.run_type = self.params.get('run_type', default='')
         if self.time_unit == 'm':
             self.time_limit = self.time_limit * 60
         elif self.time_unit == 'h':

--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -112,6 +112,11 @@ class HtxTest(Test):
                 self.cancel("Can not install %s" % pkg)
 
         if self.run_type == 'git':
+            if self.detected_distro.name == 'rhel' and \
+                    self.detected_distro.version <= "9":
+                self.cancel("Test not supported in  %s_%s"
+                            % (self.detected_distro.name,
+                               self.detected_distro.version))
             url = "https://github.com/open-power/HTX/archive/master.zip"
             tarball = self.fetch_asset("htx.zip", locations=[url], expire='7d')
             archive.extract(tarball, self.teststmpdir)


### PR DESCRIPTION
…sion of HTX

relvent error log

make[1]: Entering directory '/home/HTX-master/bin' making dir - /home/HTX-master//install/ppc64le//usr/lpp/htx//bin/ /bin/mkdir -p /home/HTX-master//install/ppc64le//usr/lpp/htx//bin/ make -C hxssup
make[2]: Entering directory '/home/HTX-master/bin/hxssup' cc  -L/home/HTX-master//export/ppc64le//lib// nf.o start_msg.o shell.o screens.o mmenu.o misc.o hxssup.o help.o search_win.o hang_monitor.o get_dispid.o erpt.o edit.o disp_dst.o build_ipc.o T_device.o R_device.o IT_device.o COE_devic.o A_device.o ART_device.o AH_system.o AH_device.o random_ahd.o equaliser.o hotplug.o -Wl,--start-group -lrt -lhtx64 -lpthread -lc -lcfgc64 -lncurses -ltinfo -lc -Wl,--end-group -o hxssup /usr/bin/ld: edit.o:(.bss+0x0): multiple definition of `editor_PID'; hxssup.o:(.bss+0x31a4): first defined here /usr/bin/ld: equaliser.o:(.bss+0x28): multiple definition of `equaliser_debug_flag'; build_ipc.o:(.bss+0x100c): first defined here /usr/bin/ld: hotplug.o:(.bss+0x0): multiple definition of `rwlattr'; equaliser.o:(.bss+0x0): first defined here /usr/bin/ld: /home/HTX-master//export/ppc64le//lib///libhtx64.a(hxfupdate.o):(.bss+0x2050): multiple definition of `ecg_info'; build_ipc.o:(.bss+0x1000): first defined here /usr/bin/ld: /home/HTX-master//export/ppc64le//lib///libhtx64.a(htxsyscfg.o):(.bss+0x120): multiple definition of `rwlattr'; equaliser.o:(.bss+0x0): first defined here /usr/bin/ld: A_device.o: in function `A_device':
A_device.c:(.text+0x584): warning: the use of `tmpnam' is dangerous, better use `mkstemp' /usr/bin/ld: R_device.o: in function `exec_HE_script': R_device.c:(.text+0x688): warning: the use of `tempnam' is dangerous, better use `mkstemp' collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:46: all] Error 1
make[2]: Leaving directory '/home/HTX-master/bin/hxssup' make[1]: *** [Makefile:33: hxssup] Error 2
make[1]: Leaving directory '/home/HTX-master/bin'
make: *** [Makefile:25: bin] Error 2

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>