### PR TITLE
update xfstest nvdimm.yaml

### DIFF
--- a/fs/xfstests.py.data/nvdimm.yaml
+++ b/fs/xfstests.py.data/nvdimm.yaml
@@ -1,20 +1,21 @@
 skip_dangerous: True
 scratch_mnt: '/mnt/scratch_pmem'
 test_mnt: '/mnt/test_pmem'
-mount_opt: '-o dax'
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'
         mkfs_opt: '-b 65536'
-        test_range: "null"
+        mount_opt: '-o block_validity,dax'
         exclude: "048"
         gen_exclude: "null"
         share_exclude: "null"
     fs_xfs:
         fs: 'xfs'
-        mkfs_opt: '-b size=65536 -s size=4096 -m reflink=0'
+        mkfs_opt: '-b size=65536 -s size=512 -m reflink=0'
+        mount_opt: '-o dax'
         exclude: "null"
         gen_exclude: "null"
+        share_exclude: "null"
 disk_type:
     type: 'nvdimm'
     disk_test: "null"

--- a/fs/xfstests.py.data/nvdimm_log.yaml
+++ b/fs/xfstests.py.data/nvdimm_log.yaml
@@ -1,21 +1,23 @@
 skip_dangerous: True
 scratch_mnt: '/mnt/scratch_pmem'
 test_mnt: '/mnt/test_pmem'
-mount_opt: '-o dax'
 logdev: true
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'
         mkfs_opt: '-b 65536'
-        test_range: "null"
+        mount_opt: '-o block_validity,dax'
+        exclude: "048"
         gen_exclude: "null"
         share_exclude: "null"
     fs_xfs:
         fs: 'xfs'
         mkfs_opt: '-b size=65536 -s size=512 -m reflink=0'
         logdev_opt: '-l logdev'
+        mount_opt: '-o dax'
         exclude: "null"
         gen_exclude: "null"
+        share_exclude: "null"
 disk_type:
     type: 'nvdimm'
     disk_test: "null"


### PR DESCRIPTION
updated xfstest nvdimm yaml file with correct mkfs/mount and other config options

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

avocado run --test-runner runner xfstests.py -m xfstests.py.data/nvdimm.yaml
JOB ID     : 7fb98693697c143f8752df71d951dd3ddbd073a3
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-11-05T09.21-7fb9869/job.log
 (1/2) xfstests.py:Xfstests.test;run-disk_type-fs_type-fs_ext4-7dfa: PASS (52.92 s)
 (2/2) xfstests.py:Xfstests.test;run-disk_type-fs_type-fs_xfs-5038: PASS (21.68 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-11-05T09.21-7fb9869/results.html
JOB TIME   : 75.51 s

[xfstest_nvdimm-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9944046/xfstest_nvdimm-job.log)

avocado run --test-runner runner xfstests.py -m xfstests.py.data/nvdimm_log.yaml 
JOB ID     : d814cc415e54a842f95ce6b37ebd7e8d2a7d691c
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-11-05T09.24-d814cc4/job.log
 (1/2) xfstests.py:Xfstests.test;run-disk_type-fs_type-fs_ext4-681d: PASS (268.93 s)
 (2/2) xfstests.py:Xfstests.test;run-disk_type-fs_type-fs_xfs-d8d5: PASS (217.99 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-11-05T09.24-d814cc4/results.html
JOB TIME   : 487.88 s

[xfstest_nvdimm_log-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/9944049/xfstest_nvdimm_log-job.log)