### PR TITLE
use a 32-bit integer value for --burst_size option

### DIFF
--- a/io/net/infiniband/rdma_tests.py.data/ib_atomic_bw_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_atomic_bw_extended_roce.yaml
@@ -12,8 +12,8 @@ PEERCA: ""
 PEERPORT: "1"
 TIMEOUT: "600"
 test_opt: !mux
-    --burst_size=2G_--rate_limit=10:
-        test_opt: --burst_size=2G --rate_limit=10
+    --burst_size=2147483647_--rate_limit=10:
+        test_opt: --burst_size=2147483647 --rate_limit=10
 mtu: !mux
     1500:
         mtu: "1500"

--- a/io/net/infiniband/rdma_tests.py.data/ib_atomic_lat_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_atomic_lat_extended_roce.yaml
@@ -12,8 +12,8 @@ PEERCA: ""
 PEERPORT: "1"
 TIMEOUT: "600"
 test_opt: !mux
-    --burst_size=2G_--rate_limit=10:
-        test_opt: --burst_size=2G --rate_limit=10
+    --burst_size=2147483647_--rate_limit=10:
+        test_opt: --burst_size=2147483647 --rate_limit=10
 mtu: !mux
     1500:
         mtu: "1500"

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended_roce.yaml
@@ -28,8 +28,8 @@ test_opt: !mux
         test_opt: -l 4
     -c_RC:
         test_opt: -c RC
-    --burst_size=2G_--rate_limit=10:
-        test_opt: --burst_size=2G --rate_limit=10
+    --burst_size=2147483647_--rate_limit=10:
+        test_opt: --burst_size=2147483647 --rate_limit=10
     -R:
         test_opt: -R
     -R_-a:

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended_roce.yaml
@@ -24,8 +24,8 @@ test_opt: !mux
         test_opt: -y 10G
     -z:
         test_opt: -z
-    --burst_size=2G_--rate_limit=10:
-        test_opt: --burst_size=2G --rate_limit=10
+    --burst_size=2147483647_--rate_limit=10:
+        test_opt: --burst_size=2147483647 --rate_limit=10
     -R:
         test_opt: -R
     -R_-a:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended_roce.yaml
@@ -22,8 +22,8 @@ test_opt: !mux
         test_opt: -y 10G
     -z:
         test_opt: -z
-    --burst_size=2G_--rate_limit=10:
-        test_opt: --burst_size=2G --rate_limit=10
+    --burst_size=2147483647_--rate_limit=10:
+        test_opt: --burst_size=2147483647 --rate_limit=10
     -R:
         test_opt: -R
     -R_-a:


### PR DESCRIPTION
For bandwidth type app we need to use 32bit integer value equal to 2147483647

Signed-off-by: Pavaman Subramaniyam <pavsubra@linux.vnet.ibm.com>