### PR TITLE
generic change for stopping the HTX

### DIFF
--- a/generic/htx_test.py
+++ b/generic/htx_test.py
@@ -216,6 +216,7 @@ class HtxTest(Test):
                 '/usr/lpp/htx/etc/scripts/htxd_shutdown', ignore_status=True)
             process.system('umount /htx_pmem*', shell=True, ignore_status=True)
         else:
-            daemon_state = process.system_output('/etc/init.d/htx.d status')
+            cmd = '/usr/lpp/htx/etc/scripts/htx.d status'
+            daemon_state = process.system_output(cmd)
             if daemon_state.decode().split(" ")[-1] == 'running':
                 process.system('/usr/lpp/htx/etc/scripts/htxd_shutdown')


### PR DESCRIPTION
the existing way with "/etc/init.d/htx.d status" is failing as it is removed in latest HTX code. so the alternate file to get exact status is added in this code. this is working fine after changing the file path.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>