### PR TITLE
Improve platform detection logic for various ras tools

### DIFF
--- a/ras/lparstat.py
+++ b/ras/lparstat.py
@@ -17,7 +17,10 @@
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import distro
+from avocado import skipIf
 from avocado.utils.software_manager.manager import SoftwareManager
+
+IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()
 
 
 class lparstat(Test):
@@ -30,6 +33,7 @@ class lparstat(Test):
     :avocado: tags=ras,ppc64le
     """
 
+    @skipIf(IS_KVM_GUEST, "This test is not supported on KVM guest platform")
     def setUp(self):
         sm = SoftwareManager()
         detected_distro = distro.detect()

--- a/ras/ras_lsvpd.py
+++ b/ras/ras_lsvpd.py
@@ -157,6 +157,7 @@ class RASToolsLsvpd(Test):
             self.fail("%s command(s) failed in lscfg tool verification"
                       % self.is_fail)
 
+    @skipIf(IS_KVM_GUEST, "This test is not supported on KVM guest platform")
     def test_lsmcode(self):
         """
         lsmcode provides FW version information
@@ -183,7 +184,7 @@ class RASToolsLsvpd(Test):
             self.fail("%s command(s) failed in lsmcode tool verification"
                       % self.is_fail)
 
-    @skipIf(IS_POWER_NV, "Skipping test in PowerNV platform")
+    @skipIf(IS_POWER_NV or IS_KVM_GUEST, "Not supported in PowerNV/KVM guest ")
     def test_lsvio(self):
         """
         lsvio lists the virtual I/O adopters and devices
@@ -197,6 +198,7 @@ class RASToolsLsvpd(Test):
             self.fail("%s command(s) failed in lsvio tool verification"
                       % self.is_fail)
 
+    @skipIf(IS_KVM_GUEST, "This test is not supported on KVM guest platform")
     def test_locking_mechanism(self):
         """
         This tests database (vpd.db) locking mechanism when multiple

--- a/ras/ras_ppcdiag.py
+++ b/ras/ras_ppcdiag.py
@@ -16,7 +16,10 @@
 
 from avocado import Test
 from avocado.utils import process
+from avocado import skipIf
 from avocado.utils.software_manager.manager import SoftwareManager
+
+IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()
 
 
 class RASToolsPpcdiag(Test):
@@ -64,6 +67,7 @@ class RASToolsPpcdiag(Test):
             self.fail("%s command(s) failed to execute  "
                       % self.fail_cmd)
 
+    @skipIf(IS_KVM_GUEST, "This test is not supported on KVM guest platform")
     def test_usysattn(self):
         """
         View and manipulate the system attention and fault indicators (LEDs)
@@ -78,6 +82,7 @@ class RASToolsPpcdiag(Test):
             self.fail("%s command(s) failed to execute  "
                       % self.fail_cmd)
 
+    @skipIf(IS_KVM_GUEST, "This test is not supported on KVM guest platform")
     def test_usysfault(self):
         """
         View and manipulate the system attention and fault indicators (LEDs)
@@ -92,6 +97,7 @@ class RASToolsPpcdiag(Test):
             self.fail("%s command(s) failed to execute  "
                       % self.fail_cmd)
 
+    @skipIf(IS_KVM_GUEST, "This test is not supported on KVM guest platform")
     def test_usysident(self):
         """
         This tests to turn on device identify indicators and other help

--- a/ras/rtas_dbg.py
+++ b/ras/rtas_dbg.py
@@ -20,11 +20,13 @@ from avocado.utils.software_manager.manager import SoftwareManager
 from avocado import skipIf
 
 IS_POWER_NV = 'PowerNV' in genio.read_file('/proc/cpuinfo').rstrip('\t\r\n\0')
+IS_KVM_GUEST = 'qemu' in open('/proc/cpuinfo', 'r').read()
 
 
 class rtas_dbg(Test):
 
-    @skipIf(IS_POWER_NV, "This test is supported on PowerVM environment")
+    @skipIf(IS_POWER_NV or IS_KVM_GUEST,
+            "This test is supported only on PowerVM environment")
     def setUp(self):
         sm = SoftwareManager()
         if not sm.check_installed("powerpc-utils") and \

--- a/ras/rtas_dbg.py
+++ b/ras/rtas_dbg.py
@@ -34,7 +34,8 @@ class rtas_dbg(Test):
             self.cancel("Fail to install required 'powerpc-utils' package")
 
     def test_rtas_dbg(self):
-        lists = self.params.get('list', default=['-l', '-l 14', '-l get-power-level'])
+        lists = self.params.get('list', default=['-l', '-l 14',
+                                                 '-l get-power-level'])
         for list_item in lists:
             cmd = "rtas_dbg %s" % list_item
             if process.system(cmd, ignore_status=True, sudo=True):


### PR DESCRIPTION
Various tools bundled with Linux distribution are not supported inside a KVM guest.

Update the platform detection logic for such tests.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>