### PR TITLE
Removing the switch credetails details from yaml for port_bounce

### DIFF
--- a/io/disk/port_bounce.py.data/port_bounce.yaml
+++ b/io/disk/port_bounce.py.data/port_bounce.yaml
@@ -1,6 +1,6 @@
 switch_name: ""
-userid: "admin"
-password: "passw0rd"
+userid: ""
+password: "********"
 wwids: ''
 sbt: 60
 lbt: 120

--- a/io/disk/vfc-tests/virtual_fc.py.data/virtual_fc.yaml
+++ b/io/disk/vfc-tests/virtual_fc.py.data/virtual_fc.yaml
@@ -1,6 +1,6 @@
-vioses: "ltcfleet2-vios1,ltcfleet2-vios2"
-hmc_pwd: 'abc123'
-hmc_username: 'hscroot'
+vioses: ""
+hmc_pwd: '*****'
+hmc_username: '*****'
 skip_host: 'hostX'
 count: 1
 vfchost_id: '100-150'

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -19,8 +19,6 @@
 DLPAR operations
 """
 
-import os
-import shutil
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import distro
@@ -49,7 +47,7 @@ class DlparPci(Test):
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
         if not self.hmc_ip:
             self.cancel("HMC IP not got")
-        self.hmc_user = self.params.get("hmc_username", default='hscroot')
+        self.hmc_user = self.params.get("hmc_username", default='*******')
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default='********')
         self.sriov = self.params.get("sriov", default="no")
         self.lpar_1 = self.get_partition_name("Partition Name")
@@ -154,15 +152,6 @@ class DlparPci(Test):
         for pkg in packages:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel('%s is needed for the test to be run' % pkg)
-        if detected_distro.name == "Ubuntu":
-            ubuntu_url = self.params.get('ubuntu_url', default=None)
-            debs = self.params.get('debs', default=None)
-            for deb in debs:
-                deb_url = os.path.join(ubuntu_url, deb)
-                deb_install = self.fetch_asset(deb_url, expire='7d')
-                shutil.copy(deb_install, self.workdir)
-                process.system("dpkg -i %s/%s" % (self.workdir, deb),
-                               ignore_status=True, sudo=True)
 
     def rsct_service_start(self):
         '''

--- a/io/pci/dlpar.py.data/dlpar.yaml
+++ b/io/pci/dlpar.py.data/dlpar.yaml
@@ -1,5 +1,3 @@
-ubuntu_url: 'http://ausgsa.ibm.com/projects/r/rsctdev/builds/muthu/rmuts006a/ppc64le'
-debs: ['src_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core.utils_3.2.0.6-15111_ppc64el.deb', 'rsct.core_3.2.0.6-15111_ppc64el.deb', 'rsct.basic_3.2.0.6-15111_ppc64el.deb', 'devices.chrp.base.servicerm_2.5.0.1-15111_ppc64el.deb', 'dynamicrm_2.0.1-3_ppc64el.deb']
 url: 
 hmc_pwd: 
 hmc_username: 


### PR DESCRIPTION
removing the access details of switch from yaml for security reason.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>