### PR TITLE
add_dawr_test

### DIFF
--- a/trace/dawr.py
+++ b/trace/dawr.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2022 IBM
+# Author: Akanksha J N <akanksha@linux.ibm.com>
+
+import time
+import sys
+import os
+import shutil
+import pexpect
+from avocado import Test
+from avocado.utils import build, distro
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class Dawr(Test):
+    """
+    Reading single Dawr register and multiple Dawr registers
+    with gdb interface
+    """
+
+    def setUp(self):
+        '''
+        Install the basic packages to support gdb
+        '''
+        # Check for basic utilities
+        smm = SoftwareManager()
+        self.detected_distro = distro.detect()
+        self.distro_name = self.detected_distro.name
+        deps = ['gcc', 'make', 'gdb']
+        for package in deps:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+        for value in range(1, 4):
+            shutil.copyfile(self.get_data('dawr_v%d.c' % value),
+                            os.path.join(self.teststmpdir,
+                                         'dawr_v%d.c' % value))
+        shutil.copyfile(self.get_data('Makefile'),
+                        os.path.join(self.teststmpdir, 'Makefile'))
+        build.make(self.teststmpdir)
+        os.chdir(self.teststmpdir)
+
+    def run_cmd(self, bin_var):
+        child = pexpect.spawn('gdb ./%s' % bin_var, encoding='utf-8')
+        time.sleep(0.3)
+        child.logfile = sys.stdout
+        child.expect('(gdb)')
+        return_value = []
+        return child, return_value
+
+    def test_read_dawr_v1(self):
+        """
+        Setting Read/Write watchpoint on single variable using awatch and
+        executing the program
+        """
+        child, return_value = self.run_cmd('dawr_v1')
+        child.sendline('awatch a')
+        return_value.append(child.expect_exact(['watchpoint 1: a',
+                                                pexpect.TIMEOUT]))
+        child.sendline('r')
+        return_value.append(child.expect_exact(
+            ['Value = 10', pexpect.TIMEOUT]))
+        child.sendline('c')
+        return_value.append(child.expect_exact(
+            ['New value = 20', pexpect.TIMEOUT]))
+        for i in return_value:
+            if i != 0:
+                self.fail('Test case failed for 1 variable')
+
+    def test_read_dawr_v2(self):
+        """
+        Setting Read/Write watchpoints on two variables using awatch and
+        executing the program
+        """
+        child, return_value = self.run_cmd('dawr_v2')
+        i = 0
+        for value in ['a', 'b']:
+            i = i+1
+            child.sendline('awatch %s' % value)
+            return_value.append(child.expect_exact([pexpect.TIMEOUT,
+                                                    'watchpoint %s: %s'
+                                                    % (i, value)]))
+        child.sendline('r')
+        values = [pexpect.TIMEOUT, 'Value = 10', 'New value = 20',
+                  'Value = 10', 'New value = 20', 'Value = 20', 'Value = 20']
+        for match in values:
+            return_value.append(child.expect_exact([pexpect.TIMEOUT, match]))
+            child.sendline('c')
+        return_value.append(child.expect_exact(
+            [pexpect.TIMEOUT, 'exited normally']))
+        for i in return_value:
+            if i == 0:
+                self.fail('Test case failed for 2 variables')
+
+    def test_read_dawr_v3(self):
+        """
+        Setting Read/Write watchpoints on three variables using awatch and
+        executing the program
+        """
+        child, return_value = self.run_cmd('dawr_v3')
+        i = 0
+        for value in ['a', 'b', 'c']:
+            i = i+1
+            child.sendline('awatch %s' % value)
+            return_value.append(child.expect_exact([pexpect.TIMEOUT,
+                                                    'watchpoint %s: %s'
+                                                    % (i, value)]))
+        child.sendline('r')
+        return_value.append(child.expect_exact([pexpect.TIMEOUT,
+                                                'not enough available hardware']))
+        for i in return_value:
+            if i == 0:
+                self.fail('Test case failed for 3 variables')

--- a/trace/dawr.py.data/Makefile
+++ b/trace/dawr.py.data/Makefile
@@ -1,0 +1,9 @@
+all : dawr_v1  dawr_v2 dawr_v3
+dawr_v1 : dawr_v1.c
+	gcc -g -o dawr_v1 dawr_v1.c
+dawr_v2 : dawr_v2.c
+	gcc -g -o dawr_v2 dawr_v2.c
+dawr_v3 : dawr_v3.c
+	gcc -g -o dawr_v3 dawr_v3.c
+clean : 
+	rm dawr_v1 dawr_v2 dawr_v3

--- a/trace/dawr.py.data/dawr_v1.c
+++ b/trace/dawr.py.data/dawr_v1.c
@@ -1,0 +1,23 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2022 IBM
+# Author: Akanksha J N <akanksha@linux.ibm.com>
+
+#include <stdio.h>
+int a = 10;
+int main()
+{
+    a += 10;
+    printf("%p", &a);
+    return 0;
+}
+

--- a/trace/dawr.py.data/dawr_v2.c
+++ b/trace/dawr.py.data/dawr_v2.c
@@ -1,0 +1,25 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2022 IBM
+# Author: Akanksha J N <akanksha@linux.ibm.com>
+
+#include <stdio.h>
+int a = 10;
+int b = 10;
+int main()
+{
+    a += 10;
+    b += 10;
+    printf("%p, %p\n", &a, &b);
+    return 0;
+}
+

--- a/trace/dawr.py.data/dawr_v3.c
+++ b/trace/dawr.py.data/dawr_v3.c
@@ -1,0 +1,25 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2022 IBM
+# Author: Akanksha J N <akanksha@linux.ibm.com>
+
+#include<stdio.h>
+int a=10;
+int b=50;
+int c=100;
+int main()
+{	a+=10;
+	b+=10;
+	c+=10;
+	printf("%p, %p ,%p/n", &a, &b, &c);
+	return 0;
+}


### PR DESCRIPTION
Reading single dawr register and multiple dawr registers with gdb interface

Signed-off-by: Akanksha J N <akanksha@linux.ibm.com>

# avocado run --test-runner runner dawr.py 
JOB ID     : 7ba758268998e02e31f0950ed2ebe7f74d8873e7
JOB LOG    : /root/ak/avocado-fvt-wrapper/results/job-2022-12-01T00.00-7ba7582/job.log
 (1/3) dawr.py:Dawr.test_read_dawr_v1: PASS (2.41 s)
 (2/3) dawr.py:Dawr.test_read_dawr_v2: PASS (32.58 s)
 (3/3) dawr.py:Dawr.test_read_dawr_v3: PASS (2.33 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/ak/avocado-fvt-wrapper/results/job-2022-12-01T00.00-7ba7582/results.html
JOB TIME   : 67.53 s



[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10129800/job.log)


