### PR TITLE
vnic: Get backing devices for specific slot

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -755,14 +755,14 @@ class NetworkVirtualization(Test):
             self.fail("lshwres operation failed ")
         return output.stdout_text
 
-    def get_backing_devices(self):
+    def get_backing_devices(self, slot):
         '''
         Lists the Backing devices for a Network virtualized
         device
         '''
         cmd = 'lshwres -r virtualio -m %s --rsubtype vnic --level lpar \
-               --filter lpar_names=%s -F backing_devices' \
-               % (self.server, self.lpar)
+               --filter lpar_names=%s,slots=%s -F backing_devices' \
+               % (self.server, self.lpar, slot)
         try:
             output = self.session_hmc.cmd(cmd)
         except CmdError as details:
@@ -777,7 +777,7 @@ class NetworkVirtualization(Test):
         '''
         logport = self.get_active_device_logport(slot)
         adapter_id = ''
-        for entry in self.get_backing_devices().split(','):
+        for entry in self.get_backing_devices(slot).split(','):
             if logport in entry:
                 adapter_id = entry.split('/')[3]
                 port = entry.split('/')[4]
@@ -958,7 +958,7 @@ class NetworkVirtualization(Test):
         '''
         Get the backing device proiority of the vnic interface
         '''
-        for entry in self.get_backing_devices().split(','):
+        for entry in self.get_backing_devices(slot).split(','):
             logport = self.get_backing_device_logport(slot)
             if logport in entry:
                 backing_dev_prio = entry.split('/')[8]


### PR DESCRIPTION
Hello,

I was hitting issues running vnic add and remove tests (`test_add` and `test_remove`) when there was already an existing vnic device on the lpar. The error was from `update_backing_devices` : "local variable 'index' referenced before assignment".
The reason for the error was that the wrong list of backing devices was returned from `get_backing_devices`. Rather than returning a list of backing devices for the new vnic device, `get_backing_devices`  returned a list of backing devices for the older backing device. This is because `get_backing_devices` does not return backing_devices for a specific slot, it instead returns all the backing devices for all the vnic devices on the lpar.

Therefore, this PR adds an argument `slot` to `get_backing_devices` so that it can retrieve only the backing devices of a specific vnic device.

Thanks.