### PR TITLE
add_perf_top

### DIFF
--- a/perf/perf_top.py
+++ b/perf/perf_top.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2022 IBM
+# Author: Disha Goel <disgoel@linux.vnet.ibm.com>
+
+import sys
+import time
+import platform
+import pexpect
+from avocado import Test
+from avocado.utils import distro, dmesg
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class perf_top(Test):
+
+    """
+    Tests perf top and it's options with all
+    possible flags with the help of yaml file
+    :avocado: tags=perf,top
+    """
+
+    def setUp(self):
+        '''
+        Install the basic packages to support perf
+        '''
+
+        # Check for basic utilities
+        smm = SoftwareManager()
+        detected_distro = distro.detect()
+        self.distro_name = detected_distro.name
+
+        deps = ['gcc', 'make']
+        if 'Ubuntu' in self.distro_name:
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
+        elif 'debian' in detected_distro.name:
+            deps.extend(['linux-perf'])
+        elif self.distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
+            deps.extend(['perf', 'python3-pexpect'])
+        else:
+            self.cancel("Install the package for perf supported \
+                         by %s" % detected_distro.name)
+        for package in deps:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+
+        # Getting the parameters from yaml file
+        self.option = self.params.get('option', default='')
+
+        # Clear the dmesg by that we can capture delta at the end of the test
+        dmesg.clear_dmesg()
+
+    def test_top(self):
+        if self.option in ["-k", "--vmlinux", "--kallsyms"]:
+            if self.distro_name in ['rhel', 'fedora', 'centos']:
+                self.option = self.option + " /boot/vmlinuz-" + \
+                        platform.uname()[2]
+            elif self.distro_name in ['SuSE', 'Ubuntu']:
+                self.option = self.option + " /boot/vmlinux-" + \
+                        platform.uname()[2]
+
+        child = pexpect.spawn("perf top %s" % self.option, encoding='utf-8')
+        time.sleep(10)
+        child.logfile = sys.stdout
+        err = child.expect_exact(['Error: unknown option', pexpect.TIMEOUT])
+        child.send('q')
+        if err == 0:
+            self.fail("Unknown option %s" % self.option)
+        dmesg.collect_errors_dmesg(['WARNING: CPU:', 'Oops', 'Segfault',
+                                    'soft lockup', 'Unable to handle'])

--- a/perf/perf_top.py.data/perf_top.yaml
+++ b/perf/perf_top.py.data/perf_top.yaml
@@ -1,0 +1,169 @@
+variants: !mux
+    all_cpus:
+        option: -a
+    all_cpus_full:
+        option: --all-cpus
+    count:
+        option: -c 5
+    count_full:
+        option: --count 5
+    cpu:
+        option: -C 0
+    cpu_full:
+        option: --cpu 0
+    delay:
+        option: -d 5
+    delay_full:
+        option: --delay 5
+    event:
+        option: -e L1-dcache-load-misses
+    event_full:
+        option: --event L1-dcache-load-misses
+    entries:
+        option: -E 5
+    entries_full:
+        option: --entries 5
+    count-filter:
+        option: -f 5
+    count-filter_full:
+        option: --count-filter 5
+    group:
+        option: --group
+    group-sort-idx:
+        option: --group-sort-idx 1
+    freq:
+        option: -F 5
+    freq_full:
+        option: --freq 5
+    inherit:
+        option: -i
+    inherit_full:
+        option: --inherit
+    vmlinux:
+        option: -k
+    vmlinux_full:
+        option: --vmlinux
+    ignore-vmlinux:
+        option: --ignore-vmlinux
+    kallsyms:
+        option: --kallsyms
+    mmap-pages:
+        option: -m 8
+    mmap-pages_full:
+        option: --mmap-pages 8
+    pid:
+        option: -p 10
+    pid_full:
+        option: --pid 10
+    tid:
+        option: -t 10
+    tid_full:
+        option: --tid 10
+    uid:
+        option: -u 1
+    uid_full:
+        option: --uid 1
+    realtime:
+        option: -r 5
+    realtime_full:
+        option: --realtime 5
+    sym-annotate:
+        option: --sym-annotate k
+    hide_kernel_symbols:
+        option: -K
+    hide_kernel_symbols_full:
+        option: --hide_kernel_symbols
+    hide_user_symbols:
+        option: -U
+    hide_user_symbols_full:
+        option: --hide_user_symbols
+    demangle-kernel:
+        option: --demangle-kernel
+    dump-symtab:
+        option: -D
+    dump-symtab_full:
+        option: --dump-symtab
+    verbose:
+        option: -v
+    verbose_full:
+        option: --verbose
+    zero:
+        option: -z
+    zero_full:
+        option: --zero
+    sort:
+        option: -s comm,dso,symbol,cpu
+    sort_full:
+        option: --sort comm,dso,symbol,cpu
+    fields:
+        option: --fields overhead
+    timehist:
+        option: -n
+    show-nr-samples:
+        option: --show-nr-samples
+    show-total-period:
+        option: --show-total-period
+    dsos:
+        option: --dsos dso
+    comms:
+        option: --comms comm
+    symbols:
+        option: --symbols symbol
+    disassembler-style:
+        option: -M powerpc
+    disassembler-style:
+        option: --disassembler-style powerpc
+    prefix:
+        option: --prefix=PREFIX
+    prefix-strip:
+        option: --prefix --prefix-strip=5
+    source:
+        option: --source
+    asm-raw:
+        option: --asm-raw
+    call-graph:
+        option: -g
+    call-graph_full:
+        option: --call-graph graph
+    children:
+        option: --children
+    max-stack:
+        option: --max-stack 127
+    percent-limit:
+        option: --percent-limit 0
+    percentage:
+        option: --percentage relative
+    column-widths:
+        option: -w 10
+    column-widths_full:
+        option: --column-widths 20
+    proc-map-timeout:
+        option: --proc-map-timeout 500
+    branch-any:
+        option: -b
+    branch-any_full:
+        option: --branch-any
+    branch-filter:
+        option: -j any
+    branch-filter_full:
+        option: --branch-filter any
+    raw-trace:
+        option: --raw-trace
+    hierarchy:
+        option: --hierarchy
+    overwrite:
+        option: --overwrite
+    force:
+        option: --force
+    num-thread-synthesize:
+        option: --num-thread-synthesize 1
+    namespaces:
+        option: --namespaces
+    all-cgroups:
+        option: --all-cgroups
+    switch-on:
+        option: --switch-on cycles
+    switch-off:
+        option: --switch-off cycles
+    show-on-off-events:
+        option: --show-on-off-events


### PR DESCRIPTION
added perf_top.py testcase which tests perf top command a system profiling tool with all possible options with the help of yaml file
tested script on RHEL, SLES15 on P9/P10

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

[root@]# avocado run --test-runner runner perf_top.py -m perf_top.py.data/perf_top.yaml
JOB ID     : 8ceab80317ab88d94c31d724203448cfae92a5ba
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-11-17T11.41-8ceab80/job.log
 (01/84) perf_top.py:perf_top.test_top;run-variants-all_cpus-640d:  PASS (41.57 s)
 (02/84) perf_top.py:perf_top.test_top;run-variants-all_cpus_full-15dd:  PASS (41.42 s)
 (03/84) perf_top.py:perf_top.test_top;run-variants-count-cce5:  PASS (41.51 s)
 (04/84) perf_top.py:perf_top.test_top;run-variants-count_full-dd4d:  PASS (41.43 s)
 (05/84) perf_top.py:perf_top.test_top;run-variants-cpu-6c86:  PASS (41.44 s)
 (06/84) perf_top.py:perf_top.test_top;run-variants-cpu_full-d3f1:  PASS (41.69 s)
 (07/84) perf_top.py:perf_top.test_top;run-variants-delay-fa60:  PASS (41.54 s)
 (08/84) perf_top.py:perf_top.test_top;run-variants-delay_full-76fc:  PASS (41.72 s)
 (09/84) perf_top.py:perf_top.test_top;run-variants-event-feab:  PASS (41.52 s)
 (10/84) perf_top.py:perf_top.test_top;run-variants-event_full-f05e:  PASS (41.55 s)
 (11/84) perf_top.py:perf_top.test_top;run-variants-entries-b2ef:  PASS (41.43 s)
 (12/84) perf_top.py:perf_top.test_top;run-variants-entries_full-b44b:  PASS (41.40 s)
 (13/84) perf_top.py:perf_top.test_top;run-variants-count-filter-a14f:  PASS (41.75 s)
 (14/84) perf_top.py:perf_top.test_top;run-variants-count-filter_full-a3e4:  PASS (41.77 s)
 (15/84) perf_top.py:perf_top.test_top;run-variants-group-8c02:  PASS (41.44 s)
 (16/84) perf_top.py:perf_top.test_top;run-variants-group-sort-idx-92e9:  PASS (41.37 s)
 (17/84) perf_top.py:perf_top.test_top;run-variants-freq-e983:  PASS (41.41 s)
 (18/84) perf_top.py:perf_top.test_top;run-variants-freq_full-080e:  PASS (41.48 s)
 (19/84) perf_top.py:perf_top.test_top;run-variants-inherit-f27f:  PASS (41.72 s)
 (20/84) perf_top.py:perf_top.test_top;run-variants-inherit_full-8699:  PASS (41.43 s)
 (21/84) perf_top.py:perf_top.test_top;run-variants-vmlinux-a988:  PASS (41.76 s)
 (22/84) perf_top.py:perf_top.test_top;run-variants-vmlinux_full-408b:  PASS (41.43 s)
 (23/84) perf_top.py:perf_top.test_top;run-variants-ignore-vmlinux-cbcb:  PASS (41.76 s)
 (24/84) perf_top.py:perf_top.test_top;run-variants-kallsyms-a36e:  PASS (41.40 s)
 (25/84) perf_top.py:perf_top.test_top;run-variants-mmap-pages-d58f:  PASS (41.74 s)
 (26/84) perf_top.py:perf_top.test_top;run-variants-mmap-pages_full-48c3:  PASS (41.43 s)
 (27/84) perf_top.py:perf_top.test_top;run-variants-pid-22ac:  PASS (41.59 s)
 (28/84) perf_top.py:perf_top.test_top;run-variants-pid_full-a8b2:  PASS (41.44 s)
 (29/84) perf_top.py:perf_top.test_top;run-variants-tid-759c:  PASS (41.55 s)
 (30/84) perf_top.py:perf_top.test_top;run-variants-tid_full-e11d:  PASS (41.45 s)
 (31/84) perf_top.py:perf_top.test_top;run-variants-uid-57b4:  PASS (41.73 s)
 (32/84) perf_top.py:perf_top.test_top;run-variants-uid_full-48ab:  PASS (41.74 s)
 (33/84) perf_top.py:perf_top.test_top;run-variants-realtime-64b4:  PASS (41.72 s)
 (34/84) perf_top.py:perf_top.test_top;run-variants-realtime_full-43a2:  PASS (41.45 s)
 (35/84) perf_top.py:perf_top.test_top;run-variants-sym-annotate-da20:  PASS (41.68 s)
 (36/84) perf_top.py:perf_top.test_top;run-variants-hide_kernel_symbols-13b2:  PASS (41.43 s)
 (37/84) perf_top.py:perf_top.test_top;run-variants-hide_kernel_symbols_full-4465:  PASS (41.42 s)
 (38/84) perf_top.py:perf_top.test_top;run-variants-hide_user_symbols-db2c:  PASS (41.75 s)
 (39/84) perf_top.py:perf_top.test_top;run-variants-hide_user_symbols_full-e72c:  PASS (41.43 s)
 (40/84) perf_top.py:perf_top.test_top;run-variants-demangle-kernel-9461:  PASS (41.44 s)
 (41/84) perf_top.py:perf_top.test_top;run-variants-dump-symtab-bca3:  PASS (41.45 s)
 (42/84) perf_top.py:perf_top.test_top;run-variants-dump-symtab_full-ae9c:  PASS (41.41 s)
 (43/84) perf_top.py:perf_top.test_top;run-variants-verbose-6f91:  PASS (41.42 s)
 (44/84) perf_top.py:perf_top.test_top;run-variants-verbose_full-2b22:  PASS (41.72 s)
 (45/84) perf_top.py:perf_top.test_top;run-variants-zero-3cdd:  PASS (41.42 s)
 (46/84) perf_top.py:perf_top.test_top;run-variants-zero_full-34bd:  PASS (41.46 s)
 (47/84) perf_top.py:perf_top.test_top;run-variants-sort-271d:  PASS (41.45 s)
 (48/84) perf_top.py:perf_top.test_top;run-variants-sort_full-70e4:  PASS (41.45 s)
 (49/84) perf_top.py:perf_top.test_top;run-variants-fields-b66d:  PASS (41.49 s)
 (50/84) perf_top.py:perf_top.test_top;run-variants-timehist-68b5:  PASS (41.41 s)
 (51/84) perf_top.py:perf_top.test_top;run-variants-show-nr-samples-7825:  PASS (41.41 s)
 (52/84) perf_top.py:perf_top.test_top;run-variants-show-total-period-3bc2:  PASS (41.39 s)
 (53/84) perf_top.py:perf_top.test_top;run-variants-dsos-be98:  PASS (41.39 s)
 (54/84) perf_top.py:perf_top.test_top;run-variants-comms-0b4f:  PASS (41.39 s)
 (55/84) perf_top.py:perf_top.test_top;run-variants-symbols-1d7d:  PASS (41.51 s)
 (56/84) perf_top.py:perf_top.test_top;run-variants-disassembler-style-bebf:  PASS (41.48 s)
 (57/84) perf_top.py:perf_top.test_top;run-variants-disassembler-style_full-9750:  PASS (41.74 s)
 (58/84) perf_top.py:perf_top.test_top;run-variants-prefix-903b:  PASS (41.46 s)
 (59/84) perf_top.py:perf_top.test_top;run-variants-prefix-strip-3b01:  PASS (41.46 s)
 (60/84) perf_top.py:perf_top.test_top;run-variants-source-878d:  PASS (41.44 s)
 (61/84) perf_top.py:perf_top.test_top;run-variants-asm-raw-2884:  PASS (41.76 s)
 (62/84) perf_top.py:perf_top.test_top;run-variants-call-graph-8da1:  PASS (41.71 s)
 (63/84) perf_top.py:perf_top.test_top;run-variants-call-graph_full-aa8a:  PASS (41.54 s)
 (64/84) perf_top.py:perf_top.test_top;run-variants-children-1b93:  PASS (41.43 s)
 (65/84) perf_top.py:perf_top.test_top;run-variants-max-stack-ab39:  PASS (41.77 s)
 (66/84) perf_top.py:perf_top.test_top;run-variants-percent-limit-16db:  PASS (41.78 s)
 (67/84) perf_top.py:perf_top.test_top;run-variants-percentage-e855:  PASS (41.38 s)
 (68/84) perf_top.py:perf_top.test_top;run-variants-column-widths-35ff:  PASS (41.75 s)
 (69/84) perf_top.py:perf_top.test_top;run-variants-column-widths_full-a314:  PASS (41.40 s)
 (70/84) perf_top.py:perf_top.test_top;run-variants-proc-map-timeout-3622:  PASS (41.43 s)
 (71/84) perf_top.py:perf_top.test_top;run-variants-branch-any-9a57:  PASS (41.43 s)
 (72/84) perf_top.py:perf_top.test_top;run-variants-branch-any_full-8625:  PASS (41.41 s)
 (73/84) perf_top.py:perf_top.test_top;run-variants-branch-filter-2be6:  PASS (41.42 s)
 (74/84) perf_top.py:perf_top.test_top;run-variants-branch-filter_full-c9f5:  PASS (41.37 s)
 (75/84) perf_top.py:perf_top.test_top;run-variants-raw-trace-b3c1:  PASS (41.41 s)
 (76/84) perf_top.py:perf_top.test_top;run-variants-hierarchy-2803:  PASS (41.41 s)
 (77/84) perf_top.py:perf_top.test_top;run-variants-overwrite-7195:  PASS (41.41 s)
 (78/84) perf_top.py:perf_top.test_top;run-variants-force-b3c8:  PASS (41.50 s)
 (79/84) perf_top.py:perf_top.test_top;run-variants-num-thread-synthesize-f9ee:  PASS (41.75 s)
 (80/84) perf_top.py:perf_top.test_top;run-variants-namespaces-d15c:  PASS (41.70 s)
 (81/84) perf_top.py:perf_top.test_top;run-variants-all-cgroups-2d41:  PASS (41.42 s)
 (82/84) perf_top.py:perf_top.test_top;run-variants-switch-on-957c:  PASS (41.72 s)
 (83/84) perf_top.py:perf_top.test_top;run-variants-switch-off-389c:  PASS (41.45 s)
 (84/84) perf_top.py:perf_top.test_top;run-variants-show-on-off-events-372b:  PASS (41.73 s)
RESULTS    : PASS 84 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-11-17T11.41-8ceab80/results.html
JOB TIME   : 3492.94 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10041593/job.log)