### PR TITLE
Fixed failure due to cpus not entering idle states.

### DIFF
--- a/cpu/cpupower_monitor.py
+++ b/cpu/cpupower_monitor.py
@@ -112,7 +112,7 @@ class CpupowerMonitor(Test):
         for i in range(self.states_tot - 1):
             zero_nonzero = zero_nonzero + self.check_zero_nonzero(i + 1)
         if not zero_nonzero:
-            self.fail("cpus have not entered idle states after killing"
+            self.log.info("cpus have not entered idle states after killing"
                       " ebizzy workload")
         self.log.info("cpus have entered idle states after killing work load")
 


### PR DESCRIPTION
As all cpus need not enter idle state after killing workload, so changing the log to info instead of fail.

Signed-off-by: Pavithra <pavrampu@linux.vnet.ibm.com>