### PR TITLE
netperf: Add unzip dependency check

### DIFF
--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -117,15 +117,17 @@ class Netperf(Test):
                                          recursive=True)
         if not output:
             self.cancel("unable to copy the netperf into peer machine")
-        cmd = "unzip /tmp/%s -d /tmp;cd /tmp/%s;./configure --build=powerpc64le;make" % (
-            os.path.basename(tarball), self.version)
+        self.netperf_dir_peer = "/tmp/%s" % self.version
+        self.netperf_dir = os.path.join(self.netperf, self.version)
+        cmd = "unzip /tmp/%s -d /tmp;cd %s;./configure --build=powerpc64le;make" % (
+            os.path.basename(tarball), self.netperf_dir_peer)
         output = self.session.cmd(cmd)
         if not output.exit_status == 0:
             self.fail("test failed because command failed in peer machine")
-        os.chdir(self.neperf)
+        os.chdir(self.netperf_dir)
         process.system('./configure --build=powerpc64le', shell=True)
-        build.make(self.neperf)
-        self.perf = os.path.join(self.neperf, 'src', 'netperf')
+        build.make(self.netperf_dir)
+        self.perf = os.path.join(self.netperf_dir, 'src', 'netperf')
         self.expected_tp = self.params.get("EXPECTED_THROUGHPUT", default="90")
         self.duration = self.params.get("duration", default="300")
         self.min = self.params.get("minimum_iterations", default="1")

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -70,7 +70,7 @@ class Netperf(Test):
             self.cancel("failed connecting to peer")
         smm = SoftwareManager()
         detected_distro = distro.detect()
-        pkgs = ['gcc']
+        pkgs = ['gcc', 'unzip']
         if detected_distro.name == "Ubuntu":
             pkgs.append('openssh-client')
         elif detected_distro.name == "SuSE":


### PR DESCRIPTION
When running netperf tests. I got:
```
[stdlog] 2022-06-15 10:26:23,260 avocado.utils.process INFO | Running '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l root -q 10.1.0.238 'unzip /tmp/netperf-2.7.0.zip -d /tmp;cd /tmp/netperf-netperf-2.7.0;./configure --build=powerpc64le;make''
[stdlog] 2022-06-15 10:26:23,295 avocado.utils.process DEBUG| [stderr] bash: unzip: command not found
[stdlog] 2022-06-15 10:26:23,295 avocado.utils.process DEBUG| [stderr] bash: line 0: cd: /tmp/netperf-netperf-2.7.0: No such file or directory
[stdlog] 2022-06-15 10:26:23,295 avocado.utils.process DEBUG| [stderr] bash: ./configure: No such file or directory
[stdlog] 2022-06-15 10:26:23,313 avocado.utils.process DEBUG| [stderr] make: *** No targets specified and no makefile found.  Stop.
[stdlog] 2022-06-15 10:26:23,313 avocado.utils.process INFO | Command '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l root -q 10.1.0.238 'unzip /tmp/netperf-2.7.0.zip -d /tmp;cd /tmp/netperf-netperf-2.7.0;./configure --build=powerpc64le;make'' finished with 2 after 0.051976051s
[stdlog] 2022-06-15 10:26:23,314 avocado.test ERROR| 
[stdlog] 2022-06-15 10:26:23,314 avocado.test ERROR| Reproduced traceback from: /usr/lib/python3.6/site-packages/avocado_framework-94.0-py3.6.egg/avocado/core/test.py:746
[stdlog] 2022-06-15 10:26:23,314 avocado.test ERROR| Traceback (most recent call last):
[stdlog] 2022-06-15 10:26:23,314 avocado.test ERROR|   File "/tmp/ci-stuff/avocado-fvt-wrapper/tests/avocado-misc-tests/io/net/netperf_test.py", line 124, in setUp
[stdlog] 2022-06-15 10:26:23,314 avocado.test ERROR|     self.fail("test failed because command failed in peer machine")
[stdlog] 2022-06-15 10:26:23,315 avocado.test ERROR|   File "/usr/lib/python3.6/site-packages/avocado_framework-94.0-py3.6.egg/avocado/core/test.py", line 892, in fail
[stdlog] 2022-06-15 10:26:23,315 avocado.test ERROR|     raise exceptions.TestFail(message)
[stdlog] 2022-06-15 10:26:23,315 avocado.test ERROR| avocado.core.exceptions.TestFail: test failed because command failed in peer machine
```

Please install `unzip` if the peer does not already have it installed.
Thank you.