### PR TITLE
add_ptrace_yaml

### DIFF
--- a/kernel/kselftest.py.data/ptrace.yaml
+++ b/kernel/kselftest.py.data/ptrace.yaml
@@ -1,0 +1,11 @@
+component: !mux
+    ptrace:
+        comp: 'powerpc'
+        subtest: 'ptrace'
+
+run_type: !mux
+    distro:
+        type: 'distro'
+    upstream:
+        type: 'upstream'
+        location: 'https://github.com/torvalds/linux/archive/master.zip'


### PR DESCRIPTION
Adding ptrace.yaml file to run with kselftest.py

Signed-off-by: Akanksha J N <akanksha@linux.ibm.com>