### PR TITLE
ras/ras_ppcdiag: Add support for upstream target

### DIFF
--- a/ras/ras_ppcdiag.py.data/options.yaml
+++ b/ras/ras_ppcdiag.py.data/options.yaml
@@ -2,3 +2,9 @@ nvsetenv_list: ['load-base', 'load-base 7000']
 usysattn_list: ['-h', '-V', '-P']
 usysfault_list: ['-h', '-V', '-P']
 usysident_list: ['-h', '-V', '-P']
+run_type: !mux
+    upstream:
+        ppcdiag_url: ''
+        type: 'upstream'
+    distro:
+        type: 'distro'


### PR DESCRIPTION
Add capabilities to download and compile upstream source
for ppc64-diag utilities

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>