### PR TITLE
Enhancing the port_bounce.py to support nvmf adapters.

### DIFF
--- a/io/disk/port_bounce.py.data/README
+++ b/io/disk/port_bounce.py.data/README
@@ -11,4 +11,9 @@ password : FC switch password to login
 sbt: short bounce time in seconds
 lbt: long bounce time in seconds
 count : Number of times test to run
-pci_device: pci_bus_adress of adapter, space separated
+wwids : wwids of corresponding fc/vfc adapter's multipath
+	you can get it from output of "multipath -ll" for fc/vfc adapter type.
+	for nvmf adapter, you can leave this as blank.
+pci_devices: pci_bus_adress of adapter, space separated. in case of virtual fc/vfc,
+	     leave it as blank and make sure you have passed wwids
+adapter_type: type of adapter, like fc or nvmf

--- a/io/disk/port_bounce.py.data/port_bounce.yaml
+++ b/io/disk/port_bounce.py.data/port_bounce.yaml
@@ -1,7 +1,9 @@
-switch_name: ""
-userid: ""
+switch_name:
+userid:
 password: "********"
-wwids: ''
+wwids:
+adapter_type:
+pci_devices:
 sbt: 60
 lbt: 120
 count: 1


### PR DESCRIPTION
current script doesn't work for NVMeoFC adapters as they do not support multipath. and cuurent script works with wwid's of any fc adapter. So enhanced the script to support nvmf adapter too along with fc/vfc adapters.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>