### PR TITLE
update xfstest yaml

### DIFF
--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -4,7 +4,6 @@ test_mnt: '/mnt/test'
 disk_mnt: '/mnt/loop-device'
 # Uncomment and edit test_range for running specific tests
 test_range: "null"
-# Run with either loop_type (or) disk_type
 loop_type: !mux
     type: 'loop'
     loop_size: '7GiB'
@@ -12,18 +11,29 @@ loop_type: !mux
     # Uses '/' by default for file creation
     disk: "null"
 fs_type: !mux
-    fs_ext4:
+    fs_ext4_4k:
         fs: 'ext4'
-        exclude: "null"
+        mkfs_opt: '-b 4096'
+        mount_opt: '-o block_validity'
+        exclude: "048"
         gen_exclude: "null"
         share_exclude: "null"
-    fs_xfs:
+    fs_ext4_64k:
+        fs: 'ext4'
+        mkfs_opt: '-b 65536'
+        mount_opt: '-o block_validity'
+        exclude: "048"
+        gen_exclude: "null"
+        share_exclude: "null"
+    fs_xfs_4k:
         fs: 'xfs'
-        # Exclude only if test_range not provided
+        mkfs_opt: '-f -b size=4096'
         exclude: "null"
         gen_exclude: "null"
         share_exclude: "null"
-disk_type: !mux
-    type: 'disk'
-    disk_test: "null"
-    disk_scratch: "null"
+    fs_xfs_64k:
+        fs: 'xfs'
+        mkfs_opt: '-f -b size=65536'
+        exclude: "null"
+        gen_exclude: "null"
+        share_exclude: "null"


### PR DESCRIPTION
updated xfstest yaml file to run only with loop devices and added ext4 & xfs tests with 4k & 64k block size

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

previously it was giving error as contains both loop and disk type
ERROR: Multiple  leaves contain the key 'type'; ['/run/loop_type=>loop', '/run/disk_type=>disk']

[root@ fs]# avocado run --test-runner runner xfstests.py -m xfstests.py.data/xfstests.yaml 
JOB ID     : 51b6eba3eb84dbabb3149e1da488ee0feb1c5dbc
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-12-09T02.10-51b6eba/job.log
 (1/4) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-loop_type-60cb: PASS (34.51 s)
 (2/4) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_64k-loop_type-5070: PASS (18.00 s)
 (3/4) xfstests.py:Xfstests.test;run-fs_type-fs_xfs_4k-loop_type-d140: PASS (35.04 s)
 (4/4) xfstests.py:Xfstests.test;run-fs_type-fs_xfs_64k-loop_type-2ea9: PASS (33.86 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-12-09T02.10-51b6eba/results.html
JOB TIME   : 122.01 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10193019/job.log)