### PR TITLE
Good path scenario on vnic --> cfg handles

### DIFF
--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -138,6 +138,13 @@ class Bonding(Test):
             self.ib = True
         self.log.info("Bond Test on IB Interface? = %s", self.ib)
 
+        dir = os.listdir('/sys/class/net')
+        if "test_cleanup" in str(self.name.name) and self.bond_name in dir:
+            cmd = 'ip addr add %s/%s dev %s;sleep 5;'\
+                  % (self.ipaddr[0], self.netmask,
+                    self.bond_name)
+            process.system(cmd, shell=True, ignore_status=True)
+
         '''
         An individual interface, that has a LACP PF, cannot communicate without
         being bonded. So the test uses the public ip address to create an SSH

--- a/io/net/bonding.py
+++ b/io/net/bonding.py
@@ -142,7 +142,7 @@ class Bonding(Test):
         if "test_cleanup" in str(self.name.name) and self.bond_name in dir:
             cmd = 'ip addr add %s/%s dev %s;sleep 5;'\
                   % (self.ipaddr[0], self.netmask,
-                    self.bond_name)
+                     self.bond_name)
             process.system(cmd, shell=True, ignore_status=True)
 
         '''

--- a/io/net/bridge.py.data/bridge.yaml
+++ b/io/net/bridge.py.data/bridge.yaml
@@ -3,3 +3,7 @@ peer_ip:
 host_ip:
 netmask:
 bridge_interface: "br0"
+peer_interface:
+peer_public_ip:
+peer_password: "********"
+user_name:


### PR DESCRIPTION
Handling cleanups and test configurations that were causing the tests to be failed while running cfg on VNIC for good_path_scenario