### PR TITLE
security/libgcrypt: Fix failure with distro as run_type

### DIFF
--- a/security/libgcrypt-tests.py
+++ b/security/libgcrypt-tests.py
@@ -51,15 +51,6 @@ class libgcrypt(Test):
             git.get_repo(url, destination_dir=self.workdir)
             os.chdir(self.workdir)
             self.srcdir = self.workdir
-            process.run("./autogen.sh")
-            process.run("./configure --enable-maintainer-mode --disable-doc")
-            if build.make(self.workdir):
-                # If the make fails then need to run make with -lpthread
-                output = build.run_make(self.workdir,
-                                        extra_args="CFLAGS+=-lpthread",
-                                        process_kwargs={"ignore_status": True})
-                if output.exit_status:
-                    self.fail("'make' failed.")
         elif run_type == "distro":
             self.srcdir = os.path.join(self.workdir, "libgcrypt-distro")
             if not os.path.exists(self.srcdir):
@@ -67,6 +58,16 @@ class libgcrypt(Test):
             self.srcdir = smm.get_source("libgcrypt", self.srcdir)
             if not self.srcdir:
                 self.fail("libgcrypt source install failed.")
+            os.chdir(self.srcdir)
+        process.run("./autogen.sh")
+        process.run("./configure --enable-maintainer-mode --disable-doc")
+        if build.make(self.srcdir):
+            # If the make fails then need to run make with -lpthread
+            output = build.run_make(self.srcdir,
+                                    extra_args="CFLAGS+=-lpthread",
+                                    process_kwargs={"ignore_status": True})
+            if output.exit_status:
+                self.fail("'make' failed.")
 
     def test(self):
         '''

--- a/security/libgcrypt-tests.py.data/libgcrypt.yaml
+++ b/security/libgcrypt-tests.py.data/libgcrypt.yaml
@@ -3,5 +3,4 @@ run_type: !mux
         type: 'upstream'
     distro:
         type: 'distro'
-prefix: '/usr'
 url: "https://dev.gnupg.org/source/libgcrypt.git"


### PR DESCRIPTION
libgcrypt tests fail to execute when using distro as a run_type.
The test only installs corresponding source package. Steps to
compile the code is missing.

Add the corresponding steps to compile the source code before
attempting to run the self tests.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>