### PR TITLE
security/annobin: Runtime failure fixes

### DIFF
--- a/security/annobin-tests.py
+++ b/security/annobin-tests.py
@@ -68,6 +68,8 @@ class annobin(Test):
         count = 0
         output = build.run_make(self.annobin_dir, extra_args="check",
                                 process_kwargs={"ignore_status": True})
+        if output.exit_status:
+            self.fail("annobin-tests.py: make check failed")
         for line in output.stdout_text.splitlines():
             if 'FAIL:' in line and 'XFAIL:' not in line and \
                '# FAIL:' not in line:

--- a/security/annobin-tests.py
+++ b/security/annobin-tests.py
@@ -38,7 +38,7 @@ class annobin(Test):
         # gcc versions like 5,6,7,8 skipping Ubuntu for this test.
         # In SLES 'gcc-plugin-devel' package not available, skipping.
         if self.distro_name in ['rhel', 'fedora', 'centos']:
-            deps.extend(['gcc-plugin-devel', 'rpm-devel'])
+            deps.extend(['gcc-plugin-devel', 'rpm-devel', 'binutils-devel'])
         else:
             self.cancel("%s not supported for this test" % self.distro_name)
         for package in deps:


### PR DESCRIPTION
annobin-tests.py test fails due to missing package. Add a dependency
for that package.

The test does not check return code for make check due to which it
is marked as pass inspite of make command failure. 

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>