### PR TITLE
trace/dawr: Fix compile time failure

### DIFF
--- a/trace/dawr.py.data/dawr_v1.c
+++ b/trace/dawr.py.data/dawr_v1.c
@@ -1,16 +1,18 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: 2022 IBM
-# Author: Akanksha J N <akanksha@linux.ibm.com>
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See LICENSE for more details.
+ *
+ * Copyright: 2022 IBM
+ * Author: Akanksha J N <akanksha@linux.ibm.com>
+*/
 
 #include <stdio.h>
 int a = 10;

--- a/trace/dawr.py.data/dawr_v2.c
+++ b/trace/dawr.py.data/dawr_v2.c
@@ -1,16 +1,18 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: 2022 IBM
-# Author: Akanksha J N <akanksha@linux.ibm.com>
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See LICENSE for more details.
+ *
+ * Copyright: 2022 IBM
+ * Author: Akanksha J N <akanksha@linux.ibm.com>
+*/
 
 #include <stdio.h>
 int a = 10;

--- a/trace/dawr.py.data/dawr_v3.c
+++ b/trace/dawr.py.data/dawr_v3.c
@@ -1,16 +1,18 @@
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# See LICENSE for more details.
-#
-# Copyright: 2022 IBM
-# Author: Akanksha J N <akanksha@linux.ibm.com>
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See LICENSE for more details.
+ *
+ * Copyright: 2022 IBM
+ * Author: Akanksha J N <akanksha@linux.ibm.com>
+*/
 
 #include<stdio.h>
 int a=10;


### PR DESCRIPTION
dawr test fails to compile the c code due to invalid preprocessing directive.

Use correct style for comments in the c source code.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>