### PR TITLE
memory/migrate_pages: Handle migrate page tests(libhugetlbfs) for RHE…

### DIFF
--- a/memory/migrate_pages.py.data/Makefile
+++ b/memory/migrate_pages.py.data/Makefile
@@ -1,7 +1,11 @@
 all : node_move_pages
 
 node_move_pages : node_move_pages.c
-	gcc node_move_pages.c -o $@ -lhugetlbfs -lnuma
+ifdef HAVE_HUGETLB_HEADER
+	gcc node_move_pages.c -o $@ -lhugetlbfs -lnuma -DHAVE_HUGETLB_HEADER
+else
+	gcc node_move_pages.c -o $@ -lnuma
+endif
 
 clean :
 	rm node_move_pages

--- a/memory/migrate_pages.py.data/node_move_pages.c
+++ b/memory/migrate_pages.py.data/node_move_pages.c
@@ -6,7 +6,9 @@
 #include <fcntl.h>
 #include <numa.h>
 #include <numaif.h>
+#ifdef HAVE_HUGETLB_HEADER
 #include <hugetlbfs.h>
+#endif
 
 #define PATTERN		0xff
 #define PAGE_SHIFT 12
@@ -327,11 +329,12 @@ int main(int argc, char *argv[])
                 case 'n':
 			chunks = strtoul(optarg, NULL, 10);
                         break;
-                case 'o':
-			overcommit = 1;
-                        break;
                 case 't':
 			thp = 1;
+                        break;
+#ifdef HAVE_HUGETLB_HEADER
+                case 'o':
+			overcommit = 1;
                         break;
                 case 'h':
 			hugepage = 1;
@@ -339,8 +342,13 @@ int main(int argc, char *argv[])
 			/* Using 1% of system memory for hugepages*/
         		memory = (total_mem) / 100;
                         break;
+#endif
                 default:
+#ifdef HAVE_HUGETLB_HEADER
                         errmsg("%s [-n <no-of-chunks] [-t fot THP] [-o for hugepage-overcommit] [-h for hugepage]\n", argv[0]);
+#else
+                        errmsg("%s [-n <no-of-chunks] [-t fot THP]\n", argv[0]);
+#endif
                         break;
                 }
         }


### PR DESCRIPTION
…L-9 distro

 Fix is added to handle libhugetlbfs dependency with migrate page tests for RHEL-9 or later rhel distro.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>