### PR TITLE
ras/ras_lsvpd: Add sg3_utils package dependency

### DIFF
--- a/ras/ras_lsvpd.py
+++ b/ras/ras_lsvpd.py
@@ -76,7 +76,8 @@ class RASToolsLsvpd(Test):
                 deps.extend(['libsgutils-devel', 'sqlite3-devel',
                              'libvpd2-devel'])
             elif self.detected_distro.name in ['centos', 'fedora', 'rhel']:
-                deps.extend(['sqlite-devel', 'libvpd-devel'])
+                deps.extend(['sqlite-devel', 'libvpd-devel',
+                             'sg3_utils-devel'])
             else:
                 self.cancel("Unsupported Linux distribution")
             for package in deps:


### PR DESCRIPTION
With upstream as a value for run_type, code compile fails if
sg3_utils-devel package is not installed.

Make sure the package is installed.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>