### PR TITLE
perf/duplicate_probe: Run test against upstream kernel

### DIFF
--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -30,13 +30,18 @@ class PerfProbe(Test):
         smm = SoftwareManager()
         distro_name = distro.detect().name
         deps = []
+        run_type = self.params.get('type', default='distro')
         if 'Ubuntu' in distro_name:
             deps.extend(['linux-tools-common', 'linux-tools-%s' %
                          platform.uname()[2]])
         elif 'rhel' in distro_name:
-            deps.extend(['perf', 'kernel-debuginfo'])
+            deps.extend(['perf'])
+            if run_type == 'distro':
+                deps.extend(['kernel-debuginfo'])
         elif 'SuSE' in distro_name:
-            deps.extend(['perf', 'kernel-default-debuginfo'])
+            deps.extend(['perf'])
+            if run_type == 'distro':
+                deps.extend(['kernel-default-debuginfo'])
         else:
             self.cancel("Install the package for perf supported\
                       by %s" % distro_name)

--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -64,5 +64,7 @@ class PerfProbe(Test):
             self.fail("perf is placing multiple probes at the same location ")
 
     def tearDown(self):
-        # Deleting all the probed events
-        process.run('perf probe -d \\*')
+        # Check for active probes
+        if process.run("perf probe --list", sudo=True).stdout:
+            # Deleting all the probed events
+            process.run('perf probe -d \\*')

--- a/perf/perf_duplicate_probe.py.data/perf_duplicate.yaml
+++ b/perf/perf_duplicate_probe.py.data/perf_duplicate.yaml
@@ -1,0 +1,5 @@
+run_type: !mux
+    upstream:
+        type: 'upstream'
+    distro:
+        type: 'distro'


### PR DESCRIPTION
This 2 patch series adds support to run the test against
upstream kernel. Second patch is a test case fixup.

perf/duplicate_probe: Run test against upstream kernel
perf/duplicate_probe: Delete probes only if previously installed

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>