### PR TITLE
Fix disktest and paralleldd for new subprocess call

### DIFF
--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -212,8 +212,7 @@ class Disktest(Test):
         """
         cmd = ("%s/disktest -m %d -f %s/testfile.%d -i -S >> \"%s\" 2>&1" %
                (self.teststmpdir, self.chunk_mb, disk, chunk, self.disk_log))
-        proc = process.get_sub_process_klass(cmd)(cmd, shell=True,
-                                                  verbose=False)
+        proc = process.SubProcess(cmd, shell=True, verbose=False)
         pid = proc.start()
         return pid, proc
 

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -123,8 +123,7 @@ class ParallelDd(Test):
                 cmd += " %s=%s" % (option.split(":")[0],
                                    option.split(":")[1])
             # Wait for everyone to complete
-            proc = process.get_sub_process_klass(cmd)(cmd + ' > /dev/null',
-                                                      shell=True)
+            proc = process.SubProcess(cmd + ' > /dev/null', shell=True)
             proc.start()
             proc.poll()
             proc.wait()
@@ -146,8 +145,7 @@ class ParallelDd(Test):
                 process.run(cmd + ' > /dev/null', shell=True)
             else:
                 # Wait for everyone to complete
-                proc = process.get_sub_process_klass(cmd)(cmd + ' > /dev/null',
-                                                          shell=True)
+                proc = process.SubProcess(cmd + ' > /dev/null', shell=True)
                 proc.start()
                 proc.poll()
                 proc.wait()


### PR DESCRIPTION
With latest avocado code, the get_sub_process_klass method is removed in process.py utils, causing the test to ERROR: module 'avocado.utils.process' has no attribute 'get_sub_process_klass', this patch fixes the error

Reported-by: Maram Srimannarayana Murthy <Maram.Srimannarayana.Murthy@ibm.com>
Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>