### PR TITLE
enhance stress-ng-fs

### DIFF
--- a/generic/stress-ng.py.data/stress-ng-fs.yaml
+++ b/generic/stress-ng.py.data/stress-ng-fs.yaml
@@ -1,0 +1,19 @@
+workers:
+ttimeout: '60'
+verify: True
+syslog: True
+metrics: True
+maximize: True
+times: True
+aggressive: True
+class: 'filesystem'
+dir: '/mnt'
+fs_type: !mux
+    ext4:
+        fs: 'ext4'
+    xfs:
+        fs: 'xfs'
+    btrfs:
+        fs: 'btrfs'
+stressors: null
+exclude: null


### PR DESCRIPTION
added code to run stress-ng fs test with different file systems(ext4/xfs/btrfs) mounted

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

on RHEL9
[root@]# avocado run --test-runner runner stress-ng.py -m stress-ng.py.data/stress-ng-fs.yaml
Fetching asset from stress-ng.py:Stressng.test
JOB ID     : 1b7de62f952cfb3d01fe517b8fbedbb106038af9
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-01-12T00.18-1b7de62/job.log
 (1/3) stress-ng.py:Stressng.test;run-exclude-fs_type-ext4-stressors-workers-f640:  PASS (2983.27 s)
 (2/3) stress-ng.py:Stressng.test;run-exclude-fs_type-xfs-stressors-workers-411a:  PASS (2984.93 s)
 (3/3) stress-ng.py:Stressng.test;run-exclude-fs_type-btrfs-stressors-workers-ccec:  CANCEL: btrfs is not supported on rhel (16.43 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-01-12T00.18-1b7de62/results.html
JOB TIME   : 6000.69 s

on SLES15
localhost: # avocado run --test-runner runner stress-ng.py -m stress-ng.py.data/stress-ng-fs.yaml
Fetching asset from stress-ng.py:Stressng.test
JOB ID     : fbbdc7488b79d170b5f33cd2eb9f7756e5089805
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-01-10T17.24-fbbdc74/job.log
 (1/3) stress-ng.py:Stressng.test;run-exclude-fs_type-ext4-stressors-workers-f640:  PASS (2910.05 s)
 (2/3) stress-ng.py:Stressng.test;run-exclude-fs_type-xfs-stressors-workers-411a:  PASS (2881.49 s)
 (3/3) stress-ng.py:Stressng.test;run-exclude-fs_type-btrfs-stressors-workers-ccec:  PASS (1037.08 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-01-10T17.24-fbbdc74/results.html
JOB TIME   : 6838.20 s

[stress-ng-fs-job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10399583/stress-ng-fs-job.log)