### PR TITLE
fix perf_nmem

### DIFF
--- a/perf/perf_nmem.py
+++ b/perf/perf_nmem.py
@@ -210,6 +210,8 @@ class perfNMEM(Test):
             self.log.info("Found cpumasks are = %s" % pmu_cpumask)
         else:
             self.fail("Fail to get cpumask")
+        if int(process.run("numactl -H").stdout.split()[1]) > 1:
+            self.cancel("test not supported for multiple numa nodes")
         # Get the unique value from the cpumask list
         if len(set(pmu_cpumask)) != 1:
             self.fail("cpumask values are not same: %s" % pmu_cpumask)
@@ -229,8 +231,9 @@ class perfNMEM(Test):
             self.fail("Can't offline cpumask cpu %s" % disable_cpu)
         current_cpu = self._get_cpumask(pmu1)
         self.log.info("Current CPU: %s" % current_cpu)
-        self._check_cpumask()
         # After confirming cpu got disabled, enable back
         if current_cpu in online_cpus and disable_cpu != current_cpu:
             if cpu.online(disable_cpu):
+                self.log.info("cpu enabled back %s" % online_cpus)
+            else:
                 self.fail("Can't online cpu %s" % disable_cpu)

--- a/perf/perf_nmem.py
+++ b/perf/perf_nmem.py
@@ -173,10 +173,10 @@ class perfNMEM(Test):
             mix_events = []
             for keys in self.all_events.keys():
                 mix_events.append(self.all_events[keys][0])
-            op = process.system_output("perf stat -e '{%s}' sleep 1"
-                                       % (",".join(mix_events)), shell=True,
-                                       ignore_status=True)
-            er_ln = "The events in group usually have to be from the same PMU"
+            op = process.run("perf stat -e '{%s}' sleep 1"
+                             % (",".join(mix_events)), shell=True,
+                             ignore_status=True)
+            er_ln = "WARNING: grouped events cpus do not match, disabling group:"
             output = op.stdout.decode() + op.stderr.decode()
             # Expecting failure with the string in 'er_ln'
             if er_ln in output:


### PR DESCRIPTION
fixed error 'bytes' object has no attribute 'stdout'
make 8th test skip in case of multiple numa nodes as cpumask values are determined based on nearest numa node and can be different
test was not able to bring back disabled cpu online, patch fixes this

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

before patch:
localhost: # avocado run --test-runner runner perf_nmem.py
JOB ID     : 3443460f0e63f8b13d14dcc75d575239c76d779d
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-01-16T11.10-3443460/job.log
 (1/9) perf_nmem.py:perfNMEM.test_pmu_register_dmesg: PASS (0.93 s)
 (2/9) perf_nmem.py:perfNMEM.test_sysfs: PASS (0.86 s)
 (3/9) perf_nmem.py:perfNMEM.test_pmu_count: PASS (0.85 s)
 (4/9) perf_nmem.py:perfNMEM.test_all_events: PASS (52.62 s)
 (5/9) perf_nmem.py:perfNMEM.test_all_group_events: PASS (4.13 s)
 (6/9) perf_nmem.py:perfNMEM.test_mixed_events: ERROR: 'bytes' object has no attribute 'stdout' (2.02 s)
 (7/9) perf_nmem.py:perfNMEM.test_pmu_cpumask: PASS (0.85 s)
 (8/9) perf_nmem.py:perfNMEM.test_cpumask: FAIL: cpumask values are not same: [16, 0, 0] (0.87 s)
 (9/9) perf_nmem.py:perfNMEM.test_cpumask_cpu_off: FAIL: cpumask values are not same: [17, 0, 0] (1.15 s)
RESULTS    : PASS 6 | ERROR 1 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-01-16T11.10-3443460/results.html
JOB TIME   : 90.14 s

after patch:
localhost: # avocado run --test-runner runner perf_nmem.py 
JOB ID     : 6ab2eb1c111cc8dc1345ff12e2ab752e9a6b2b4e
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-01-16T16.15-6ab2eb1/job.log
 (1/9) perf_nmem.py:perfNMEM.test_pmu_register_dmesg: PASS (1.07 s)
 (2/9) perf_nmem.py:perfNMEM.test_sysfs: PASS (0.83 s)
 (3/9) perf_nmem.py:perfNMEM.test_pmu_count: PASS (0.80 s)
 (4/9) perf_nmem.py:perfNMEM.test_all_events: PASS (52.54 s)
 (5/9) perf_nmem.py:perfNMEM.test_all_group_events: PASS (4.00 s)
 (6/9) perf_nmem.py:perfNMEM.test_mixed_events: PASS (1.89 s)
 (7/9) perf_nmem.py:perfNMEM.test_pmu_cpumask: PASS (0.76 s)
 (8/9) perf_nmem.py:perfNMEM.test_cpumask: CANCEL: test not supported for multiple numa nodes (0.82 s)
 (9/9) perf_nmem.py:perfNMEM.test_cpumask_cpu_off: PASS (1.26 s)
RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-01-16T16.15-6ab2eb1/results.html
JOB TIME   : 89.26 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10425122/job.log)