### PR TITLE
Add yaml file to run the LTP tracing tests

### DIFF
--- a/generic/ltp.py.data/ltp-tracing.yaml
+++ b/generic/ltp.py.data/ltp-tracing.yaml
@@ -1,0 +1,4 @@
+runltp:
+    script: 'runltp'
+    tracing:
+        args: '-f tracing'


### PR DESCRIPTION
Add ltp-tracing.yaml file in order to run the LTP tracing tests

Signed-off-by: Akanksha J N <akanksha@linux.ibm.com>

avocado run ltp.py -m ltp.py.data/ltp-tracing.yaml 
Fetching asset from ltp.py:LTP.test
Fetching asset from ltp.py:LTP.test
JOB ID     : ab5dc3ac09624cd95c1c46752d813e4d9de59262
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-01-17T03.20-ab5dc3a/job.log
 (1/1) ltp.py:LTP.test;run-runltp-tracing-a507: STARTED
 (1/1) ltp.py:LTP.test;run-runltp-tracing-a507: PASS (263.36 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-01-17T03.20-ab5dc3a/results.html
JOB TIME   : 282.25 s
[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10433751/job.log)
