### PR TITLE
Fixing Ubuntu dependency and make cleaning in "x86_64"

### DIFF
--- a/io/disk/rawread.py
+++ b/io/disk/rawread.py
@@ -39,11 +39,11 @@ class Rawread(Test):
         compile of rawread suit.
         """
         smm = SoftwareManager()
-        deps = ['gcc', 'make', 'libaio-devel']
+        deps = ['gcc', 'make']
         if distro.detect().name == 'Ubuntu':
-            deps.extend(['g++'])
+            deps.extend(['g++','libaio-dev'])
         else:
-            deps.extend(['gcc-c++'])
+            deps.extend(['gcc-c++','libaio-devel'])
 
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
@@ -55,6 +55,10 @@ class Rawread(Test):
                                    os.path.basename(
                                        tarball.split('.tar')[0]))
         os.chdir(self.source)
+        d_distro = distro.detect()
+        arch = d_distro.arch
+        if arch == 'x86_64':
+            build.make(self.source, extra_args="clean")
         build.make(self.source)
 
         self.disk = self.params.get('disk', default=None)

--- a/io/disk/rawread.py
+++ b/io/disk/rawread.py
@@ -41,9 +41,9 @@ class Rawread(Test):
         smm = SoftwareManager()
         deps = ['gcc', 'make']
         if distro.detect().name == 'Ubuntu':
-            deps.extend(['g++','libaio-dev'])
+            deps.extend(['g++', 'libaio-dev'])
         else:
-            deps.extend(['gcc-c++','libaio-devel'])
+            deps.extend(['gcc-c++', 'libaio-devel'])
 
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):


### PR DESCRIPTION
"Libaio-devel" -> libaio-dev on Ubuntu distro's
and make needs cleaning on x86_64 systems for rawread.tar.

Signed-off-by: ayushjain951 <ayush.jain3@amd.com>