### PR TITLE
Fixing Ubuntu dependency and make cleaning in "x86_64"

### DIFF
--- a/io/disk/rawread.py
+++ b/io/disk/rawread.py
@@ -39,11 +39,11 @@ class Rawread(Test):
         compile of rawread suit.
         """
         smm = SoftwareManager()
-        deps = ['gcc', 'make', 'libaio-devel']
+        deps = ['gcc', 'make']
         if distro.detect().name == 'Ubuntu':
-            deps.extend(['g++'])
+            deps.extend(['g++', 'libaio-dev'])
         else:
-            deps.extend(['gcc-c++'])
+            deps.extend(['gcc-c++', 'libaio-devel'])
 
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
@@ -55,6 +55,7 @@ class Rawread(Test):
                                    os.path.basename(
                                        tarball.split('.tar')[0]))
         os.chdir(self.source)
+        build.make(self.source, extra_args="clean")
         build.make(self.source)
 
         self.disk = self.params.get('disk', default=None)


### PR DESCRIPTION
"Libaio-devel" -> libaio-dev on Ubuntu distro's
and make needs cleaning on x86_64 systems for rawread.tar.

Signed-off-by: Ayush Jain <ayush.jain3@amd.com>