### PR TITLE
Basic packages like flex, bison required for test

### DIFF
--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -72,7 +72,7 @@ class Iperf(Test):
         if not self.session.connect():
             self.cancel("failed connecting to peer")
         smm = SoftwareManager()
-        for pkg in ["gcc", "autoconf", "perl", "m4", "libtool", "gcc-c++"]:
+        for pkg in ["gcc", "autoconf", "perl", "m4", "libtool", "gcc-c++", "flex", "bison"]:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel("%s package is need to test" % pkg)
             cmd = "%s install %s" % (smm.backend.base_command, pkg)

--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -70,7 +70,7 @@ class Netperf(Test):
             self.cancel("failed connecting to peer")
         smm = SoftwareManager()
         detected_distro = distro.detect()
-        pkgs = ['gcc', 'unzip']
+        pkgs = ['gcc', 'unzip', 'flex', 'bison']
         if detected_distro.name == "Ubuntu":
             pkgs.append('openssh-client')
         elif detected_distro.name == "SuSE":

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -73,7 +73,7 @@ class Uperf(Test):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         pkgs = ["gcc", "gcc-c++", "autoconf",
-                "perl", "m4", "git-core", "automake"]
+                "perl", "m4", "git-core", "automake", "flex", "bison"]
         if detected_distro.name == "Ubuntu":
             pkgs.extend(["libsctp1", "libsctp-dev", "lksctp-tools"])
         elif detected_distro.name == "rhel":


### PR DESCRIPTION
On a fresh os, the source compilation is failing due to missing packages like flex bison for test like iperf, uperf and netperf

configure: error: Neither flex nor lex was found
configure: error: ./configure failed for libpcap

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>