### PR TITLE
Resolve duplicate debug msg in memory/fork_mem test

### DIFF
--- a/memory/fork_mem.py.data/forkoff.c
+++ b/memory/fork_mem.py.data/forkoff.c
@@ -20,7 +20,9 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/wait.h>
 
+int
 main(int argc,char *argv[])
 {
         unsigned long size, psize, procs, itterations;
@@ -53,6 +55,7 @@ main(int argc,char *argv[])
                 printf("address = %lx\n", ptr);
                 perror("");
         }
+		fflush(stdout);
         k = procs;
         do{
                 pid = fork();
@@ -71,4 +74,5 @@ main(int argc,char *argv[])
 		}
 	} while(--k);
 	while (procs-- && wait(&status));
+	return 0;
 }


### PR DESCRIPTION
Here below are the logs of duplicate msg "mmaping xx anonynous bytes"

[stdlog] 2023-01-19 06:20:26,564 avocado.utils.process DEBUG| [stdout] mmaping 10485760 anonymous bytes
[stdlog] 2023-01-19 06:20:26,564 avocado.utils.process DEBUG| [stdout] PID 31747 touching 160 pages
[stdlog] 2023-01-19 06:20:26,564 avocado.utils.process DEBUG| [stdout] mmaping 10485760 anonymous bytes
[stdlog] 2023-01-19 06:20:26,564 avocado.utils.process DEBUG| [stdout] PID 31753 touching 160 pages
[stdlog] 2023-01-19 06:20:26,564 avocado.utils.process DEBUG| [stdout] mmaping 10485760 anonymous bytes

Becuase, stdout is streamed to some file, the return character ('\n') is not able to flush the stdout stream
and on each time fork is called, the parent log are printed again.

Also this patch resolve some compiler time warnings.

Signed-off-by: Tarun Sahu <tsahu@linux.ibm.com>
Reported-by: Geetika <geetika@linux.ibm.com>