### PR TITLE
Fix sign extension issue with read_memory function.

### DIFF
--- a/memory/migrate_pages.py.data/node_move_pages.c
+++ b/memory/migrate_pages.py.data/node_move_pages.c
@@ -139,7 +139,7 @@ void unlock_mem(void *mmap_pointer, unsigned long memory)
 }
 
 /* Read and verify the pattern from given address for given size */
-void read_memory(char *addr, int pattern, unsigned long size, unsigned long pagesize)
+void read_memory(char *addr, char pattern, unsigned long size, unsigned long pagesize)
 {
 	unsigned long iterator;
 	unsigned long read = 0;


### PR DESCRIPTION
 In read_memory function in node_move_pages.c, the 'pattern' being compared
 with the 'value' which is a char, this leads to an sign extension issue.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>