### PR TITLE
 memory/mm_subsystem: replace gitlab/linux-mm with newly created gith…

### DIFF
--- a/memory/mm_subsystem.py
+++ b/memory/mm_subsystem.py
@@ -65,7 +65,7 @@ class MmSubsystemTest(Test):
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        git.get_repo("https://gitlab.com/harish-24/linux-mm",
+        git.get_repo("https://github.com/narasimhan-v/linux-mm",
                      destination_dir=self.logdir)
         os.chdir(self.logdir)
         build.make(self.logdir)


### PR DESCRIPTION
…ub link for linux-mm

  Due to less response on gitlab/linux-mm, a new github repo created.
  Any changes or fixes henceforth will be done on this git linux-mm repo
  New git repo link: https://github.com/narasimhan-v/linux-mm

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>