### PR TITLE
 memmory/numa_test: Add appropriate cancel messages for missing libhu…

### DIFF
--- a/memory/numa_test.py
+++ b/memory/numa_test.py
@@ -67,6 +67,8 @@ class NumaTest(Test):
             pkgs.extend(['libpthread-stubs0-dev',
                          'libnuma-dev', 'libhugetlbfs-dev'])
         elif dist.name in ["centos", "rhel", "fedora"]:
+            if (dist.name == 'rhel' and dist.version >= '9'):
+                self.cancel("libhugetlbfs packages are not available on RHEL 9.x onwards.")
             pkgs.extend(['numactl-devel', 'libhugetlbfs-devel'])
         elif dist.name == "SuSE":
             pkgs.extend(['libnuma-devel'])


### PR DESCRIPTION
…getlbfs packages on rhel-9.x

  Fix is to ensure proper messages are logged when libhugetlfs packages
  are not available on rhel-9.x distro.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>