### PR TITLE
Mis-match of yaml parameter name for numactl test

### DIFF
--- a/cpu/numactl.py.data/numa_fc.yaml
+++ b/cpu/numactl.py.data/numa_fc.yaml
@@ -2,5 +2,5 @@ disk:
 seek:
 count:
 bytes:
-input_device:
+input_file:
 pci_device: 


### PR DESCRIPTION
The name of a parameter in yaml is "input_device" and in .py file it is "input_file" names were not matching. so changed yaml parameter name to "input_file" which is appropriate.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>