### PR TITLE
Fixing no attribute 'err_mesg'

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -66,7 +66,7 @@ class Bonnie(Test):
                                           default=getpass.getuser())
         self.number_to_stat = self.params.get('number-to-stat', default=2048)
         self.data_size = self.params.get('data_size_to_pass', default=0)
-
+        self.err_mesg = []
         smm = SoftwareManager()
         # Install the package from web
         deps = ['gcc', 'make']
@@ -106,7 +106,6 @@ class Bonnie(Test):
         self.raid_name = '/dev/md/sraid'
         self.vgname = 'avocado_vg'
         self.lvname = 'avocado_lv'
-        self.err_mesg = []
         self.target = self.disk
         self.lv_disk = self.disk
         self.part_obj = Partition(self.disk, mountpoint=self.dir)

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -62,6 +62,7 @@ class Disktest(Test):
         :param chunk_mb: Size of the portion of the disk used to run the test.
                          Cannot be smaller than the total amount of RAM.
         """
+        self.err_mesg = []
         smm = SoftwareManager()
         if not smm.check_installed("gcc") and not smm.install("gcc"):
             self.cancel('Gcc is needed for the test to be run')
@@ -75,7 +76,6 @@ class Disktest(Test):
         self.dir = self.params.get('dir', default=None)
         self.fstype = self.params.get('fs', default='ext4')
         self.raid_name = '/dev/md/sraid'
-        self.err_mesg = []
 
         if self.fstype == 'btrfs':
             ver = int(distro.detect().version)

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -67,7 +67,7 @@ class FioTest(Test):
         lv_needed = self.params.get('lv', default=False)
         raid_needed = self.params.get('raid', default=False)
         self.fio_file = 'fiotest-image'
-
+        self.err_mesg = []
         self.fs_create = False
         self.lv_create = False
         self.raid_create = False
@@ -114,7 +114,6 @@ class FioTest(Test):
         self.raid_name = '/dev/md/sraid'
         self.vgname = 'avocado_vg'
         self.lvname = 'avocado_lv'
-        self.err_mesg = []
 
         if self.disk_type == 'nvdimm':
             self.setup_pmem_disk(mnt_args)

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -57,6 +57,7 @@ class LtpFs(Test):
         self.dir = self.params.get('dir', default='/mnt')
         self.fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
+        self.err_mesg = []
         smm = SoftwareManager()
         packages = ['gcc', 'make', 'automake', 'autoconf']
         if raid_needed:
@@ -76,7 +77,6 @@ class LtpFs(Test):
         self.raid_name = '/dev/md/sraid'
         self.vgname = 'avocado_vg'
         self.lvname = 'avocado_lv'
-        self.err_mesg = []
         self.target = self.disk
         self.lv_disk = self.disk
         self.part_obj = Partition(self.disk, mountpoint=self.dir)
@@ -216,7 +216,7 @@ class LtpFs(Test):
         if wait.wait_for(is_raid_deleted, timeout=10):
             self.log.info("software raid  %s deleted" % self.raid_name)
         else:
-            self.err_mesg.append("failed to delete swraid %s" % self.raid_name)
+            self.err_mesg.extend(["failed to delete swraid %s" % self.raid_name])
 
     def delete_lv(self):
         """
@@ -233,7 +233,7 @@ class LtpFs(Test):
         if wait.wait_for(is_lv_deleted, timeout=10):
             self.log.info("lv %s deleted", self.lvname)
         else:
-            self.err_mesg.append("failed to delete lv %s" % self.lvname)
+            self.err_mesg.extend(["failed to delete lv %s" % self.lvname])
         # checking and deleteing if lvm_meta_data exists after lv removed
         cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
         out = process.system_output(cmd, shell=True,
@@ -279,7 +279,7 @@ class LtpFs(Test):
             if wait.wait_for(is_disk_unmounted, timeout=10):
                 self.log.info("%s unmounted successfully" % l_disk)
             else:
-                self.err_mesg.append("%s unmount failed", l_disk)
+                self.err_mesg.extend(["%s unmount failed", l_disk])
         else:
             self.log.info("disk %s not mounted." % l_disk)
         self.log.info("checking if dir %s is mounted." % self.dir)
@@ -288,7 +288,7 @@ class LtpFs(Test):
             if wait.wait_for(is_dir_unmounted, timeout=10):
                 self.log.info("%s unmounted successfully" % self.dir)
             else:
-                self.err_mesg.append("failed to unount %s", self.dir)
+                self.err_mesg.extend(["failed to unount %s", self.dir])
         else:
             self.log.info("dir %s not mounted." % self.dir)
         self.log.info("checking if fs exists in {}" .format(l_disk))
@@ -297,7 +297,7 @@ class LtpFs(Test):
             if wait.wait_for(is_fs_deleted, timeout=10):
                 self.log.info("fs removed successfully..")
             else:
-                self.err_mesg.append(f'failed to delete fs on {l_disk}')
+                self.err_mesg.extend([f"failed to delete fs on {l_disk}"])
         else:
             self.log.info("No fs detected on %s" % self.disk)
 
@@ -345,4 +345,4 @@ class LtpFs(Test):
                 self.delete_raid()
         dmesg.clear_dmesg()
         if self.err_mesg:
-            self.warn("test failed due to following errors %s" % self.err_mesg)
+            self.log.warning("test failed due to following errors %s" % self.err_mesg)

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -58,6 +58,7 @@ class LtpFs(Test):
         self.fsstress_count = self.params.get('fsstress_loop', default='1')
         self.n_val = self.params.get('n_val', default='100')
         self.p_val = self.params.get('p_val', default='100')
+        self.err_mesg = []
 
         smm = SoftwareManager()
         packages = ['gcc', 'make', 'automake', 'autoconf']
@@ -82,7 +83,6 @@ class LtpFs(Test):
         self.raid_name = '/dev/md/sraid'
         self.vgname = 'avocado_vg'
         self.lvname = 'avocado_lv'
-        self.err_mesg = []
         self.target = self.disk
         self.lv_disk = self.disk
         self.part_obj = Partition(self.disk, mountpoint=self.dir)
@@ -221,7 +221,7 @@ class LtpFs(Test):
         if wait.wait_for(is_raid_deleted, timeout=10):
             self.log.info("software raid  %s deleted" % self.raid_name)
         else:
-            self.err_mesg.append("failed to delete sraid %s" % self.raid_name)
+            self.err_mesg.extend(['failed to delete sraid %s' % self.raid_name])
 
     def delete_lv(self):
         """
@@ -238,7 +238,7 @@ class LtpFs(Test):
         if wait.wait_for(is_lv_deleted, timeout=10):
             self.log.info("lv %s deleted", self.lvname)
         else:
-            self.err_mesg.append("failed to delete lv %s" % self.lvname)
+            self.err_mesg.extend(['failed to delete lv %s' % self.lvname])
         # checking and deleteing if lvm_meta_data exists after lv removed
         cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
         out = process.system_output(cmd, shell=True,
@@ -284,7 +284,7 @@ class LtpFs(Test):
             if wait.wait_for(is_disk_unmounted, timeout=10):
                 self.log.info("%s unmounted successfully" % l_disk)
             else:
-                self.err_mesg.append("%s unmount failed", l_disk)
+                self.err_mesg.extend(['%s unmount failed', l_disk])
         else:
             self.log.info("disk %s not mounted." % l_disk)
         self.log.info("checking if dir %s is mounted." % self.dir)
@@ -293,7 +293,7 @@ class LtpFs(Test):
             if wait.wait_for(is_dir_unmounted, timeout=10):
                 self.log.info("%s unmounted successfully" % self.dir)
             else:
-                self.err_mesg.append("failed to unount %s", self.dir)
+                self.err_mesg.extend(['failed to unount %s', self.dir])
         else:
             self.log.info("dir %s not mounted." % self.dir)
         self.log.info("checking if fs exists in {}" .format(l_disk))
@@ -302,7 +302,7 @@ class LtpFs(Test):
             if wait.wait_for(is_fs_deleted, timeout=10):
                 self.log.info("fs removed successfully..")
             else:
-                self.err_mesg.append(f'failed to delete fs on {l_disk}')
+                self.err_mesg.extend([f'failed to delete fs on {l_disk}'])
         else:
             self.log.info(f'No fs detected on {self.disk}')
 
@@ -335,4 +335,4 @@ class LtpFs(Test):
                 self.delete_raid()
         dmesg.clear_dmesg()
         if self.err_mesg:
-            self.warn("test failed due to following errors %s" % self.err_mesg)
+            self.log.warning("test failed due to following errors %s" % self.err_mesg)


### PR DESCRIPTION
Redefining err_msg parameters in testcases before they get called by functions. Fix for ERROR: list.append() takes exactly one argument by changing to extending lists.

Signed-off-by: Ayush Jain <ayush.jain3@amd.com>