### PR TITLE
Changing the command to get exact nvme controller_id out two controll…

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -193,12 +193,12 @@ class NVMeTest(Test):
         """
         Returns the nvme controller id
         """
-        cmd = "%s list-ctrl %s" % (self.binary, self.device)
+        cmd = "%s id-ctrl %s" % (self.binary, self.device)
         output = process.system_output(cmd, shell=True,
                                        ignore_status=True).decode("utf-8")
         for line in output.splitlines():
-            if '0]' in line:
-                return line.split(':')[-1]
+            if 'cntlid' in line:
+                return line.split(':')[-1].strip()
         return ""
 
     def get_lba(self):


### PR DESCRIPTION
…er IDs

with command "list-ctrl" it show two different controller IDs and we cannot judge which is the active ID here. Hence test cases are failing due to this So change the command to "id-ctrl" which gives the exact active controller_id.

Also changed the action values that we use to run after firmware flash it was 0-4 ealier which is not required in real. Firmware download was failing for 4 times as we need to download the fw for each slots. action values 1-3 are enough to commit the fw after flash. so changing it to 1-3.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>