### PR TITLE
Changing the fw-commit action values from 0-4 to 0-3 in nvmetest.py

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -295,7 +295,7 @@ class NVMeTest(Test):
             if not self.firmware_slot_write_supported(slot):
                 continue
             passed_actions = []
-            for action in range(0, 4):
+            for action in range(0, 3):
                 # Downloading new FW to the device for each slot
                 if process.system(d_cmd, shell=True, ignore_status=True):
                     continue


### PR DESCRIPTION
The fw-commit uses an option called action (-a) to commit the flashed firmware on nvme drive. 0-3 are the valid values we have to use for this option. value  4 is not applicable and on using the test is failing. So changing it to 0-3.

Signed-off-by: Naresh Bannoth <nbannoth@in.ibm.com>