### PR TITLE
Fix the test failure validation

### DIFF
--- a/toolchain/gdb.py
+++ b/toolchain/gdb.py
@@ -66,10 +66,8 @@ class GDB(Test):
         build.make(sourcedir)
 
     def test(self):
-        process.run("make check-gdb", ignore_status=True, sudo=True)
-        logfile = os.path.join(self.logdir, "stdout")
-        with open(logfile, 'r') as f:
-            for line in f.readlines():
-                for match in re.finditer("of unexpected failures[1-9]", line):
-                    self.log.info(line)
-                    self.fail("Few gdb tests have failed")
+        ret = process.run("make check-gdb", ignore_status=True, sudo=True)
+        match = re.search(r'of unexpected failures[\t]*[1-9]',  ret.stdout.decode("utf-8"), re.M | re.I)
+        if match:
+            self.fail("test failed, Please check the debug log for failed test cases")
+

--- a/toolchain/gsl.py
+++ b/toolchain/gsl.py
@@ -44,8 +44,7 @@ class GSL(Test):
         build.make(self.sourcedir)
 
     def test(self):
-        process.run("make -k check", ignore_status=True, sudo=True)
-        logfile = os.path.join(self.logdir, "stdout")
-        match = re.search(r'FAIL:\s+[1-9]', logfile, re.M | re.I)
+        ret = process.run("make -k check", ignore_status=True, sudo=True)
+        match = re.search(r'FAIL:\s+[1-9]',  ret.stdout.decode("utf-8"), re.M | re.I)
         if match:
             self.fail("test failed, Please check debug log for failed test cases")


### PR DESCRIPTION
fixed test validation, instead of checking from stdout, checking out only on the command output.

Signed-off-by: Hariharan T S <hariharan.ts@linux.vnet.ibm.com>