### PR TITLE
fix-stress-ng

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -183,6 +183,9 @@ class Stressng(Test):
                       "\n".join(ERROR))
 
     def tearDown(self):
-        process.run("umount %s" % self.loop_dev)
-        process.run("losetup -d %s" % self.loop_dev)
-        process.run("rm -rf /tmp/blockfile")
+        if 'filesystem' in self.class_type:
+            process.run("umount %s" % self.loop_dev, ignore_status=True,
+                        sudo=True)
+            process.run("losetup -d %s" % self.loop_dev, ignore_status=True,
+                        sudo=True)
+            process.run("rm -rf /tmp/blockfile", ignore_status=True, sudo=True)


### PR DESCRIPTION
stress-ng run with other components was giving error because of last commit 736b0d186d04 for filesystem
this patch fixes the error by adding condition in teardown

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

before patch
avocado run stress-ng.py -m stress-ng.py.data/stress-ng.yaml 
Fetching asset from stress-ng.py:Stressng.test
JOB ID     : dbc595441100a6a29f0ef55db3ecfbb8418b2195
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-02-03T04.50-dbc5954/job.log
 (1/1) stress-ng.py:Stressng.test;run-subsystem-cpu-workers-8835: STARTED
 (1/1) stress-ng.py:Stressng.test;run-subsystem-cpu-workers-8835: ERROR: 'Stressng' object has no attribute 'loop_dev' (328.77 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-02-03T04.50-dbc5954/results.html
JOB TIME   : 339.40 s

after patch
avocado run stress-ng.py -m stress-ng.py.data/stress-ng.yaml 
Fetching asset from stress-ng.py:Stressng.test
JOB ID     : b081b741f6365f604ea0b5121e4dde292e95b60e
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-02-03T04.57-b081b74/job.log
 (1/1) stress-ng.py:Stressng.test;run-subsystem-cpu-workers-8835: STARTED
 (1/1) stress-ng.py:Stressng.test;run-subsystem-cpu-workers-8835: PASS (316.56 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-02-03T04.57-b081b74/results.html
JOB TIME   : 328.21 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10578325/job.log)