### PR TITLE
vNIC: Enable iteration for disable-enable test

### DIFF
--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -308,16 +308,20 @@ class NetworkVirtualization(Test):
         '''
         Test if disabling and enabling of an adapter works
         '''
-        self.disable_enable_dev('d')
-        self.is_disabled_enabled_dev('1')
-        self.disable_enable_dev('e')
-        self.is_disabled_enabled_dev('0')
         device = self.find_device(self.mac_id[0])
         networkinterface = NetworkInterface(device, self.local)
-        wait.wait_for(networkinterface.is_link_up, timeout=60)
-        if networkinterface.ping_check(self.peer_ip[0], count=5) is not None:
-            self.fail(
-                "Enabling and disabling of the interface has affected network connectivity")
+        for _ in range(self.count):
+            self.disable_enable_dev('d')
+            self.is_disabled_enabled_dev('1')
+            self.disable_enable_dev('e')
+            self.is_disabled_enabled_dev('0')
+            device = self.find_device(self.mac_id[0])
+            if not device:
+                self.fail("Interface is not available")
+            wait.wait_for(networkinterface.is_link_up, timeout=60)
+            if networkinterface.ping_check(self.peer_ip[0], count=5) is not None:
+                self.fail(
+                    "Enabling and disabling of the interface has affected network connectivity")
         self.check_dmesg_error()
 
     def disable_enable_dev(self, option):


### PR DESCRIPTION
    Make sure the test can be run for given iterations and always check the device config post every iteration
  

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>