### PR TITLE
ethtool: Enable mac addr as an input option

### DIFF
--- a/io/net/ethtool_test.py.data/README.txt
+++ b/io/net/ethtool_test.py.data/README.txt
@@ -11,7 +11,7 @@ to be updated, so that setting 'up / down <interface>' configures the interface.
 
 Input Needed (in multiplexer file):
 -----------------------------------
-Interfaces     -   Specify the interface for which the test needs to be run.
+interface      -   Specify the interface name 'eth1' or mac addr '34:80:0d:9b:dc:30' of device under test
 arg            -   Specify the argument that needs to be tested.
 action_elapse  -   Specify action elapse for those arguments that need it.
 host-IP        -   Specify host-IP for ip configuration.

--- a/io/net/ethtool_test.py.data/ethtool_infiniband.yaml
+++ b/io/net/ethtool_test.py.data/ethtool_infiniband.yaml
@@ -1,4 +1,4 @@
-interface: ib0
+interface:
 peer_ip:
 host_ip:
 netmask:

--- a/io/net/ethtool_test.py.data/ethtool_sriov_test.yaml
+++ b/io/net/ethtool_test.py.data/ethtool_sriov_test.yaml
@@ -1,4 +1,4 @@
-interface: 
+interface:
 hbond:
 peer_ip:
 host_ip:


### PR DESCRIPTION
In a contineous test environement setups where device names are not persistent accross os install, having a unique key like mac addr as yaml input which does not change across reboots, dlpar and os install with different linux flavours, also the legacy interface name as input is still intact with these changes

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>