### PR TITLE
add-group-param-xfstest

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -221,6 +221,7 @@ class Xfstests(Test):
                 self.cancel("Fail to install %s required for this test." %
                             package)
         self.skip_dangerous = self.params.get('skip_dangerous', default=True)
+        self.group = self.params.get('group', default=None)
         self.test_range = self.params.get('test_range', default=None)
         self.scratch_mnt = self.params.get(
             'scratch_mnt', default='/mnt/scratch')
@@ -443,7 +444,7 @@ class Xfstests(Test):
             args = ''
             if self.exclude or self.gen_exclude:
                 args = ' -E %s' % self.exclude_file
-            cmd = './check %s -g auto' % args
+            cmd = './check %s -g %s' % (args, self.group)
             result = process.run(cmd, ignore_status=True, verbose=True)
             if result.exit_status == 0:
                 self.log.info('OK: All Tests passed.')
@@ -453,6 +454,8 @@ class Xfstests(Test):
                 failures = True
 
         else:
+            if self.group:
+                self.error("change group param to null in yaml to run test range")
             self.log.info('Running only specified tests')
             for test in self.test_list:
                 test = '%s/%s' % (self.fs_to_test, test)

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -223,6 +223,7 @@ class Xfstests(Test):
         self.skip_dangerous = self.params.get('skip_dangerous', default=True)
         self.group = self.params.get('group', default=None)
         self.test_range = self.params.get('test_range', default=None)
+        self.base_disk = self.params.get('disk', default=None)
         self.scratch_mnt = self.params.get(
             'scratch_mnt', default='/mnt/scratch')
         self.test_mnt = self.params.get('test_mnt', default='/mnt/test')
@@ -315,7 +316,6 @@ class Xfstests(Test):
                           ignore_status=True):
             self.cancel('Unknown filesystem %s' % self.fs_to_test)
         mount = True
-        self.devices = []
         self.log_devices = []
         shutil.copyfile(self.get_data('local.config'),
                         os.path.join(self.teststmpdir, 'local.config'))
@@ -326,9 +326,8 @@ class Xfstests(Test):
         self.log_scratch = self.params.get('log_scratch', default='')
 
         if self.dev_type == 'loop':
-            base_disk = self.params.get('disk', default=None)
             loop_size = self.params.get('loop_size', default='7GiB')
-            if not base_disk:
+            if not self.base_disk:
                 # Using root for file creation by default
                 check = (int(loop_size.split('GiB')[0]) * 2) + 1
                 if disk.freespace('/') / 1073741824 > check:
@@ -336,7 +335,7 @@ class Xfstests(Test):
                     mount = False
                 else:
                     self.cancel('Need %s GB to create loop devices' % check)
-            self._create_loop_device(base_disk, loop_size, mount)
+            self._create_loop_device(loop_size, mount)
         elif self.dev_type == 'nvdimm':
             self.setup_nvdimm()
         else:
@@ -494,7 +493,7 @@ class Xfstests(Test):
             for dev in self.devices:
                 process.system('losetup -d %s' % dev, shell=True,
                                sudo=True, ignore_status=True)
-            if self.disk_mnt:
+            if self.part:
                 self.part.unmount()
         elif self.dev_type == 'nvdimm':
             if hasattr(self, 'region'):
@@ -509,10 +508,10 @@ class Xfstests(Test):
                             process.system('losetup -d %s' % dev, shell=True,
                                            sudo=True, ignore_status=True)
 
-    def _create_loop_device(self, base_disk, loop_size, mount=True):
+    def _create_loop_device(self, loop_size, mount=True):
         if mount:
             self.part = partition.Partition(
-                base_disk, mountpoint=self.disk_mnt)
+                self.base_disk, mountpoint=self.disk_mnt)
             self.part.mount()
         # Creating two loop devices
         for i in range(2):

--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -231,6 +231,12 @@ class Xfstests(Test):
         self.fs_to_test = self.params.get('fs', default='ext4')
         self.run_type = self.params.get('run_type', default='distro')
 
+        self.devices = []
+        self.part = None
+        if (self.group and self.test_range) or (self.group==None and self.test_range==None):
+            self.cancel("incorrect yaml parameter, group and test range can \
+                         not be run/none at same time")
+
         if self.run_type == 'upstream':
             prefix = "/usr/local"
             bin_prefix = "/usr/local/bin"
@@ -453,8 +459,6 @@ class Xfstests(Test):
                 failures = True
 
         else:
-            if self.group:
-                self.error("change group param to null in yaml to run test range")
             self.log.info('Running only specified tests')
             for test in self.test_list:
                 test = '%s/%s' % (self.fs_to_test, test)

--- a/fs/xfstests.py.data/btrfs-subpage.yaml
+++ b/fs/xfstests.py.data/btrfs-subpage.yaml
@@ -2,7 +2,8 @@ skip_dangerous: True
 scratch_mnt: '/mnt/scratch'
 test_mnt: '/mnt/test'
 disk_mnt: '/mnt/loop-device'
-test_range: '54-55'
+group: 'auto'
+test_range: null
 fs_type: !mux
   fs_btrfs:
     fs: 'btrfs'

--- a/fs/xfstests.py.data/nvdimm.yaml
+++ b/fs/xfstests.py.data/nvdimm.yaml
@@ -1,6 +1,8 @@
 skip_dangerous: True
 scratch_mnt: '/mnt/scratch_pmem'
 test_mnt: '/mnt/test_pmem'
+group: 'auto'
+test_range: null
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'

--- a/fs/xfstests.py.data/nvdimm_log.yaml
+++ b/fs/xfstests.py.data/nvdimm_log.yaml
@@ -2,6 +2,8 @@ skip_dangerous: True
 scratch_mnt: '/mnt/scratch_pmem'
 test_mnt: '/mnt/test_pmem'
 logdev: true
+group: 'auto'
+test_range: null
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'

--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -6,7 +6,7 @@ disk_mnt: '/mnt/loop-device'
 # don't give test range while specifying group
 group: 'auto'
 # Uncomment and edit test_range for running specific tests
-test_range: "null"
+test_range: null
 loop_type: !mux
     type: 'loop'
     loop_size: '7GiB'

--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -2,6 +2,9 @@ skip_dangerous: True
 scratch_mnt: '/mnt/scratch'
 test_mnt: '/mnt/test'
 disk_mnt: '/mnt/loop-device'
+# edit group for running specific group tests
+# don't give test range while specifying group
+group: 'auto'
 # Uncomment and edit test_range for running specific tests
 test_range: "null"
 loop_type: !mux

--- a/fs/xfstests.py.data/xfstests_disk.yaml
+++ b/fs/xfstests.py.data/xfstests_disk.yaml
@@ -1,8 +1,9 @@
 skip_dangerous: True
 scratch_mnt: '/mnt/scratch'
 test_mnt: '/mnt/test'
+group: 'auto'
 # Uncomment and edit test_range for running specific tests
-test_range: '73,217-415'
+test_range: null
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'


### PR DESCRIPTION
added group parameter support in xfstest to run any group specific tests

Signed-off-by: Disha Goel <disgoel@linux.vnet.ibm.com>

with both group and test range param
[root@]# avocado run --max-parallel-tasks=1 xfstests.py -m xfstests.py.data/xfstests.yaml
JOB ID     : ef1d23e2872f073940bf623a986cf390a2d4c2e7
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-02-07T05.45-ef1d23e/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-loop_type-ae6d: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-loop_type-ae6d: ERROR: change group param to null in yaml to run test range (20.49 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-02-07T05.45-ef1d23e/results.html
JOB TIME   : 32.76 s

with test range param
[root@]# avocado run --max-parallel-tasks=1 xfstests.py -m xfstests.py.data/xfstests.yaml
JOB ID     : d52ad345e41050668f5129d64e85fbad42705326
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-02-07T05.47-d52ad34/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-group-loop_type-1670: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-group-loop_type-1670: PASS (25.61 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-02-07T05.47-d52ad34/results.html
JOB TIME   : 37.09 s

with group param
[root@]# avocado run --max-parallel-tasks=1 xfstests.py -m xfstests.py.data/xfstests.yaml
JOB ID     : c06b5ca84a80229a6fc5d8b32370ecefb5640689
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-02-07T05.49-c06b5ca/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-loop_type-test_range-b1c7: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-loop_type-test_range-b1c7: PASS (21.48 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-02-07T05.49-c06b5ca/results.html
JOB TIME   : 32.95 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10674884/job.log)