### PR TITLE
 perf/perf_uprobe: handle tearDown failure case

### DIFF
--- a/perf/perf_uprobe.py
+++ b/perf/perf_uprobe.py
@@ -71,7 +71,7 @@ class PerfUprobe(Test):
         self.report = "perf report --input=%s" % self.temp_file
 
     def cmd_verify(self, cmd):
-        return process.run(cmd, shell=True)
+        return process.run(cmd, shell=True, ignore_status=True)
 
     def test_uprobe(self):
         output = self.cmd_verify('%s /usr/bin/perf main' % self.cmdProbe)


### PR DESCRIPTION
  "Device or resource busy" error thrown from the tearDown() even
   though events gets deleted. To avoid passed "ignore_status=True"
   to process.run in cmd_verify to ignore the status. However, the cmd
   output has been taken care in parsing the results.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>