### PR TITLE
disktest.py:add support for test run by device id

### DIFF
--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -73,6 +73,10 @@ class Disktest(Test):
         self.raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
         self.disk = self.params.get('disk', default=None)
+        self.sysdisks = disk.get_disks()
+        if 'scsi-' in self.disk or 'nvme-' in self.disk:
+            self.disk = '/dev/disk/by-id/%s' % self.disk
+            self.sysdisks = disk.get_disks_by_id()
         self.dir = self.params.get('dir', default=None)
         self.fstype = self.params.get('fs', default='ext4')
         self.raid_name = '/dev/md/sraid'
@@ -122,7 +126,7 @@ class Disktest(Test):
         dmesg.clear_dmesg()
         self.pre_cleanup()
         if self.disk is not None:
-            if self.disk in disk.get_disks():
+            if self.disk in self.sysdisks:
                 if self.raid_needed:
                     self.create_raid(self.target, self.raid_name)
                     self.raid_create = True

--- a/io/disk/disktest.py.data/README.txt
+++ b/io/disk/disktest.py.data/README.txt
@@ -8,6 +8,8 @@ each disk) and checking failures after each chunk is written.
 Available parameters
 --------------------
 
-disk       - Disk to be used in test.
+disk       - Provide the test disk name /dev/sda or /dev/mapper/mpatha or 
+             scsi-360050768108000000000283 or nvme-eui.364555305250000003
+             you can get the disk by id name via /dev/disk/by-id/
 dir        - Directory of used in test. When the target does not exist,
 	     it's created.


### PR DESCRIPTION
In contineous test setups where device names undertest are unpredicatable and this code will help run the test by accepting unique device id which are persistant across os installs.

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>