### PR TITLE
 perf/perf_basic: handle file existenace issue in tearDown

### DIFF
--- a/perf/perf_basic.py
+++ b/perf/perf_basic.py
@@ -70,12 +70,11 @@ class PerfBasic(Test):
         else:
             self.cancel("perf is not supported on %s" % dist.name)
 
+        self.temp_file = tempfile.NamedTemporaryFile().name
         for pkg in pkgs:
             if not smg.check_installed(pkg) and not smg.install(pkg):
                 self.cancel(
                     "Package %s is missing/could not be installed" % pkg)
-
-        self.temp_file = tempfile.NamedTemporaryFile().name
 
     def test_perf_help(self):
         self.run_cmd("perf --help", False)


### PR DESCRIPTION
  The issue is seen when desired packages are not installed, the tests gets
  cancelled and go through "tearDown", where it check for temp_file. Since
  temp_file creation is below package cancel code. It will never go through
  that code path. So, moved the creation of temp_file before checking for
  package cancel code.

Signed-off-by: Kalpana Shetty <kalpana.shetty@amd.com>