### PR TITLE
ras/smtstate: Cancel the test on non SMT config

### DIFF
--- a/ras/smtstate.py
+++ b/ras/smtstate.py
@@ -32,6 +32,10 @@ class smtstate_tool(Test):
         if not sm.check_installed("powerpc-utils") and \
                 not sm.install("powerpc-utils"):
             self.cancel("powerpc-utils is needed for the test to be run")
+        smt_op = process.run("ppc64_cpu --smt", shell=True,
+                             ignore_status=True).stderr.decode("utf-8")
+        if "is not SMT capable" in smt_op:
+            self.cancel("Machine is not SMT capable, skipping the test")
         distro_name = self.detected_distro.name
         distro_ver = self.detected_distro.version
         distro_rel = self.detected_distro.release


### PR DESCRIPTION
If a system isn't SMT capable, this test fails with 
ERROR: Command 'ppc64_cpu --smt=on' failed.
   stderr:'Machine is not SMT capable

Add a check for the same and cancel out the test if its not

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>