### PR TITLE
Remove timers from ltp.yaml

### DIFF
--- a/generic/ltp.py.data/ltp.yaml
+++ b/generic/ltp.py.data/ltp.yaml
@@ -36,8 +36,6 @@ runltp: !mux
         args: '-f fcntl-locktests'
     connectors:
         args: '-f connectors'
-    timers:
-        args: '-f timers'
     power_management_tests:
         args: '-f power_management_tests'
     hyperthreading:


### PR DESCRIPTION
Remove timers as its ported to syscalls runtest file, and avoid no file found error.