### PR TITLE
vNIC LPM: test both config options

### DIFF
--- a/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
+++ b/io/net/virt-net/lpm.py.data/lpm_withvnic.yaml
@@ -10,4 +10,8 @@ remote_sriov_adapters:
 remote_sriov_ports:
 bandwidth:
 net_device_type: "vnic"
-options: "--vniccfg 2"
+vnic_options: !mux
+    all-mig-vnic:
+        options: "--vniccfg 1"
+    available-mig-vnic:
+        options: "--vniccfg 2"


### PR DESCRIPTION
Make sure both the config options --vniccfg 1 and 2 getting tested when running the lpm tests with vNIC