### PR TITLE
Xfstest group support

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -82,7 +82,7 @@ class Xfstests(Test):
                     mount = False
                 else:
                     self.cancel('Need %s GB to create loop devices' % check)
-                self._create_loop_device(None, '2038M', mount)
+                self._create_loop_device('2038M', mount)
                 self.log_test = self.devices.pop()
                 self.log_scratch = self.devices.pop()
             namespaces = self.plib.run_ndctl_list('-N -r %s' % self.region)
@@ -221,6 +221,7 @@ class Xfstests(Test):
                 self.cancel("Fail to install %s required for this test." %
                             package)
         self.skip_dangerous = self.params.get('skip_dangerous', default=True)
+        self.group = self.params.get('group', default='auto')
         self.test_range = self.params.get('test_range', default=None)
         self.scratch_mnt = self.params.get(
             'scratch_mnt', default='/mnt/scratch')
@@ -228,6 +229,12 @@ class Xfstests(Test):
         self.disk_mnt = self.params.get('disk_mnt', default='/mnt/loop_device')
         self.fs_to_test = self.params.get('fs', default='ext4')
         self.run_type = self.params.get('run_type', default='distro')
+
+        self.devices = []
+        self.part = None
+        if self.group and self.test_range:
+            self.cancel("incorrect yaml parameter, group and test range can"
+                        "not be run at same time")
 
         if self.run_type == 'upstream':
             prefix = "/usr/local"
@@ -443,7 +450,7 @@ class Xfstests(Test):
             args = ''
             if self.exclude or self.gen_exclude:
                 args = ' -E %s' % self.exclude_file
-            cmd = './check %s -g auto' % args
+            cmd = './check %s -g %s' % (args, self.group)
             result = process.run(cmd, ignore_status=True, verbose=True)
             if result.exit_status == 0:
                 self.log.info('OK: All Tests passed.')

--- a/fs/xfstests.py.data/README
+++ b/fs/xfstests.py.data/README
@@ -15,9 +15,18 @@ started are really simple:
 1.2) In yaml file set test_number which test need to run  and skip_dangerous
      (it will check with group ) and    will skip all the test .
 
-1.3) In Yaml file test range also can be set like test_range='4,12-89'
-Note that range is optional. If not provided, complete generic and specified
-file systems tests would execute
+1.3) group and test_range options can not be run at the same time.
+In yaml you can edit and give group name you want to run, test_range
+should be empty in this case. Refer below example:
+group: 'quick'
+test_range:
+
+1.4) In Yaml file test range also can be set to run specific set of tests.
+We need to pass group as null in this case. Note that range is optional.
+If not provided, complete generic and specified file systems tests would execute.
+Refer below example:
+group: ''
+test_range: '4,12-89'
 
 General notes
 -------------

--- a/fs/xfstests.py.data/btrfs-subpage.yaml
+++ b/fs/xfstests.py.data/btrfs-subpage.yaml
@@ -2,7 +2,8 @@ skip_dangerous: True
 scratch_mnt: '/mnt/scratch'
 test_mnt: '/mnt/test'
 disk_mnt: '/mnt/loop-device'
-test_range: '54-55'
+group:
+test_range:
 fs_type: !mux
   fs_btrfs:
     fs: 'btrfs'

--- a/fs/xfstests.py.data/nvdimm.yaml
+++ b/fs/xfstests.py.data/nvdimm.yaml
@@ -1,6 +1,8 @@
 skip_dangerous: True
 scratch_mnt: '/mnt/scratch_pmem'
 test_mnt: '/mnt/test_pmem'
+group:
+test_range:
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'

--- a/fs/xfstests.py.data/nvdimm_log.yaml
+++ b/fs/xfstests.py.data/nvdimm_log.yaml
@@ -2,6 +2,8 @@ skip_dangerous: True
 scratch_mnt: '/mnt/scratch_pmem'
 test_mnt: '/mnt/test_pmem'
 logdev: true
+group:
+test_range:
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'

--- a/fs/xfstests.py.data/xfstests.yaml
+++ b/fs/xfstests.py.data/xfstests.yaml
@@ -2,8 +2,10 @@ skip_dangerous: True
 scratch_mnt: '/mnt/scratch'
 test_mnt: '/mnt/test'
 disk_mnt: '/mnt/loop-device'
-# Uncomment and edit test_range for running specific tests
-test_range: "null"
+# edit group for running specific group like 'quick'
+group:
+# edit test_range for running specific tests like '4,15-20'
+test_range:
 loop_type: !mux
     type: 'loop'
     loop_size: '7GiB'

--- a/fs/xfstests.py.data/xfstests_disk.yaml
+++ b/fs/xfstests.py.data/xfstests_disk.yaml
@@ -1,8 +1,9 @@
 skip_dangerous: True
 scratch_mnt: '/mnt/scratch'
 test_mnt: '/mnt/test'
-# Uncomment and edit test_range for running specific tests
-test_range: '73,217-415'
+group:
+# edit test_range for running specific tests
+test_range:
 fs_type: !mux
     fs_ext4:
         fs: 'ext4'


### PR DESCRIPTION
added group parameter support in xfstest to run any group specific tests
fixed cleanup in teardown
update all yaml files with group and test_range parameter

Signed-off-by: Disha Goel [disgoel@linux.vnet.ibm.com](mailto:disgoel@linux.vnet.ibm.com)

with both group and test_range as null
JOB ID     : a8f8df6816cf620a827159a931b4e7e2bc0a3175
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-02-28T02.32-a8f8df6/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-gen_exclude-share_exclude-group-loop_type-disk-test_range-bd68: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-gen_exclude-share_exclude-group-loop_type-disk-test_range-bd68: CANCEL: incorrect yaml parameter, group and test range can                          not be run/none at same time (0.61 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-02-28T02.32-a8f8df6/results.html
JOB TIME   : 13.12 s

with group parameter
JOB ID     : 7ada616a8184c943c30dc5801c32e20a29f8324a
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-02-28T02.34-7ada616/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-gen_exclude-share_exclude-loop_type-disk-test_range-83c9: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_ext4_4k-gen_exclude-share_exclude-loop_type-disk-test_range-83c9: PASS (23.13 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-02-28T02.34-7ada616/results.html
JOB TIME   : 34.69 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10848237/job.log)