### PR TITLE
ras/ras_ppcdiag: Fix usysident test failure

### DIFF
--- a/ras/ras_ppcdiag.py
+++ b/ras/ras_ppcdiag.py
@@ -159,6 +159,7 @@ class RASToolsPpcdiag(Test):
         loc_code = self.run_cmd_out("usysident -P | awk 'NR==1{print $1}'")
         cmd = "usysident -l %s -s normal" % loc_code
         self.run_cmd(cmd)
+        cmd = "usysident -l %s -s identify" % loc_code
         if 'on' not in self.run_cmd_out(cmd):
             self.fail_cmd.append(cmd)
         if self.fail_cmd:


### PR DESCRIPTION
commit 7b8017c77a97 ras/rastools: Consolidate sub tests added
test_usysident subtest to ppcdiag. While doing so a subtle difference
of command usage was missed -- normal vs identify as a value.

This causes the test to fail. Fix it by using correct command to be
passed to run_cmd() routine.

Credits to Shirisha for spotting this error.

Reported-by: Shirisha Ganta <shirisha.ganta1@ibm.com>
Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>