### PR TITLE
Add support for vnic channel parameters

### DIFF
--- a/io/net/ethtool_test.py.data/ethtool_veth_test.yaml
+++ b/io/net/ethtool_test.py.data/ethtool_veth_test.yaml
@@ -16,3 +16,11 @@ args: !mux
         arg: -P
     Show-time-stamping:
         arg: -T
+    Show-channels:
+        arg: -l
+    Set-channels:
+        arg: -L
+        tx_channel:
+        rx_channel:
+        other_channel:
+        combined_channel:

--- a/io/net/ethtool_test.py.data/ethtool_vnic_test.yaml
+++ b/io/net/ethtool_test.py.data/ethtool_vnic_test.yaml
@@ -18,3 +18,11 @@ args: !mux
         arg: -P
     Show-time-stamping:
         arg: -T
+    Show-channels:
+        arg: -l
+    Set-channels:
+        arg: -L
+        tx_channel:
+        rx_channel:
+        other_channel:
+        combined_channel:


### PR DESCRIPTION
vNIC and veth yamls is added with latest channel parameters -l, -L, rx and tx options. there are few bugs reporting for vnic crashing for channel parameter set