### PR TITLE
smartctl: works on single disk and skip if logical disk

### DIFF
--- a/io/disk/smartctl.py.data/Readme
+++ b/io/disk/smartctl.py.data/Readme
@@ -3,7 +3,7 @@ Technology(SMART) system built into most ATA/SATA and SCSI/SAS
 hard drives and solid-state drives.
 
 Values to be passed in yaml file:
-    1 Name of the devices on which this scripts should be run.
+    1 Name of the device on which this scripts should be run.
     2 smartctl tool options.
 
 Note:

--- a/io/disk/smartctl.py.data/smartctl.yaml
+++ b/io/disk/smartctl.py.data/smartctl.yaml
@@ -1,8 +1,4 @@
-scenario: !mux
-    test1:
-        disk: /dev/sda
-    test2:
-        disk: /dev/sdb
+disk:
 Options: !mux
     self_test:
         option: --test=long


### PR DESCRIPTION
smartctl do not support logical disks and also it requires only single input device to test. so this patch will cancel test if it is logical device and cleanup yaml