### PR TITLE
All block device test with all device names support [wait for utils/5618]

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -60,7 +60,8 @@ class Bonnie(Test):
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
 
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default='/mnt')
         self.uid_to_use = self.params.get('uid-to-use',
                                           default=getpass.getuser())
@@ -115,7 +116,7 @@ class Bonnie(Test):
 
         if self.disk is not None:
             self.pre_cleanup()
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     self.create_raid(self.disk, self.raid_name)
                     self.raid_create = True

--- a/io/disk/bonnie.py.data/Readme.txt
+++ b/io/disk/bonnie.py.data/Readme.txt
@@ -3,7 +3,7 @@ Example : ./bonnie++ -u root -d /mnt -s0 -b -n 10:100:10:1000
 
 so one has to pass following parameter in the yaml file
 
-disk: disk name on which test will run
+disk: disk name on which test will run, sdx or mpatha or by-id scsi-xxxx etc
 dir: /mnt (disk mounted on some dir. say /mnt here)
 uid-to-use: root (user name or it UUID, here it is name i,e root)
 number-to-stat: 10:0:0:2:8192 (Number of files to create file test)

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -57,9 +57,10 @@ class Dbench(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
-        if not self.disk:
+        device = self.params.get('disk', default=None)
+        if not device:
             self.cancel("Provide the test disks to proceed !")
+        self.disk = disk.get_absolute_disk_path(device)
         self.md_name = self.params.get('raid_name', default='md127')
         self.mountpoint = self.params.get('dir', default='/mnt')
         self.disk_obj = Partition(self.disk, mountpoint=self.mountpoint)
@@ -99,7 +100,7 @@ class Dbench(Test):
         process.run('./configure')
         build.make(self.sourcedir)
         if self.disk is not None:
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     raid_name = '/dev/%s' % self.md_name
                     self.create_raid(self.disk, raid_name)

--- a/io/disk/dbench.py.data/Readme.txt
+++ b/io/disk/dbench.py.data/Readme.txt
@@ -1,0 +1,5 @@
+Dbench is a tool to generate I/O workloads to either a filesystem or to a networked CIFS or NFS server. Dbench is a utility to benchmark a system based on client workload profiles
+
+
+disk: Provide disk name under test: sdx or /dev/mapper/mpathx or scsi id in /dev/disk/by-id/scsi-xxx
+dir: provide a mount point directory  for disk to be mounted before test by default it is /mnt

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -28,6 +28,7 @@ from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils import distro
 from avocado.utils import multipath
+from avocado.utils import disk
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.process import CmdError
@@ -51,7 +52,8 @@ class DiskInfo(Test):
         """
         smm = SoftwareManager()
         pkg = ""
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         if 'ppc' not in platform.processor():
             self.cancel("Processor is not ppc64")
         self.dirs = self.params.get('dir', default=self.workdir)
@@ -88,14 +90,16 @@ class DiskInfo(Test):
                             % pkg)
         self.disk_nodes = []
         self.disk_base = os.path.basename(self.disk)
+        self.disk_abs = os.path.basename(os.path.realpath(self.disk))
+        if 'dm' in self.disk_abs:
+            self.disk_base = multipath.get_mapper_name(self.disk_abs)
         if multipath.is_mpath_dev(self.disk_base):
             self.mpath = True
-            self.disk_abs = os.path.basename(os.readlink(self.disk))
             mwwid = multipath.get_multipath_wwid(self.disk_base)
             self.disk_nodes = multipath.get_paths(mwwid)
         else:
             self.mpath = False
-            self.disk_abs = self.disk_base
+            self.disk_base = self.disk_abs
             self.disk_nodes.append(self.disk_base)
 
     def run_command(self, cmd):
@@ -125,10 +129,10 @@ class DiskInfo(Test):
         size, UUID and IO sizes etc
         """
         msg = []
-        if process.system("ls /dev/disk/by-id -l| grep -i %s" % self.disk_abs,
+        if process.system("ls /dev/disk/by-id -l| grep -i %s" % self.disk_base,
                           ignore_status=True, shell=True, sudo=True) != 0:
             msg.append("Given disk %s is not in /dev/disk/by-id" %
-                       self.disk_abs)
+                       self.disk_base)
         for disk_node in self.disk_nodes:
             if process.system("ls /dev/disk/by-path -l| grep -i %s" % disk_node,
                               ignore_status=True, shell=True, sudo=True) != 0:

--- a/io/disk/disk_info.py.data/Readme.txt
+++ b/io/disk/disk_info.py.data/Readme.txt
@@ -20,6 +20,6 @@ test this carefully as it may override the data in sdb, sdc ...sdn
 
 Inputs:
 ------
-disk: '/dev/sdb'
+disk: '/dev/sdb' or mpathx or /dev/disk/by-path/dm-uuid-mpathb-xxxxx, /dev/dm-0
 fs: 'ext4'
 dir: '/mnt'

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -72,11 +72,8 @@ class Disktest(Test):
         self.fs_create = False
         self.raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
-        self.sysdisks = disk.get_disks()
-        if 'scsi-' in self.disk or 'nvme-' in self.disk:
-            self.disk = '/dev/disk/by-id/%s' % self.disk
-            self.sysdisks = disk.get_disks_by_id()
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default=None)
         self.fstype = self.params.get('fs', default='ext4')
         self.raid_name = '/dev/md/sraid'
@@ -126,7 +123,7 @@ class Disktest(Test):
         dmesg.clear_dmesg()
         self.pre_cleanup()
         if self.disk is not None:
-            if self.disk in self.sysdisks:
+            if self.disk in disk.get_all_disk_paths():
                 if self.raid_needed:
                     self.create_raid(self.target, self.raid_name)
                     self.raid_create = True

--- a/io/disk/dlpar_vscsi.py
+++ b/io/disk/dlpar_vscsi.py
@@ -19,6 +19,7 @@ DLPAR operations
 
 from avocado import Test
 from avocado.utils import process
+from avocado.utils import disk
 from avocado.utils.ssh import Session
 
 
@@ -32,7 +33,8 @@ class DlparTest(Test):
         '''
         Gather necessary test inputs.
         '''
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.num_of_dlpar = int(self.params.get("num_of_dlpar", default='1'))
         self.vios_ip = self.params.get('vios_ip', '*', default=None)
         self.vios_user = self.params.get('vios_username', '*', default=None)

--- a/io/disk/dlpar_vscsi.py.data/Readme.txt
+++ b/io/disk/dlpar_vscsi.py.data/Readme.txt
@@ -1,0 +1,8 @@
+DLPAR vscsi test performs virtual scsi hotplug add remove operation from VIOS cosole
+
+disk: Provide the device node name or device by-id or by-path
+vios_ip: Virtual IO server ip address
+vios_username: Virtual IO server username 
+vios_pwd: Virtual IO server password
+num_of_dlpar:  Provide count for number of times hotplug operation
+

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -58,7 +58,8 @@ class FioTest(Test):
         """
         default_url = "https://brick.kernel.dk/snaps/fio-git-latest.tar.gz"
         url = self.params.get('fio_tool_url', default=default_url)
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default='/mnt')
         self.disk_type = self.params.get('disk_type', default='')
         fstype = self.params.get('fs', default='')
@@ -147,7 +148,7 @@ class FioTest(Test):
         self.sraid = softwareraid.SoftwareRaid(self.raid_name, '0',
                                                self.disk.split(), '1.2')
         dmesg.clear_dmesg()
-        if self.disk in disk.get_disks():
+        if self.disk in disk.get_all_disk_paths():
             self.pre_cleanup()
             if raid_needed:
                 self.create_raid(self.target, self.raid_name)

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -57,7 +57,8 @@ class FSMark(Test):
         self.raid_create = False
         self.fstype = self.params.get('fs', default='')
         self.fs_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default=None)
         self.num = self.params.get('num_files', default='1024')
         self.size = self.params.get('size', default='1000')

--- a/io/disk/ioping.py
+++ b/io/disk/ioping.py
@@ -19,7 +19,7 @@
 import os
 
 from avocado import Test
-from avocado.utils import process, archive, build
+from avocado.utils import process, archive, build, disk
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -44,7 +44,8 @@ class Ioping(Test):
         self.interval = self.params.get('interval', default='1s')
         self.size = self.params.get('size', default='4k')
         self.wsize = self.params.get('wsize', default='10m')
-        self.disk = self.params.get('disk', default='/home')
+        device = self.params.get('disk', default='/home')
+        self.disk = disk.get_absolute_disk_path(device)
 
         for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):

--- a/io/disk/ioping.py.data/README
+++ b/io/disk/ioping.py.data/README
@@ -10,7 +10,7 @@ period - print raw statistics for every <period> requests
 interval - interval between requests in seconds
 size - Request size (4k)
 wsize - Working set size (1m for directory, whole size for file or device)
-disk - path for the disk (ex: /dev/mapper/mpathd)
+disk - path for the disk (ex: /dev/mapper/mpathd or sda, or /dev/disk/by-id/scs-xx or by-path etc)
 
 Usage: ioping [-LABCDWRq] [-c count] [-w deadline] [-pP period] [-i interval]
                [-s size] [-S wsize] [-o offset] directory|file|device

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -422,7 +422,8 @@ class IOZone(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.source_url = self.params.get('source', default=None)
 
         self.base_dir = os.path.abspath(self.basedir)
@@ -470,7 +471,7 @@ class IOZone(Test):
             build.make(make_dir, extra_args='linux')
         self.dirs = self.disk
         if self.disk is not None:
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     raid_name = '/dev/md/sraid'
                     self.create_raid(self.disk, raid_name)

--- a/io/disk/iozone.py.data/README
+++ b/io/disk/iozone.py.data/README
@@ -4,6 +4,7 @@ runs under many operating systems.
 
 Inputs Needed in yaml file:
 ---------------------------
+disk - provide disk device name or by-id or by-path name
 args - Arguements with which iozone command is to be run.
 previous_results - Absolute path of raw_output file of any previously ran
                    iozone test for comparison with new test results.

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -53,7 +53,8 @@ class LtpFs(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default='/mnt')
         self.fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
@@ -86,7 +87,7 @@ class LtpFs(Test):
 
         if self.disk is not None:
             self.pre_cleanup()
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     self.create_raid(self.disk, self.raid_name)
                     self.raid_create = True

--- a/io/disk/ltp_fs.py.data/README.txt
+++ b/io/disk/ltp_fs.py.data/README.txt
@@ -9,5 +9,5 @@ The disk and the mount point has to be provided by the user. Do not pass the roo
 The user can also give a filesystem of choice to be created and to start the test.
 
 Example for the inputs needed to run the program:
-disk: '/dev/sda'
+disk: '/dev/sda' or provide any name of device by-id or by-path etc
 mount_point: '/mnt'

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -47,7 +47,8 @@ class LtpFs(Test):
         '''
         To check and install dependencies for the test
         '''
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default='')
         self.fstype = self.params.get('fs', default='')
         self.fs_create = False
@@ -92,7 +93,7 @@ class LtpFs(Test):
 
         if self.disk is not None:
             self.pre_cleanup()
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     self.create_raid(self.disk, self.raid_name)
                     self.raid_create = True

--- a/io/disk/ltp_fsstress.py.data/Readme.txt
+++ b/io/disk/ltp_fsstress.py.data/Readme.txt
@@ -9,3 +9,6 @@ User can change the above parameter values based on requirement.
 
 example:
 ./fsstress -d /mnt -l 2 -n 250 -p 200
+
+disk: Provide disk name like sda or /dev/mapper/mapthb or scsi-xxxx
+dir: provide mount point for disk to be tested default is /mnt

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -49,9 +49,13 @@ class Lvsetup(Test):
         """
         Check existence of input PV,VG, LV and snapshots prior to Test.
         """
-        pkgs = [""]
+        pkgs = []
+        self.disks = []
         smm = SoftwareManager()
-        self.disk = self.params.get('lv_disks', default=None)
+        devices = self.params.get('lv_disks', default=None).split()
+        if devices:
+            for dev in devices:
+                self.disks.append(disk.get_absolute_disk_path(dev))
         self.vg_name = self.params.get('vg_name', default='avocado_vg')
         self.lv_name = self.params.get('lv_name', default='avocado_lv')
         self.fs_name = self.params.get('fs', default='ext4').lower()
@@ -98,8 +102,8 @@ class Lvsetup(Test):
             else:
                 self.lv_size = int(self.lv_size) / 1024 / 1024
 
-        if self.disk:
-            disk_size = lv_utils.get_devices_total_space(self.disk.split())
+        if self.disks:
+            disk_size = lv_utils.get_devices_total_space(self.disks)
             # converting bytes to megabytes
             disk_size = disk_size / (1024 * 1024)
 
@@ -109,7 +113,7 @@ class Lvsetup(Test):
             else:
                 self.lv_size = disk_size
 
-            self.device = self.disk
+            self.device = ' '.join(self.disks)
         else:
             if not self.lv_size:
                 self.lv_size = 1024 * 1024 * 1024
@@ -206,5 +210,5 @@ class Lvsetup(Test):
         Cleans up loop device.
         """
         self.delete_lv()
-        if not self.disk:
+        if not self.disks:
             disk.delete_loop_device(self.device)

--- a/io/disk/lvsetup.py.data/README
+++ b/io/disk/lvsetup.py.data/README
@@ -6,7 +6,8 @@ volume and merges snapshot with the logical volume.
 Inputs Needed in yaml file:
 ---------------------------
 lv_disks: Name of the disks on which volume groups, logical volumes,
-      snapshots are created. Created on loop device if not specified
+      snapshots are created like /dev/sda or mpathb or scsi id from /dev/disk/by-id/. 
+      Created on loop device if not specified
 lv_size: Size of the logical volume as string in the form "#G"
          (for example 30G).
 lv_snapshot_name: Name of the snapshot with origin the logical

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -29,7 +29,7 @@ import time
 import sys
 import json
 from avocado import Test
-from avocado.utils import process, distro
+from avocado.utils import process, distro, disk
 from avocado.utils import partition as partition_lib
 
 
@@ -54,9 +54,10 @@ class ParallelDd(Test):
         :params fs_dd_roptions: dd read in streams.
         """
 
-        self.disk = self.params.get('disk')
-        if not self.disk:
+        device = self.params.get('disk', default=None)
+        if not device:
             self.cancel('Test requires disk parameter,Please check README')
+        self.disk = disk.get_absolute_disk_path(device)
         self.fsys = partition_lib.Partition(self.disk, mountpoint=self.workdir)
         self.megabytes = self.params.get('megabytes', default=100)
         self.blocks = self.params.get('blocks', default=None)

--- a/io/disk/parallel_dd.py.data/README
+++ b/io/disk/parallel_dd.py.data/README
@@ -1,5 +1,5 @@
 The disk for which performance of read write operation over a file system has to be measured should be specified in yaml file.
-The disk can either be physical disk partition or loop device.
+The disk can either be physical disk like /dev/sda or device by-id or device by-path or loop device.
 Loop device can be created using dd and losetup commands.
 ex:
  dd if=/dev/zero of=/home/image1.img bs=4k count=800000

--- a/io/disk/rawread.py
+++ b/io/disk/rawread.py
@@ -21,7 +21,7 @@ Rawread test
 import os
 from avocado import Test
 from avocado.utils import archive
-from avocado.utils import build
+from avocado.utils import build, disk
 from avocado.utils import process, distro
 from avocado.utils.software_manager.manager import SoftwareManager
 
@@ -38,11 +38,10 @@ class Rawread(Test):
         checking install of required packages and extract and
         compile of rawread suit.
         """
-        self.disk = self.params.get("disk", default=None)
-
-        if not self.disk:
+        device = self.params.get("disk", default=None)
+        if not device:
             self.cancel("Please provide disk to run the test")
-
+        self.disk = disk.get_absolute_disk_path(device)
         smm = SoftwareManager()
         deps = ['gcc', 'make']
         if distro.detect().name == 'Ubuntu':

--- a/io/disk/smartctl.py
+++ b/io/disk/smartctl.py
@@ -26,14 +26,14 @@ import os
 
 from avocado import Test
 from avocado.utils.software_manager.manager import SoftwareManager
-from avocado.utils import process, multipath
+from avocado.utils import process, multipath, disk
 
 
 class SmartctlTest(Test):
 
     """
     This scripts performs S.M.A.R.T relavent tests using smartctl tool
-    on different scsi disk types
+    on different disk types
     """
 
     def setUp(self):
@@ -47,13 +47,14 @@ class SmartctlTest(Test):
             self.log.info("smartctl should be installed prior to the test")
             if smm.install("smartmontools") is False:
                 self.cancel("Unable to install smartctl")
-        self.option = self.params.get('option', default=None)
-        self.disk = self.params.get('disk', default=None)
-        if not(self.disk or self.option):
-            self.cancel(" Test skipped!!, please ensure Block device and \
-            options are specified in yaml file")
+            self.option = self.params.get('option', default=None)
+            device = self.params.get('disk', default=None)
+            self.disk = disk.get_absolute_disk_path(device)
+            if not(self.disk or self.option):
+                self.cancel(" Test skipped!!, please ensure Block device and \
+                options are specified in yaml file")
         if multipath.is_mpath_dev(os.path.basename(self.disk)):
-            self.cancel("Test unsupported on logical device")
+            self.cancel("unsupported on logical device")
         else:
             self.disk = os.path.realpath(self.disk)
         cmd = "df -h /boot | grep %s" % (self.disk)

--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -27,7 +27,7 @@ failure.
 
 from avocado import Test
 from avocado.utils.software_manager.manager import SoftwareManager
-from avocado.utils import softwareraid
+from avocado.utils import softwareraid, disk
 
 
 class SoftwareRaid(Test):
@@ -41,30 +41,33 @@ class SoftwareRaid(Test):
         Checking if the required packages are installed,
         if not found packages will be installed.
         """
+        self.disks = []
+        self.spare_disks = []
         smm = SoftwareManager()
         if not smm.check_installed("mdadm"):
             self.log.info("Mdadm must be installed before continuing the test")
             if SoftwareManager().install("mdadm") is False:
                 self.cancel("Unable to install mdadm")
-        disks = self.params.get('disks', default='').strip(" ")
+        disks = self.params.get('disks', default='').split()
         if not disks:
             self.cancel('No disks given')
+        for dev in disks:
+            self.disks.append(disk.get_absolute_disk_path(dev))
         required_disks = self.params.get('required_disks', default=1)
-        disks = disks.split()
         raidlevel = str(self.params.get('raid', default='0'))
-        if len(disks) < required_disks:
+        if len(self.disks) < required_disks:
             self.cancel("Minimum %d disks required for %s" % (required_disks,
                                                               raidlevel))
-        spare_disks = self.params.get('spare_disks', default='').strip(" ")
-        if spare_disks:
-            spare_disks = spare_disks.split()
+        spare_disks = self.params.get('spare_disks', default='').split()
+        for dev in spare_disks:
+            self.spare_disks.append(disk.get_absolute_disk_path(dev))
         raid = self.params.get('raidname', default='/dev/md/sraid')
         metadata = str(self.params.get('metadata', default='1.2'))
         self.remove_add_disk = ''
         if raidlevel not in ['0', 'linear']:
-            self.remove_add_disk = disks[-1]
-        self.sraid = softwareraid.SoftwareRaid(raid, raidlevel, disks,
-                                               metadata, spare_disks)
+            self.remove_add_disk = self.disks[-1]
+        self.sraid = softwareraid.SoftwareRaid(raid, raidlevel, self.disks,
+                                               metadata, self.spare_disks)
 
     def test(self):
         """

--- a/io/disk/ssd/blkdiscard.py
+++ b/io/disk/ssd/blkdiscard.py
@@ -23,7 +23,7 @@ solid-state drivers (SSDs) and thinly-provisioned storage.
 import avocado
 from avocado import Test
 from avocado.utils.software_manager.manager import SoftwareManager
-from avocado.utils import process, lv_utils
+from avocado.utils import process, lv_utils, disk
 
 # this block need to removed when test moved to python3
 try:
@@ -48,7 +48,8 @@ class Blkdiscard(Test):
         smm = SoftwareManager()
         if not smm.check_installed("util-linux"):
             self.cancel("blkdiscard is needed for the test to be run")
-        self.disk = self.params.get('disk', default='/dev/nvme0n1')
+        device = self.params.get('disk', default='/dev/nvme0n1')
+        self.disk = disk.get_absolute_disk_path(device)
         cmd = 'ls %s' % self.disk
         if process.system(cmd, ignore_status=True) is not 0:
             self.cancel("%s does not exist" % self.disk)

--- a/io/disk/ssd/blkdiscard.py.data/README
+++ b/io/disk/ssd/blkdiscard.py.data/README
@@ -3,4 +3,4 @@ solid-state drivers (SSDs) and thinly-provisioned storage.
 
 Values to be passed in yaml file:
 
-disk - Name of the device on which this script should run.
+disk - any disk name /dev/ or /dev/disk/by-id or /dev/disk/by-path dir USB/scsi/SAN etc

--- a/io/disk/ssd/ezfiotest.py
+++ b/io/disk/ssd/ezfiotest.py
@@ -24,6 +24,7 @@ import os
 from avocado import Test
 from avocado.utils import build
 from avocado.utils import process
+from avocado.utils import disk
 from avocado.utils import genio
 from avocado.utils.software_manager.manager import SoftwareManager
 import avocado.utils.git as git
@@ -43,7 +44,8 @@ class EzfioTest(Test):
         """
         Build 'fio and ezfio'.
         """
-        self.disk = self.params.get('disk', default='/dev/nvme0n1')
+        device = self.params.get('disk', default='/dev/nvme0n1')
+        self.disk = disk.get_absolute_disk_path(device)
         cmd = 'ls %s' % self.disk
         if process.system(cmd, ignore_status=True) is not 0:
             self.cancel("%s does not exist" % self.disk)

--- a/io/disk/ssd/ezfiotest.py.data/README.txt
+++ b/io/disk/ssd/ezfiotest.py.data/README.txt
@@ -5,5 +5,5 @@ This test needs to be run as root.
 
 Inputs Needed (in multiplexer file):
 ------------------------------------
-Devices -       SSD Block devices
+Devices -       SSD Block devices like /dev/nvme0n1 or device name by-id or by-path
 Utilization -   Amount of drive to test (in percent)

--- a/io/disk/ssd/nvme_cli_selftests.py
+++ b/io/disk/ssd/nvme_cli_selftests.py
@@ -22,6 +22,7 @@ import os
 import pkgutil
 from avocado import Test
 from avocado.utils import process
+from avocado.utils import disk
 from avocado.utils import archive
 from avocado.utils.software_manager.manager import SoftwareManager
 
@@ -40,9 +41,10 @@ class NVMeCliSelfTest(Test):
         """
         Download 'nvme-cli'.
         """
-        self.device = self.params.get('device', default='nvme0')
-        self.device = "/dev/%s" % self.device
-        self.disk = self.params.get('disk', default='/dev/nvme0n1')
+        nvme_node = self.params.get('device', default='nvme0')
+        self.device = disk.get_absolute_disk_path(nvme_node)
+        device = self.params.get('disk', default='/dev/nvme0n1')
+        self.disk = disk.get_absolute_disk_path(device)
         self.test = self.params.get('test', default='')
         if not self.test:
             self.cancel('no test specified in yaml')

--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -25,6 +25,7 @@ from avocado import Test
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils import build
+from avocado.utils import disk
 from avocado.utils import download
 from avocado.utils.software_manager.manager import SoftwareManager
 
@@ -42,8 +43,8 @@ class NVMeTest(Test):
         """
         Build 'nvme-cli' and setup the device.
         """
-        self.device = self.params.get('device', default='nvme0')
-        self.device = "/dev/%s" % self.device
+        nvme_node = self.params.get('device', default='nvme0')
+        self.device = disk.get_absolute_disk_path(nvme_node)
         cmd = 'ls %s' % self.device
         if process.system(cmd, ignore_status=True):
             self.cancel("%s does not exist" % self.device)

--- a/io/disk/ssd/nvmetest.py.data/README.txt
+++ b/io/disk/ssd/nvmetest.py.data/README.txt
@@ -21,4 +21,4 @@ This test needs to be run as root.
 The suite selects first namespace on the device and runs tests on it.
 Inputs Needed (in multiplexer file):
 ------------------------------------
-Device      -       NVMe device / interface (Eg: nvme0)
+Device      -       NVMe device / interface (Eg: nvme0 or device by id)

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -57,7 +57,8 @@ class Tiobench(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default="/mnt")
         self.raid_name = '/dev/md/sraid'
         self.vgname = 'avocado_vg'


### PR DESCRIPTION
Add support for persistent device name as input disk
    
This code change will allow user to provide not only device
node name /dev/sdx, but any name of the disk by-id, by-path,
by-uuid a mapper device etc which is required in cases where
the disks names are not persistent across os installs etc
