### PR TITLE
Fix ERROR: [Errno 2] No such file or directory: 'linux.0'

### DIFF
--- a/memory/dma_memtest.py
+++ b/memory/dma_memtest.py
@@ -179,5 +179,6 @@ class DmaMemtest(Test):
         self.log.info('Cleaning up')
         for j in range(self.sim_cps):
             tmp_dir = 'linux.%s' % j
-            shutil.rmtree(tmp_dir)
+            if os.path.exists(tmp_dir):
+                shutil.rmtree(tmp_dir)
         shutil.rmtree(self.base_dir)


### PR DESCRIPTION
When the test cancels it throws the ERROR:
[Errno 2] No such file or directory: 'linux.0' because tearDown tries to remove files that do not exist due to test canceling this patch fixes that.