### PR TITLE
fix perf_pmu error

### DIFF
--- a/perf/perf_pmu.py
+++ b/perf/perf_pmu.py
@@ -121,9 +121,8 @@ class PerfBasic(Test):
             self.fail("Unable to read mmcr* files as super user.")
 
         self._create_temp_user()
-        result = process.system_output("su - test_pmu -c 'cat %smmcr*'"
-                                       % sysfs_file, shell=True,
-                                       ignore_status=True)
+        result = process.run("su - test_pmu -c 'cat %smmcr*'" % sysfs_file,
+                             shell=True, ignore_status=True)
         output = result.stdout.decode() + result.stderr.decode()
         self._remove_temp_user()
         if 'Permission denied' not in output:


### PR DESCRIPTION
first test fails with error as process.system_output does not have stdout/stderr, fixing it by using process.run 

 (1/8) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: STARTED
 (1/8) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: ERROR: 'bytes' object has no attribute 'stdout' (0.19 s)

after fix:
[root@]# avocado run --max-parallel-tasks=1 perf_pmu.py
JOB ID     : 2da5627c32887494f6d795468ef381f3d70de6d7
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-03-13T04.25-2da5627/job.log
 (1/8) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: STARTED
 (1/8) perf_pmu.py:PerfBasic.test_config_PMU_sysfs: PASS (0.18 s)
 (2/8) perf_pmu.py:PerfBasic.test_config_PPC_RTAS: STARTED
 (2/8) perf_pmu.py:PerfBasic.test_config_PPC_RTAS: PASS (0.27 s)
 (3/8) perf_pmu.py:PerfBasic.test_cpu_event_count: STARTED
 (3/8) perf_pmu.py:PerfBasic.test_cpu_event_count: PASS (0.02 s)
 (4/8) perf_pmu.py:PerfBasic.test_hv_24x7_event_count: STARTED
 (4/8) perf_pmu.py:PerfBasic.test_hv_24x7_event_count: PASS (0.02 s)
 (5/8) perf_pmu.py:PerfBasic.test_imc_event_count: STARTED
 (5/8) perf_pmu.py:PerfBasic.test_imc_event_count: SKIP: This test is for PowerNV
 (6/8) perf_pmu.py:PerfBasic.test_thread_event_count: STARTED
 (6/8) perf_pmu.py:PerfBasic.test_thread_event_count: SKIP: This test is for PowerNV
 (7/8) perf_pmu.py:PerfBasic.test_nest_cpumask: STARTED
 (7/8) perf_pmu.py:PerfBasic.test_nest_cpumask: SKIP: This test is for PowerNV
 (8/8) perf_pmu.py:PerfBasic.test_core_cpumask: STARTED
 (8/8) perf_pmu.py:PerfBasic.test_core_cpumask: SKIP: This test is for PowerNV
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 4 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-03-13T04.25-2da5627/results.html
JOB TIME   : 9.31 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/10955629/job.log)