### PR TITLE
Fix : make error on running fio test with fio-pmem

### DIFF
--- a/io/disk/fiotest.py.data/fio-pmem.yaml
+++ b/io/disk/fiotest.py.data/fio-pmem.yaml
@@ -1,5 +1,5 @@
 setup:
-    pmdk_url: 'https://github.com/pmem/pmdk/releases/download/1.8/pmdk-1.8.tar.gz'
+    pmdk_url: 'https://github.com/pmem/pmdk/releases/download/1.12.1/pmdk-1.12.1.tar.gz'
     disk:
     disk_type: 'nvdimm'
     run_type: !mux


### PR DESCRIPTION
On running fiotest.py with fio-pmem.yaml we see make errors as below :
```
 (1/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-xfs-785d: STARTED
 (1/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-xfs-785d:  ERROR: Command 'make' failed.\nstdout: b'test -f .skip-doc || make -C doc all\nmake -C src all\nmake[1]: Entering directory \'/var/tmp/avocado_cimxovdo/pmdk-1.8/src\'\nmake -C libpmem\nmake -C common\nmake[2]: Entering directory \'/var/tmp/avocado_cimxovdo/pmdk-1... (4.85 s)
```
This seems to have been fixed in pmdk-1.12.1 thus updating the url to point to this as default.