### PR TITLE
Fix : ERROR: 'FioTest' object has no attribute 'warn'

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -425,4 +425,4 @@ class FioTest(Test):
             self.delete_raid()
         dmesg.clear_dmesg()
         if self.err_mesg:
-            self.warn("test failed due to following errors %s" % self.err_mesg)
+            self.log.warn("test failed due to following errors %s" % self.err_mesg)


### PR DESCRIPTION
On running fiotest with fio-pmem.yaml file we see below errors when the test throws warning instead of dispalying warning :

```
 (1/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-xfs-fefe: STARTED
 (1/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-xfs-fefe:  ERROR: 'FioTest' object has no attribute 'warn' (49.89 s)
 (2/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-ext4-54b7: STARTED
 (2/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-ext4-54b7:  ERROR: 'FioTest' object has no attribute 'warn' (32.03 s)
```

these are fixed by changing self.warn to self.log.warn


After change :

```
 (1/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-xfs-fefe: STARTED
 (1/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-xfs-fefe:  WARN: Test passed but there were warnings during execution. Check the log for details. (50.17 s)
 (2/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-ext4-54b7: STARTED
 (2/3) fiotest.py:FioTest.test;run-setup-disk-run_type-libpmem-filesystem-ext4-54b7:  WARN: Test passed but there were warnings during execution. Check the log for details. (32.96 s)
```