### PR TITLE
Add support for all device names as input block device tests

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -60,7 +60,8 @@ class Bonnie(Test):
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
 
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default='/mnt')
         self.uid_to_use = self.params.get('uid-to-use',
                                           default=getpass.getuser())
@@ -115,7 +116,7 @@ class Bonnie(Test):
 
         if self.disk is not None:
             self.pre_cleanup()
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     self.create_raid(self.disk, self.raid_name)
                     self.raid_create = True

--- a/io/disk/bonnie.py.data/Readme.txt
+++ b/io/disk/bonnie.py.data/Readme.txt
@@ -3,7 +3,7 @@ Example : ./bonnie++ -u root -d /mnt -s0 -b -n 10:100:10:1000
 
 so one has to pass following parameter in the yaml file
 
-disk: disk name on which test will run
+disk: disk name on which test will run, sdx or mpatha or by-id scsi-xxxx etc
 dir: /mnt (disk mounted on some dir. say /mnt here)
 uid-to-use: root (user name or it UUID, here it is name i,e root)
 number-to-stat: 10:0:0:2:8192 (Number of files to create file test)

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -57,9 +57,10 @@ class Dbench(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
-        if not self.disk:
+        device = self.params.get('disk', default=None)
+        if not device:
             self.cancel("Provide the test disks to proceed !")
+        self.disk = disk.get_absolute_disk_path(device)
         self.md_name = self.params.get('raid_name', default='md127')
         self.mountpoint = self.params.get('dir', default='/mnt')
         self.disk_obj = Partition(self.disk, mountpoint=self.mountpoint)
@@ -99,7 +100,7 @@ class Dbench(Test):
         process.run('./configure')
         build.make(self.sourcedir)
         if self.disk is not None:
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     raid_name = '/dev/%s' % self.md_name
                     self.create_raid(self.disk, raid_name)

--- a/io/disk/dbench.py.data/Readme.txt
+++ b/io/disk/dbench.py.data/Readme.txt
@@ -1,0 +1,5 @@
+Dbench is a tool to generate I/O workloads to either a filesystem or to a networked CIFS or NFS server. Dbench is a utility to benchmark a system based on client workload profiles
+
+
+disk: Provide disk name under test: sdx or /dev/mapper/mpathx or scsi id in /dev/disk/by-id/scsi-xxx
+dir: provide a mount point directory  for disk to be mounted before test by default it is /mnt

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -72,11 +72,8 @@ class Disktest(Test):
         self.fs_create = False
         self.raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
-        self.sysdisks = disk.get_disks()
-        if 'scsi-' in self.disk or 'nvme-' in self.disk:
-            self.disk = '/dev/disk/by-id/%s' % self.disk
-            self.sysdisks = disk.get_disks_by_id()
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default=None)
         self.fstype = self.params.get('fs', default='ext4')
         self.raid_name = '/dev/md/sraid'
@@ -126,7 +123,7 @@ class Disktest(Test):
         dmesg.clear_dmesg()
         self.pre_cleanup()
         if self.disk is not None:
-            if self.disk in self.sysdisks:
+            if self.disk in disk.get_all_disk_paths():
                 if self.raid_needed:
                     self.create_raid(self.target, self.raid_name)
                     self.raid_create = True

--- a/io/disk/dlpar_vscsi.py
+++ b/io/disk/dlpar_vscsi.py
@@ -19,6 +19,7 @@ DLPAR operations
 
 from avocado import Test
 from avocado.utils import process
+from avocado.utils import disk
 from avocado.utils.ssh import Session
 
 
@@ -32,7 +33,8 @@ class DlparTest(Test):
         '''
         Gather necessary test inputs.
         '''
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.num_of_dlpar = int(self.params.get("num_of_dlpar", default='1'))
         self.vios_ip = self.params.get('vios_ip', '*', default=None)
         self.vios_user = self.params.get('vios_username', '*', default=None)

--- a/io/disk/dlpar_vscsi.py.data/Readme.txt
+++ b/io/disk/dlpar_vscsi.py.data/Readme.txt
@@ -1,0 +1,7 @@
+DLPAR vscsi test performs virtual scsi hotplug add remove operation from VIOS cosole
+
+disk: Provide the device node name or device by-id or by-path
+vios_ip: Virtual IO server ip address
+vios_username: Virtual IO server username 
+vios_pwd: Virtual IO server password
+num_of_dlpar:  Provide count for number of times hotplug operation

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -57,7 +57,8 @@ class FSMark(Test):
         self.raid_create = False
         self.fstype = self.params.get('fs', default='')
         self.fs_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default=None)
         self.num = self.params.get('num_files', default='1024')
         self.size = self.params.get('size', default='1000')

--- a/io/disk/fs_mark.py.data/README.txt
+++ b/io/disk/fs_mark.py.data/README.txt
@@ -19,6 +19,6 @@ SAMPLE RUN
 Multiplexer Input Parameters
 ----------------------------
 
-disk		- disk on which the test is to be run
+disk		- disk on which the test is to be run i.e /dev/sdX, mpathX or /dev/disk/by-id/scsi-x
 num_files	- number of files allocated per directory
 size		- size of each file

--- a/io/disk/ioping.py
+++ b/io/disk/ioping.py
@@ -19,7 +19,7 @@
 import os
 
 from avocado import Test
-from avocado.utils import process, archive, build
+from avocado.utils import process, archive, build, disk
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -44,7 +44,8 @@ class Ioping(Test):
         self.interval = self.params.get('interval', default='1s')
         self.size = self.params.get('size', default='4k')
         self.wsize = self.params.get('wsize', default='10m')
-        self.disk = self.params.get('disk', default='/home')
+        device = self.params.get('disk', default='/home')
+        self.disk = disk.get_absolute_disk_path(device)
 
         for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):

--- a/io/disk/ioping.py.data/README
+++ b/io/disk/ioping.py.data/README
@@ -10,7 +10,7 @@ period - print raw statistics for every <period> requests
 interval - interval between requests in seconds
 size - Request size (4k)
 wsize - Working set size (1m for directory, whole size for file or device)
-disk - path for the disk (ex: /dev/mapper/mpathd)
+disk - path for the disk (ex: /dev/mapper/mpathd or sda, or /dev/disk/by-id/scs-xx or by-path etc)
 
 Usage: ioping [-LABCDWRq] [-c count] [-w deadline] [-pP period] [-i interval]
                [-s size] [-S wsize] [-o offset] directory|file|device

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -422,7 +422,8 @@ class IOZone(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.source_url = self.params.get('source', default=None)
 
         self.base_dir = os.path.abspath(self.basedir)
@@ -470,7 +471,7 @@ class IOZone(Test):
             build.make(make_dir, extra_args='linux')
         self.dirs = self.disk
         if self.disk is not None:
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     raid_name = '/dev/md/sraid'
                     self.create_raid(self.disk, raid_name)

--- a/io/disk/iozone.py.data/README
+++ b/io/disk/iozone.py.data/README
@@ -4,6 +4,7 @@ runs under many operating systems.
 
 Inputs Needed in yaml file:
 ---------------------------
+disk - provide disk device name or by-id or by-path name
 args - Arguements with which iozone command is to be run.
 previous_results - Absolute path of raw_output file of any previously ran
                    iozone test for comparison with new test results.

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -53,7 +53,8 @@ class LtpFs(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default='/mnt')
         self.fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
@@ -86,7 +87,7 @@ class LtpFs(Test):
 
         if self.disk is not None:
             self.pre_cleanup()
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     self.create_raid(self.disk, self.raid_name)
                     self.raid_create = True

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -47,7 +47,8 @@ class LtpFs(Test):
         '''
         To check and install dependencies for the test
         '''
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default='')
         self.fstype = self.params.get('fs', default='')
         self.fs_create = False
@@ -92,7 +93,7 @@ class LtpFs(Test):
 
         if self.disk is not None:
             self.pre_cleanup()
-            if self.disk in disk.get_disks():
+            if self.disk in disk.get_all_disk_paths():
                 if raid_needed:
                     self.create_raid(self.disk, self.raid_name)
                     self.raid_create = True

--- a/io/disk/ltp_fsstress.py.data/Readme.txt
+++ b/io/disk/ltp_fsstress.py.data/Readme.txt
@@ -9,3 +9,6 @@ User can change the above parameter values based on requirement.
 
 example:
 ./fsstress -d /mnt -l 2 -n 250 -p 200
+
+disk: Provide disk name like sda or /dev/mapper/mapthb or scsi-xxxx
+dir: provide mount point for disk to be tested default is /mnt

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -29,7 +29,7 @@ import time
 import sys
 import json
 from avocado import Test
-from avocado.utils import process, distro
+from avocado.utils import process, distro, disk
 from avocado.utils import partition as partition_lib
 
 
@@ -54,9 +54,10 @@ class ParallelDd(Test):
         :params fs_dd_roptions: dd read in streams.
         """
 
-        self.disk = self.params.get('disk')
-        if not self.disk:
+        device = self.params.get('disk', default=None)
+        if not device:
             self.cancel('Test requires disk parameter,Please check README')
+        self.disk = disk.get_absolute_disk_path(device)
         self.fsys = partition_lib.Partition(self.disk, mountpoint=self.workdir)
         self.megabytes = self.params.get('megabytes', default=100)
         self.blocks = self.params.get('blocks', default=None)

--- a/io/disk/parallel_dd.py.data/README
+++ b/io/disk/parallel_dd.py.data/README
@@ -1,5 +1,5 @@
 The disk for which performance of read write operation over a file system has to be measured should be specified in yaml file.
-The disk can either be physical disk partition or loop device.
+The disk can either be physical disk like /dev/sda or device by-id or device by-path or loop device.
 Loop device can be created using dd and losetup commands.
 ex:
  dd if=/dev/zero of=/home/image1.img bs=4k count=800000

--- a/io/disk/rawread.py
+++ b/io/disk/rawread.py
@@ -21,7 +21,7 @@ Rawread test
 import os
 from avocado import Test
 from avocado.utils import archive
-from avocado.utils import build
+from avocado.utils import build, disk
 from avocado.utils import process, distro
 from avocado.utils.software_manager.manager import SoftwareManager
 
@@ -38,11 +38,10 @@ class Rawread(Test):
         checking install of required packages and extract and
         compile of rawread suit.
         """
-        self.disk = self.params.get("disk", default=None)
-
-        if not self.disk:
+        device = self.params.get("disk", default=None)
+        if not device:
             self.cancel("Please provide disk to run the test")
-
+        self.disk = disk.get_absolute_disk_path(device)
         smm = SoftwareManager()
         deps = ['gcc', 'make']
         if distro.detect().name == 'Ubuntu':

--- a/io/disk/rawread.py.data/README
+++ b/io/disk/rawread.py.data/README
@@ -3,7 +3,7 @@ basic functionality or disk capability using different values of
 option t which is a sequential write() test and then reads the same.
 
 Parameter:
-disk : any disk from /dev/ dir like USB/scsi/SAN etc
+disk : any disk from /dev/ dir like USB/scsi/SAN the device name can be by-id/by-path etc
 
 
 Last update to rawread binaries by:

--- a/io/disk/smartctl.py
+++ b/io/disk/smartctl.py
@@ -26,7 +26,7 @@ import os
 
 from avocado import Test
 from avocado.utils.software_manager.manager import SoftwareManager
-from avocado.utils import process, multipath
+from avocado.utils import process, multipath, disk
 
 
 class SmartctlTest(Test):
@@ -47,13 +47,14 @@ class SmartctlTest(Test):
             self.log.info("smartctl should be installed prior to the test")
             if smm.install("smartmontools") is False:
                 self.cancel("Unable to install smartctl")
-        self.option = self.params.get('option', default=None)
-        self.disk = self.params.get('disk', default=None)
-        if not(self.disk or self.option):
-            self.cancel(" Test skipped!!, please ensure Block device and \
-            options are specified in yaml file")
+            self.option = self.params.get('option', default=None)
+            device = self.params.get('disk', default=None)
+            self.disk = disk.get_absolute_disk_path(device)
+            if not(self.disk or self.option):
+                self.cancel(" Test skipped!!, please ensure Block device and \
+                            options are specified in yaml file")
         if multipath.is_mpath_dev(os.path.basename(self.disk)):
-            self.cancel("Test unsupported on logical device")
+            self.cancel("Unsupported on logical device")
         else:
             self.disk = os.path.realpath(self.disk)
         cmd = "df -h /boot | grep %s" % (self.disk)

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -57,7 +57,8 @@ class Tiobench(Test):
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default="/mnt")
         self.raid_name = '/dev/md/sraid'
         self.vgname = 'avocado_vg'


### PR DESCRIPTION
This commit has similar code changes accross common block device tests to support block device names which persistent accross installs, dlpar, reboot etc.

Block devices names like /dev/sdb are not same across install in some distros, so all the io/disks tests currently supports the /dev/sdX as input device, now with the new code changes a user can provide any of sdX, mpathX, dm-0, /dev/mapper/mpathX ,/dev/disk/by-id/scsi-xxx, /dev/disk/by-path/fc-xxx, /dev/dmX for the below tests

io/disk/bonnie.py
io/disk/dbench.py
io/disk/disktest.py
io/disk/fs_mark.py
io/disk/ioping.py
io/disk/iozone.py
io/disk/ltp_fs.py
io/disk/ltp_fsstress.py
io/disk/parallel_dd.py
io/disk/rawread.py
io/disk/smartctl.py
io/disk/tiobench.py
io/disk/dlpar_vscsi.py