### PR TITLE
disk_info: support for any device names for input disk

### DIFF
--- a/io/disk/disk_info.py.data/Readme.txt
+++ b/io/disk/disk_info.py.data/Readme.txt
@@ -20,6 +20,6 @@ test this carefully as it may override the data in sdb, sdc ...sdn
 
 Inputs:
 ------
-disk: '/dev/sdb'
+disk: '/dev/sdb' or mpathx or /dev/disk/by-path/dm-uuid-mpathb-xxxxx, /dev/dm-0
 fs: 'ext4'
 dir: '/mnt'


### PR DESCRIPTION
This commit adds support for block device names which persistent accross installs, dlpar, reboot etc.

Block devices names like /dev/sdb are not same across install in some	distros, so disk_info.py currently supports only the the /dev/sdX as	input device, now with the new code changes a user can provide any of sdX, mpathX, dm-0, /dev/mapper/mpathX ,/dev/disk/by-id/scsi-xxx, /dev/disk/by-path/fc-xxx, /dev/dmX for the	below tests