### PR TITLE
enable_bpfselftest

### DIFF
--- a/kernel/kselftest.py.data/bpf.yaml
+++ b/kernel/kselftest.py.data/bpf.yaml
@@ -1,0 +1,8 @@
+component: !mux
+    bpf:
+        comp: 'bpf'
+        build_option: '-bc'
+
+run_type: !mux
+    distro:
+        type: 'distro'


### PR DESCRIPTION
Add bpf.yaml file and modify kselftest.py in order to compile the source kernel and run the bpf selftest for distro

```
Fetching asset from kselftest.py:kselftest.test
JOB ID     : d71bb5568fa28aaf23edbe84461abdddbcc21e54
JOB LOG    : /root/avocado/job-results/job-2023-04-17T01.52-d71bb55/job.log
 (1/1) kselftest.py:kselftest.test;run-component-bpf-run_type-distro-da72: STARTED
 (1/1) kselftest.py:kselftest.test;run-component-bpf-run_type-distro-da72:  FAIL: Testcase failed during selftests (9568.69 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2023-04-17T01.52-d71bb55/results.html
JOB TIME   : 9581.15 s
```

