### PR TITLE
Fixing self.disk and self.dir parameter

### DIFF
--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -58,11 +58,20 @@ class Dbench(Test):
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
         device = self.params.get('disk', default=None)
-        if not device:
-            self.cancel("Provide the test disks to proceed !")
-        self.disk = disk.get_absolute_disk_path(device)
         self.md_name = self.params.get('raid_name', default='md127')
-        self.mountpoint = self.params.get('dir', default='/mnt')
+        self.dir = self.params.get('dir', default=None)
+
+        if device is not None:
+            self.disk = disk.get_absolute_disk_path(device)
+            if self.disk not in disk.get_all_disk_paths():
+                self.cancel("Missing disk %s in OS" % self.disk)
+        else:
+            self.cancel("Please Provide valid device name")
+
+        if not self.dir:
+            self.dir = self.workdir
+
+        self.mountpoint = self.dir
         self.disk_obj = Partition(self.disk, mountpoint=self.mountpoint)
         self.pre_cleanup()
         self.clear_disk(self.disk_obj, self.disk)
@@ -187,10 +196,9 @@ class Dbench(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if self.disk is not None:
-            if self.fs_create:
-                self.clear_disk(self.part_obj, self.disk)
-            if self.lv_create:
-                self.delete_lv()
-            if self.raid_create:
-                self.delete_raid()
+        if self.fs_create:
+            self.clear_disk(self.part_obj, self.disk)
+        if self.lv_create:
+            self.delete_lv()
+        if self.raid_create:
+            self.delete_raid()

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -48,17 +48,27 @@ class LtpFs(Test):
         '''
         To check and install dependencies for the test
         '''
+        self.err_mesg = []
         self.fs_create = False
         lv_needed = self.params.get('lv', default=False)
         self.lv_create = False
         raid_needed = self.params.get('raid', default=False)
         self.raid_create = False
         device = self.params.get('disk', default=None)
-        self.disk = disk.get_absolute_disk_path(device)
-        self.dir = self.params.get('dir', default='/mnt')
+        self.dir = self.params.get('dir', default=None)
+
+        if device is not None:
+            self.disk = disk.get_absolute_disk_path(device)
+            if self.disk not in disk.get_all_disk_paths():
+                self.cancel("Missing disk %s in OS" % self.disk)
+        else:
+            self.cancel("Please Provide valid device name")
+
+        if not self.dir:
+            self.dir = self.workdir
+
         self.fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
-        self.err_mesg = []
         smm = SoftwareManager()
         packages = ['gcc', 'make', 'automake', 'autoconf']
         if raid_needed:
@@ -85,26 +95,20 @@ class LtpFs(Test):
                                                  self.disk.split(), '1.2')
         dmesg.clear_dmesg()
 
-        if self.disk is not None:
-            self.pre_cleanup()
-            if self.disk in disk.get_all_disk_paths():
-                if raid_needed:
-                    self.create_raid(self.disk, self.raid_name)
-                    self.raid_create = True
-                    self.target = self.raid_name
+        self.pre_cleanup()
+        if raid_needed:
+            self.create_raid(self.disk, self.raid_name)
+            self.raid_create = True
+            self.target = self.raid_name
 
-                if lv_needed:
-                    self.lv_disk = self.target
-                    self.target = self.create_lv(self.target)
-                    self.lv_create = True
+        if lv_needed:
+            self.lv_disk = self.target
+            self.target = self.create_lv(self.target)
+            self.lv_create = True
 
-                if self.fstype:
-                    self.create_fs(self.target, self.dir, self.fstype)
-                    self.fs_create = True
-            else:
-                self.cancel("Missing disk %s in OS" % self.disk)
-        else:
-            self.cancel("please provide valid disk")
+        if self.fstype:
+            self.create_fs(self.target, self.dir, self.fstype)
+            self.fs_create = True
 
         url = "https://github.com/linux-test-project/ltp/"
         url += "archive/master.zip"
@@ -337,13 +341,12 @@ class LtpFs(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if self.disk is not None:
-            if self.fs_create:
-                self.delete_fs(self.target)
-            if self.lv_create:
-                self.delete_lv()
-            if self.raid_create:
-                self.delete_raid()
+        if self.fs_create:
+            self.delete_fs(self.target)
+        if self.lv_create:
+            self.delete_lv()
+        if self.raid_create:
+            self.delete_raid()
         dmesg.clear_dmesg()
         if self.err_mesg:
             self.log.warning("test failed due to following errors %s" % self.err_mesg)


### PR DESCRIPTION
Defaulting self.dir to self.workdir instead of /mnt. 
Cancelling test when self.disk is missing.
Initialising self.err in the beginning.

[log_io_disk_changes.txt](https://github.com/avocado-framework-tests/avocado-misc-tests/files/11268373/log_io_disk_changes.txt)
