### PR TITLE
Improve the forkoff test

### DIFF
--- a/memory/fork_mem.py.data/README.md
+++ b/memory/fork_mem.py.data/README.md
@@ -1,0 +1,21 @@
+Overview
+---------
+The forkoff test demonstrates and tests the behavior of memory allocation in child processes created by the fork() system call on a Linux machine by creating multiple child processes that allocate memory and test the system's memory management behavior.
+
+This test case has three different scenarios
+1. Total free memory is allocated to one process
+2. Split free memory among given processes
+3. Create maximum processes possible with minimum memory (10 MB) per process
+
+Note that this test may consume a large amount of system resources, so it should be run on a machine with sufficient memory and processing power.
+
+Parameters
+-----------
+* procs : no. of procs to be created in scenario 2, it can be between 1 and the max_pid of the system
+Example : procs: 10 [creates 10 processes]
+
+* minmem : memory size in MB to be allocated to each process in scenario 3, depends on the memory in the system
+Example  : minmem: 10 # in MB [creates maximum no. of possible processes with 10MB allocated to each process]
+
+* iterations : no. of pages of the mmap-ed memory to be touched in all the above scenarios.
+Example :iterations: 1 [touches 1st page in the allocated region]

--- a/memory/fork_mem.py.data/forkoff.c
+++ b/memory/fork_mem.py.data/forkoff.c
@@ -35,24 +35,34 @@ main(int argc,char *argv[])
                 printf("bad args, usage: forkoff <memsize MB> #children #itterations\n");
                 exit(-1);
         }
+	/* size of memory for each process */
         size = ((long)atol(argv[1])*1024*1024);
-        psize = getpagesize();
+        
+	/* default page size */
+	psize = getpagesize();
+	
+	/* number of processes to be created */
         procs = atol(argv[2]);
+
+	/* number of pages inside the mmap-ed memory to be touched */
         itterations = atol(argv[3]);
+
+	/* check if the processes to be created don't exceed the max possible pid  */
         FILE *fd=fopen("/proc/sys/kernel/pid_max","r");
         fgets(buf,32,fd);
         maxpid=atol(buf);
         if ( procs > maxpid){
-             printf("\nNumber of Children %d provided is higher than maxpid supported on this system %d.. Exiting!!\n",procs,maxpid);
+             printf("\nNumber of Children %lu provided is higher than maxpid supported on this system %d.. Exiting!!\n",procs,maxpid);
              exit(-1);
         }else{
              printf("\nMaxpid / Children supported on the system %d\n",maxpid);
         }
         fclose(fd);
+
         printf("mmaping %ld anonymous bytes\n", size);
         ptr = (char *)mmap((void *)0, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
         if ( ptr == (char *) -1 ) {
-                printf("address = %lx\n", ptr);
+                printf("address = %sx\n", ptr);
                 perror("");
         }
 		fflush(stdout);
@@ -63,7 +73,7 @@ main(int argc,char *argv[])
                         printf("fork failure error %d: %s\n", errno, strerror(errno));
                         exit(-1);
                 } else if (!pid) {
-			printf("PID %d touching %d pages\n", getpid(), size/psize);
+			printf("PID %d touching %lu pages\n", getpid(), itterations);
 
                         for (j=0; j<itterations; j++) {
                                 for (i = ptr; i < ptr + size - 1; i += psize) {


### PR DESCRIPTION
This commit does the following:

1. fixes the wrong printing of no. of pages touched. 
no. of pages touched is the number of "itterartions". 
size/psize is the maximum no. of pages in the memory block of size

2. corrects format specifiers that throw warning on compilation.

3. adds comments for code readability and clear description of parameters.

4. adds a README file for better understanding of this test

----
Before :
```
forkoff.c:55:120: warning: format specifies type 'int' but the argument has type 'unsigned long' [-Wformat]
             printf("\nNumber of Children %d provided is higher than maxpid supported on this system %d.. Exiting!!\n",procs,maxpid);
                                          ~~                                                                           ^~~~~
                                          %lu
forkoff.c:65:43: warning: format specifies type 'unsigned long' but the argument has type 'char *' [-Wformat]
                printf("address = %lx\n", ptr);
                                  ~~~     ^~~
                                  %s
forkoff.c:76:51: warning: format specifies type 'int' but the argument has type 'unsigned long' [-Wformat]
                        printf("PID %d touching %d pages\n", getpid(), itterations);
                                                ~~                     ^~~~~~~~~~~
                                                %lu
```

After these changes we so no warnings during compilation.