### PR TITLE
Add new test for testing the home node feature in linux kernel

### DIFF
--- a/memory/homenode.py
+++ b/memory/homenode.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2023 IBM
+# Author: Geetika Moolchandani <geetika@linux.ibm.com>
+#
+
+
+import os
+import shutil
+from avocado import Test
+from avocado.utils import process, build, memory, genio, distro
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class HomeNodeTest(Test):
+    """
+    Test Description
+    """
+
+    def copyutil(self, file_name):
+        shutil.copyfile(self.get_data(file_name),
+                        os.path.join(self.teststmpdir, file_name))
+
+    def setUp(self):
+        smm = SoftwareManager()
+        self.dist = distro.detect()
+
+        self.nr_pages = self.params.get('nr_pages', default=100)
+        self.map_type = self.params.get('map_type', default='private')
+        self.hpage = self.params.get('h_page', default=False)
+
+        pkgs = ['gcc', 'make']
+
+        if self.dist.name in ["Ubuntu", 'debian']:
+            pkgs.extend(['libpthread-stubs0-dev',
+                         'libnuma-dev', 'libhugetlbfs-dev'])
+        elif self.dist.name in ["centos", "rhel", "fedora"]:
+            if (self.dist.name == 'rhel' and self.dist.version >= '9'):
+                self.cancel(
+                    "libhugetlbfs packages are unavailable RHEL 9.x onwards.")
+            pkgs.extend(['numactl-devel', 'libhugetlbfs-devel'])
+        elif self.dist.name == "SuSE":
+            pkgs.extend(['libnuma-devel'])
+            if self.dist.version >= 15:
+                pkgs.extend(['libhugetlbfs-devel'])
+            else:
+                pkgs.extend(['libhugetlbfs-libhugetlb-devel'])
+
+        hp_configured = 0
+        if self.hpage:
+            hp_size = memory.get_huge_page_size()
+            hp_configured += int(genio.read_file(
+                '/sys/kernel/mm/hugepages/hugepages-%skB'
+                '/nr_hugepages' % (str(hp_size))).strip())
+            if hp_configured < self.nr_pages:
+                self.cancel('Not enough pages to be configured on nodes')
+
+        for package in ['gcc', 'make']:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+
+        for file_name in ['homenode.c', 'Makefile']:
+            self.copyutil(file_name)
+
+        build.make(self.teststmpdir)
+
+    def test(self):
+        os.chdir(self.teststmpdir)
+        cmd = './homenode -m %s' % self.map_type
+
+        if self.hpage:
+            if (self.dist.name == 'rhel' and self.dist.version >= '9'):
+                self.cancel(
+                    "Hugepage tests are cancelled on RHEL-9 and later.")
+            cmd += ' -h %s' % self.hpage
+        else:
+            cmd += ' -n %s' % self.nr_pages
+
+        ret = process.system(cmd, shell=True, sudo=True, ignore_status=True)
+        if ret == 255:
+            self.cancel("Environment prevents test! Check logs for node data")
+        elif ret != 0:
+            self.fail('Please check the logs for failure')

--- a/memory/homenode.py.data/Makefile
+++ b/memory/homenode.py.data/Makefile
@@ -1,0 +1,8 @@
+
+all : homenode
+
+homenode : homenode.c
+	gcc homenode.c -o $@ -lnuma -lhugetlbfs
+
+clean :
+	rm homenode

--- a/memory/homenode.py.data/README.md
+++ b/memory/homenode.py.data/README.md
@@ -1,0 +1,10 @@
+
+Overview
+----------
+The homenode test, tests the new sys_set_mempolicy_home_node introduced by c6018b4b254971863bd0ad36bb5e7d0fa0f0ddb0. This syscall can be used to set a home node for the MPOL_BIND and MPOL_PREFERRED_MANY memory policy. This test tries to allocate memory from the node closest to the node that has been set as the home node.
+
+Parameters
+-----------
+* h_page: if you want to allocate hugepages set this paramter to True otherwise False
+
+* nr_pages: no. of pages you want to allocate. Make sure you don't try to allocate more pages than what the system can handle.

--- a/memory/homenode.py.data/homenode.c
+++ b/memory/homenode.py.data/homenode.c
@@ -1,0 +1,162 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE for more details.
+ * Copyright: 2023 IBM
+ * Author: Aneesh Kumar K.V <aneesh.kumar@linux.ibm.com> and Vaibhav Jain <vaibhav@linux.ibm.com>
+ * Modified-By: Geetika Moolchandani <geetika@linux.ibm.com>
+ */
+
+
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <asm/unistd.h>
+#include <numa.h>
+#include <numaif.h>
+#include <string.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <hugetlbfs.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+
+#define errmsg(x, ...) fprintf(stderr, x, ##__VA_ARGS__),exit(1)
+#define __NR_HOME_NODE 450
+
+
+
+int sys_set_mempolicy_home_node(unsigned long start, unsigned long len,
+				unsigned long home_node, unsigned long flags)
+{
+
+	int ret = syscall(__NR_HOME_NODE, start, len, home_node, 0);
+	return ret >= 0 ? ret : -errno;
+
+}
+
+
+
+int main(int argc, char *argv[])
+{
+
+	char *p;
+	int ret, c;
+	int i, nr_pages = 3;
+	int page_size = getpagesize();
+	int mapflag = MAP_ANONYMOUS;
+	int protflag = PROT_READ|PROT_WRITE;
+ 	unsigned long nr_nodes = numa_max_node() + 1;
+	struct bitmask *all_nodes, *old_nodes, *new_nodes;
+	unsigned long src_node, dest_node;
+
+ 	long freemem_before[4] = {0}, freemem_after[4] = {0};
+
+	int home_node;
+
+	while ((c = getopt(argc, argv, "m:n:hH")) != -1) {
+
+		switch(c) {
+
+		case 'm':
+			if (!strcmp(optarg, "private"))
+				mapflag |= MAP_PRIVATE;
+			else if (!strcmp(optarg, "shared"))
+				mapflag |= MAP_SHARED;
+			else
+				errmsg("invalid optarg for -m\n");
+			break;
+
+		case 'n':
+			nr_pages = strtoul(optarg, NULL, 10);
+			break;
+
+		case 'h':
+			mapflag |= MAP_HUGETLB;
+			page_size = gethugepagesize();
+			break;
+
+		case 'H':
+			errmsg("%s -m [private|shared] -h  -n <number of pages>\n", argv[0]);
+
+		default:
+			errmsg("invalid option\n");
+
+			break;
+
+		}
+	}
+
+	if (nr_nodes < 2)
+		errmsg("A minimum of 2 nodes is required for this test.\n");
+
+
+	if (!(mapflag & (MAP_SHARED | MAP_PRIVATE)))
+		errmsg("Specify shared or private using -m flag\n");
+
+
+	all_nodes = numa_bitmask_alloc(nr_nodes);
+	old_nodes = numa_bitmask_alloc(nr_nodes);
+	new_nodes = numa_bitmask_alloc(nr_nodes);
+
+	src_node = 0;
+	dest_node = 1;
+	home_node = 3;
+
+	printf("nr pages=%d page_size=%d\n", nr_pages, page_size);
+	printf("src node = %ld and dest node = %ld home node=%d\n", src_node, dest_node, home_node);
+
+
+	numa_bitmask_setbit(all_nodes, src_node);
+
+  	numa_bitmask_setbit(all_nodes, numa_max_node());
+
+  	numa_bitmask_setbit(old_nodes, src_node);
+
+  	numa_bitmask_setbit(new_nodes, dest_node);
+
+	numa_bitmask_setbit(new_nodes, dest_node + 1);
+
+	numa_sched_setaffinity(0, old_nodes);
+
+	p = mmap(NULL, nr_pages * page_size, protflag, mapflag, -1, 0);
+
+	if (p == MAP_FAILED)
+		errmsg("Failed mmap\n");
+	ret = mbind(p, nr_pages * page_size, MPOL_BIND, new_nodes->maskp,
+		    new_nodes->size + 1, MPOL_MF_MOVE|MPOL_MF_STRICT);
+
+	printf("dest node %ld->%ld\n", dest_node, home_node);
+	ret = sys_set_mempolicy_home_node((unsigned long)p + 2*page_size , nr_pages * page_size,
+					  home_node, 0);
+
+	if (ret == -1)
+		errmsg("Failed home node");
+
+
+	for(int nid=0;nid <4; ++nid)
+	  numa_node_size(nid, &freemem_before[nid]);
+
+	/* page fault in */
+	memset(p, 'a', nr_pages * page_size);
+
+
+	for(int nid=0;nid <4; ++nid) {
+	  numa_node_size(nid, &freemem_after[nid]);
+	  printf("Free Mem(%d)\tbefore(%ld)\tafter(%ld)\tDelta(%ld pages)\n", nid,freemem_before[nid],
+		 freemem_after[nid],
+		 (freemem_before[nid]-freemem_after[nid])>>16);
+	}
+
+}

--- a/memory/homenode.py.data/homenode.yaml
+++ b/memory/homenode.py.data/homenode.yaml
@@ -1,0 +1,11 @@
+page_type: !mux
+    normal_page:
+        nr_pages: 1024
+    hugepage:
+        h_page: True
+        nr_pages: 2
+maptype: !mux
+    shared:
+	maptype: shared
+    private:
+	maptype: private


### PR DESCRIPTION
mm/mempolicy: add set_mempolicy_home_node syscall
This syscall can be used to set a home node for the MPOL_BIND and MPOL_PREFERRED_MANY memory policy. The syscall allows specifying a home node/preferred node from which kernel will fulfill memory allocation requests first.

Link: https://lkml.kernel.org/r/20211202123810.267175-3-aneesh.kumar@linux.ibm.com