### PR TITLE
Fetch latest HTX build automatically for Host and peer

### DIFF
--- a/io/net/htx_nic_devices.py
+++ b/io/net/htx_nic_devices.py
@@ -71,6 +71,8 @@ class HtxNicTest(Test):
                     networkinterface.save(ipaddr, self.netmask)
                 networkinterface.bring_up()
         self.host_distro = distro.detect()
+        self.host_distro_name = self.host_distro.name
+        self.host_distro_version = self.host_distro.version
         self.session = Session(self.peer_ip, user=self.peer_user,
                                password=self.peer_password)
         if not self.session.connect():
@@ -79,12 +81,21 @@ class HtxNicTest(Test):
                                      password=self.peer_password)
 
         self.get_peer_distro()
+        self.get_peer_distro_version()
+        self.htx_rpm_link = self.params.get('htx_rpm_link', default=None)
+
+    def get_peer_distro_version(self):
+        """
+        Get the distro version installed on peer lpar
+        """
+        detected_distro = distro.detect(session=self.session)
+        self.peer_distro_version = detected_distro.version
 
     def get_peer_distro(self):
         """
         Get the distro installed on peer lpar
         """
-        detected_distro = distro.detect()
+        detected_distro = distro.detect(session=self.session)
         if detected_distro.name == "Ubuntu":
             self.peer_distro = "Ubuntu"
         elif detected_distro.name == "rhel":
@@ -101,7 +112,7 @@ class HtxNicTest(Test):
         """
         packages = ['git', 'gcc', 'make', 'wget']
         detected_distro = distro.detect()
-        if detected_distro.name in ['centos', 'fedora', 'rhel', 'redhat', 'wget']:
+        if detected_distro.name in ['centos', 'fedora', 'rhel', 'redhat']:
             packages.extend(['gcc-c++', 'ncurses-devel', 'tar'])
         elif detected_distro.name == "Ubuntu":
             packages.extend(['libncurses5', 'g++', 'ncurses-dev',
@@ -121,14 +132,44 @@ class HtxNicTest(Test):
             if not output.exit_status == 0:
                 self.cancel(
                     "Unable to install the package %s on peer machine" % pkg)
+        if self.htx_rpm_link:
+            host_distro_pattern = "%s%s" % (
+                                            self.host_distro_name,
+                                            self.host_distro_version)
+            peer_distro_pattern = "%s%s" % (
+                                            self.peer_distro,
+                                            self.peer_distro_version)
+            patterns = [host_distro_pattern, peer_distro_pattern]
+            for pattern in patterns:
+                temp_string = process.getoutput(
+                              "curl --silent %s" % (self.htx_rpm_link),
+                              verbose=False, shell=True, ignore_status=True)
+                matching_htx_versions = re.findall(
+                    r"(?<=\>)htx\w*[-]\d*[-]\w*[.]\w*[.]\w*", str(temp_string))
+                distro_specific_htx_versions = [
+                                                htx_rpm
+                                                for htx_rpm
+                                                in matching_htx_versions
+                                                if pattern in htx_rpm]
+                distro_specific_htx_versions.sort(reverse=True)
+                self.latest_htx_rpm = distro_specific_htx_versions[0]
 
-        if self.htx_url:
-            htx = self.htx_url.split("/")[-1]
-            htx_rpm = self.fetch_asset(self.htx_url)
-            process.system("rpm -ivh --force %s" % htx_rpm)
-            cmd = "wget %s -O /tmp/%s ; cd /tmp ; rpm -ivh --force %s" % (
-                self.htx_url, htx, htx)
-            self.session.cmd(cmd)
+                if pattern == host_distro_pattern:
+                    if process.system('rpm -ivh --nodeps %s%s '
+                                      '--force' % (
+                                       self.htx_rpm_link, self.latest_htx_rpm
+                                       ), shell=True, ignore_status=True):
+                        self.cancel("Installion of rpm failed")
+
+                if pattern == peer_distro_pattern:
+                    cmd = ('rpm -ivh --nodeps %s%s '
+                           '--force' % (self.htx_rpm_link,
+                                        self.latest_htx_rpm))
+                    output = self.session.cmd(cmd)
+                    if not output.exit_status == 0:
+                        self.cancel("Unable to install the package %s %s"
+                                    " on peer machine" % (self.htx_rpm_link,
+                                                          self.latest_htx_rpm))
         else:
             url = "https://github.com/open-power/HTX/archive/master.zip"
             tarball = self.fetch_asset("htx.zip", locations=[url], expire='7d')
@@ -212,8 +253,10 @@ class HtxNicTest(Test):
         Update hostname & ip of both Host & Peer in /etc/hosts file of both
         Host & Peer
         """
-        host_name = process.system_output("hostname", ignore_status=True,
-                                          shell=True, sudo=True).decode("utf-8")
+        host_name = process.system_output("hostname",
+                                          ignore_status=True,
+                                          shell=True,
+                                          sudo=True).decode("utf-8")
         cmd = "hostname"
         output = self.session.cmd(cmd)
         peer_name = output.stdout.decode("utf-8")
@@ -396,7 +439,8 @@ class HtxNicTest(Test):
                 else:
                     self.session.cmd("systemctl restart network")
                 if self.host_distro == "rhel":
-                    process.system("systemctl start NetworkManager", shell=True,
+                    process.system("systemctl start NetworkManager",
+                                   shell=True,
                                    ignore_status=True)
                 else:
                     process.system("systemctl restart network", shell=True,

--- a/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+++ b/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
@@ -11,4 +11,4 @@ peer_ips: ""
 net_ids: ""
 # time limit in minutes
 time_limit: 2
-htx_rpm: ""
+htx_rpm_link: ""

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -18,10 +18,15 @@
 """
 DLPAR operations
 """
+import time
 
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import distro
+from avocado.utils import wait, multipath
+from avocado.utils import nvme
+from avocado.utils.network.hosts import LocalHost
+from avocado.utils.network.interfaces import NetworkInterface
 from avocado.utils.ssh import Session
 from avocado.utils import pci
 from avocado.utils.software_manager.manager import SoftwareManager
@@ -50,6 +55,7 @@ class DlparPci(Test):
         self.hmc_user = self.params.get("hmc_username", default='*******')
         self.hmc_pwd = self.params.get("hmc_pwd", default='********')
         self.sriov = self.params.get("sriov", default="no")
+        self.peer_ip = self.params.get("peer_ip", default=None)
         self.lpar_1 = self.get_partition_name("Partition Name")
         if not self.lpar_1:
             self.cancel("LPAR Name not got from lparstat command")
@@ -78,6 +84,10 @@ class DlparPci(Test):
         self.num_of_dlpar = int(self.params.get("num_of_dlpar", default='1'))
         if self.loc_code is None:
             self.cancel("Failed to get the location code for the pci device")
+        self.adapter_type = pci.get_pci_class_name(self.pci_device)
+        if self.adapter_type == 'nvme':
+            self.contr_name = nvme.get_controller_name(self.pci_device)
+            self.ns_list = nvme.get_current_ns_ids(self.contr_name)
         self.session.cmd("uname -a")
         if self.sriov == "yes":
             cmd = "lshwres -r sriov --rsubtype logport -m %s \
@@ -189,6 +199,7 @@ class DlparPci(Test):
         for _ in range(self.num_of_dlpar):
             self.dlpar_remove()
             self.dlpar_add()
+            self.validation_in_os()
             self.dlpar_move()
 
     def test_drmgr_pci(self):
@@ -198,8 +209,10 @@ class DlparPci(Test):
         for _ in range(self.num_of_dlpar):
             self.do_drmgr_pci('r')
             self.do_drmgr_pci('a')
+            self.validation_in_os()
         for _ in range(self.num_of_dlpar):
             self.do_drmgr_pci('R')
+            self.validation_in_os()
 
     def test_drmgr_phb(self):
         '''
@@ -208,6 +221,7 @@ class DlparPci(Test):
         for _ in range(self.num_of_dlpar):
             self.do_drmgr_phb('r')
             self.do_drmgr_phb('a')
+            self.validation_in_os()
 
     def do_drmgr_pci(self, operation):
         '''
@@ -366,6 +380,101 @@ class DlparPci(Test):
         if cmd.exit_status != 0:
             self.log.debug(cmd.stderr)
             self.fail("dlpar %s operation failed" % msg)
+
+    def validation_in_os(self):
+        '''
+        validating the adapter functionality after from OS adapter added
+        '''
+        def is_added():
+            """
+            Returns True if pci device is added, False otherwise.
+            """
+            if self.pci_device not in pci.get_pci_addresses():
+                return False
+            return True
+
+        def fc_recovery_check():
+            """
+            Checks if the block device adapter is recovers all its disks/paths
+            properly after hotplug of adapter.
+            Returns True if all disks/paths back online after adapter added
+            Back, else False.
+            """
+            def is_path_online():
+                path_stat = list(multipath.get_path_status(curr_path))
+                if path_stat[0] != 'active' or path_stat[2] != 'ready':
+                    return False
+                return True
+
+            curr_path = ''
+            err_disks = []
+            disks = pci.get_disks_in_pci_address(self.pci_device)
+            for disk in disks:
+                curr_path = disk.split("/")[-1]
+                self.log.info("curr_path=%s" % curr_path)
+                if not wait.wait_for(is_path_online, timeout=10):
+                    self.log.info("%s failed to recover after add" % disk)
+                    err_disks.append(disk)
+
+            if err_disks:
+                self.log.info("few paths failed to recover : %s" % err_disks)
+                return False
+            return True
+
+        def net_recovery_check():
+            """
+            Checks if the network adapter fuctionality like ping/link_state,
+            after adapter added back.
+            Returns True on propper Recovery, False if not.
+            """
+            self.log.info("entering the net recovery check")
+            local = LocalHost()
+            iface = pci.get_interfaces_in_pci_address(self.pci_device, 'net')
+            networkinterface = NetworkInterface(iface[0], local)
+            if wait.wait_for(networkinterface.is_link_up, timeout=120):
+                if networkinterface.ping_check(self.peer_ip, count=5) is None:
+                    self.log.info("inteface is up and pinging")
+                    return True
+            return False
+
+        def nvme_recovery_check():
+            '''
+            Checks if the nvme adapter functionality like all namespaces are
+            up and running or not after adapter is recovered
+            '''
+            err_ns = []
+            current_namespaces = nvme.get_current_ns_ids(self.contr_name)
+            if current_namespaces == self.ns_list:
+                for ns_id in current_namespaces:
+                    status = nvme.get_ns_status(self.contr_name, ns_id)
+                    if not status[0] == 'live' and status[1] == 'optimized':
+                        err_ns.append(ns_id)
+            else:
+                self.log.info("following ns not back listing after hot_plug" %
+                              (self.ns_list - current_namespaces))
+                return False
+
+            if err_ns:
+                self.log.info(f"following namespaces not recovered ={err_ns}")
+                return False
+            return True
+
+        if wait.wait_for(is_added, timeout=30):
+            time.sleep(45)
+            if self.adapter_type == 'net':
+                if not wait.wait_for(net_recovery_check, timeout=30):
+                    self.fail("Network adapter failed to ping after dlapr")
+            elif self.adapter_type == 'nvme':
+                if not wait.wait_for(nvme_recovery_check, timeout=30):
+                    self.fail("nvme adapter failed to recover")
+            elif self.adapter_type == 'fc_host':
+                if not wait.wait_for(fc_recovery_check, timeout=30):
+                    self.fail("FC_adapter failed to recover")
+            else:
+                self.log.warn("OS validation for this adapter not available \
+                              please check manually")
+        else:
+            self.fail("pci_address not showing up in OS after dlpar")
 
     def tearDown(self):
         if self.session:

--- a/io/pci/dlpar.py.data/dlpar.yaml
+++ b/io/pci/dlpar.py.data/dlpar.yaml
@@ -4,4 +4,5 @@ hmc_username:
 lpar_2: 
 pci_device:
 num_of_dlpar: 
+peer_ip:
 sriov: 'no'


### PR DESCRIPTION
This code supports to fetch the latest available HTX builds on RHEL for both Host and Peer as per RHEL OS version.
Ex: 1. For RHEL-8 installs RHEL-8 based HTX rpm.
    2. For RHEL-9 installs RHEL-9 based HTX rpm.