### PR TITLE
Remove Hardcoded loop device value and Use self.workdir as default 'dir'

### DIFF
--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -370,7 +370,8 @@ class Sosreport(Test):
 
     def test_fs(self):
         is_fail = 0
-        loop_dev = "/dev/loop0"
+        loop_dev = process.system_output('losetup -f').decode("utf-8").strip()
+
         fstype = self.params.get('fs', default='ext4')
         mnt = self.params.get('dir', default='/mnt')
         if 'blockfile' not in self.run_cmd_out("ls /tmp"):

--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -371,9 +371,10 @@ class Sosreport(Test):
     def test_fs(self):
         is_fail = 0
         loop_dev = process.system_output('losetup -f').decode("utf-8").strip()
-
         fstype = self.params.get('fs', default='ext4')
-        mnt = self.params.get('dir', default='/mnt')
+        mnt = self.params.get('dir', default=None)
+        if not mnt:
+            mnt = self.workdir
         if 'blockfile' not in self.run_cmd_out("ls /tmp"):
             blk_dev = process.run("dd if=/dev/zero of=/tmp/blockfile bs=1M count=5120")
             process.run("losetup %s /tmp/blockfile" % loop_dev)


### PR DESCRIPTION
```
JOB ID     : 6873f93a47c716029af1d73ff80f81c7fa8ba296
JOB LOG    : /home/*/results/job-2023-05-03T01.00-6873f93/job.log
 (1/2) sosreport.py:Sosreport.test_fs;run-dir-filesystem-ext4-1c60: STARTED
 (1/2) sosreport.py:Sosreport.test_fs;run-dir-filesystem-ext4-1c60:  PASS (105.57 s)
 (2/2) sosreport.py:Sosreport.test_fs;run-dir-filesystem-xfs-e780: STARTED
 (2/2) sosreport.py:Sosreport.test_fs;run-dir-filesystem-xfs-e780:  PASS (107.60 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/*/results/job-2023-05-03T01.00-6873f93/results.html
JOB TIME   : 216.17 s
```


2023-05-03 01:02:22,408 avocado.utils.process INFO | Command '/usr/bin/dnf -y install java' finished with 0 after 0.829737151s
2023-05-03 01:02:22,408 avocado.utils.process INFO | Running 'losetup -f'
2023-05-03 01:02:22,408 avocado.utils.process INFO | Command 'losetup -f' finished with 0 after 0.000674677s
2023-05-03 01:02:22,458 avocado.utils.process DEBUG| [stdout] /dev/loop1
2023-05-03 01:02:22,459 avocado.test DEBUG| PARAMS (key=fs, path=*, default=ext4) => 'xfs'
2023-05-03 01:02:22,459 avocado.test DEBUG| PARAMS (key=dir, path=*, default=None) => None
2023-05-03 01:02:22,459 avocado.test DEBUG| Test workdir initialized at: /home/***/results/job-2023-05-03T01.00-6873f93/test-results/2-sosreport.py_Sosreport.test_fs_run-dir-filesystem-xfs-e780/tmp_dir32ezs_4v/1-sosreport.py_Sosreport.test_fs_run-dir-filesystem-xfs-e780
2023-05-03 01:02:22,511 avocado.utils.process INFO | Running 'ls /tmp'

