### PR TITLE
Add option of mpol flag in home node test

### DIFF
--- a/memory/homenode.py
+++ b/memory/homenode.py
@@ -39,6 +39,7 @@ class HomeNodeTest(Test):
         self.nr_pages = self.params.get('nr_pages', default=100)
         self.map_type = self.params.get('map_type', default='private')
         self.hpage = self.params.get('h_page', default=False)
+        self.pol_type = self.params.get('pol_type', default='MPOL_BIND')
 
         pkgs = ['gcc', 'make']
 
@@ -77,7 +78,7 @@ class HomeNodeTest(Test):
 
     def test(self):
         os.chdir(self.teststmpdir)
-        cmd = './homenode -m %s' % self.map_type
+        cmd = './homenode -m %s' % self.map_type + ' -f %s' % self.pol_type
 
         if self.hpage:
             if (self.dist.name == 'rhel' and self.dist.version >= '9'):

--- a/memory/homenode.py.data/homenode.yaml
+++ b/memory/homenode.py.data/homenode.yaml
@@ -6,6 +6,11 @@ page_type: !mux
         nr_pages: 2
 maptype: !mux
     shared:
-	maptype: shared
+        maptype: shared
     private:
-	maptype: private
+        maptype: private
+policy_type: !mux
+    mpol_bind:
+        pol_type: 'MPOL_BIND'
+    mpol_preferred_many:
+        pol_type: 'MPOL_PREFERRED_MANY'


### PR DESCRIPTION
Add the option to mbind the memory mapped region with either MPOL_BIND flag or MPOL_PREFERRED_MANY flag. Also Add the corresponding yaml file parameter.