### PR TITLE
fio_test: support for any device names for input disk

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -58,7 +58,8 @@ class FioTest(Test):
         """
         default_url = "https://brick.kernel.dk/snaps/fio-git-latest.tar.gz"
         url = self.params.get('fio_tool_url', default=default_url)
-        self.disk = self.params.get('disk', default=None)
+        device = self.params.get('disk', default=None)
+        self.disk = disk.get_absolute_disk_path(device)
         self.dir = self.params.get('dir', default=None)
         self.disk_type = self.params.get('disk_type', default='')
         fstype = self.params.get('fs', default='')
@@ -139,7 +140,7 @@ class FioTest(Test):
                         self.cancel("PMEM engines not built with fio")
 
         if self.disk:
-            if self.disk not in disk.get_disks():
+            if self.disk not in disk.get_all_disk_paths():
                 self.cancel("Missing disk %s in OS" % self.disk)
         else:
             self.cancel("Please Provide valid disk name")

--- a/io/disk/fiotest.py.data/README
+++ b/io/disk/fiotest.py.data/README
@@ -1,0 +1,6 @@
+fio is an I/O tool meant to be used both for benchmark and stress/hardware verification.
+
+parameters
+disk: '/dev/sdb' or mpathx or /dev/disk/by-path/dm-uuid-mpathb-xxxxx, /dev/dm-0
+fs: file system type to be created on test disk, it can be any of ext4, ext3, xfs, btrfs etc
+dir: Mount point directory if disk is given, else default workdir will be used


### PR DESCRIPTION
This commit adds support for block device names which persistent accross installs, dlpar, reboot etc.

Block devices names like /dev/sdb are not same across install in some distros, so fio-test.py currently supports only the the /dev/sdX as input device, now with the new code changes a user can provide any of sdX, mpathX, dm-0, /dev/mapper/mpathX ,/dev/disk/by-id/scsi-xxx, /dev/disk/by-path/fc-xxx, /dev/dmX for the below tests