### PR TITLE
lv_setup.py: support for any device names for input disk

### DIFF
--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -49,9 +49,13 @@ class Lvsetup(Test):
         """
         Check existence of input PV,VG, LV and snapshots prior to Test.
         """
-        pkgs = [""]
+        pkgs = []
+        self.disks = []
         smm = SoftwareManager()
-        self.disk = self.params.get('lv_disks', default=None)
+        devices = self.params.get('lv_disks', default=None).split()
+        if devices:
+            for dev in devices:
+                self.disks.append(disk.get_absolute_disk_path(dev))
         self.vg_name = self.params.get('vg_name', default='avocado_vg')
         self.lv_name = self.params.get('lv_name', default='avocado_lv')
         self.fs_name = self.params.get('fs', default='ext4').lower()
@@ -98,8 +102,8 @@ class Lvsetup(Test):
             else:
                 self.lv_size = int(self.lv_size) / 1024 / 1024
 
-        if self.disk:
-            disk_size = lv_utils.get_devices_total_space(self.disk.split())
+        if self.disks:
+            disk_size = lv_utils.get_devices_total_space(self.disks)
             # converting bytes to megabytes
             disk_size = disk_size / (1024 * 1024)
 
@@ -109,7 +113,7 @@ class Lvsetup(Test):
             else:
                 self.lv_size = disk_size
 
-            self.device = self.disk
+            self.device = ' '.join(self.disks)
         else:
             if not self.lv_size:
                 self.lv_size = 1024 * 1024 * 1024
@@ -206,5 +210,5 @@ class Lvsetup(Test):
         Cleans up loop device.
         """
         self.delete_lv()
-        if not self.disk:
+        if not self.disks:
             disk.delete_loop_device(self.device)

--- a/io/disk/lvsetup.py.data/README
+++ b/io/disk/lvsetup.py.data/README
@@ -5,8 +5,9 @@ volume and merges snapshot with the logical volume.
 
 Inputs Needed in yaml file:
 ---------------------------
-lv_disks: Name of the disks on which volume groups, logical volumes,
-      snapshots are created. Created on loop device if not specified
+lv_disks: Name of the disks on which volume groups, logical volumes
+          like space separated /dev/sda or mpathb or scsi id from /dev/disk/by-id/
+          Created on loop device if not specified
 lv_size: Size of the logical volume as string in the form "#G"
          (for example 30G).
 lv_snapshot_name: Name of the snapshot with origin the logical


### PR DESCRIPTION
This commit adds support for block device names which are persistent accross installs, dlpar, reboot etc.

Block devices names like /dev/sdb are not same across install in some distros, so lvsetup.py currently supports only the the /dev/sdX as input device, the new code changes a user can provide any of sdX, mpathX, dm-0, /dev/mapper/mpathX ,/dev/disk/by-id/, /dev/disk/by-path/fc-xxx, /dev/dmX.