### PR TITLE
htxblock: Add support for persistent device name as input disks

### DIFF
--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -26,6 +26,8 @@ import re
 from avocado import Test
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import build
+from avocado.utils import disk
+from avocado.utils import multipath
 from avocado.utils import process, archive
 from avocado.utils import distro
 
@@ -66,8 +68,12 @@ class HtxTest(Test):
             self.block_device = ""
         else:
             self.block_device = []
-            for disk in self.block_devices.split():
-                self.block_device.append(disk.rsplit("/")[-1])
+            for dev in self.block_devices.split():
+                dev_path = disk.get_absolute_disk_path(dev)
+                dev_base = os.path.basename(os.path.realpath(dev_path))
+                if 'dm' in dev_base:
+                    dev_base = multipath.get_mpath_from_dm(dev_base)
+                self.block_device.append(dev_base)
             self.block_device = " ".join(self.block_device)
 
     def setup_htx(self):
@@ -210,9 +216,9 @@ class HtxTest(Test):
         cmd = f"htxcmdline -query -mdt {self.mdt_file}"
         output = process.system_output(cmd).decode("utf-8")
         device = []
-        for disk in self.block_device.split(" "):
-            if disk not in output:
-                device.append(disk)
+        for dev in self.block_device.split(" "):
+            if dev not in output:
+                device.append(dev)
         if device:
             self.log.info(
                 f"block_devices {device} are not avalable in {self.mdt_file} ")
@@ -238,9 +244,9 @@ class HtxTest(Test):
         device_list = self.block_device.split(" ")
         active_devices = []
         for line in output:
-            for disk in device_list:
-                if disk in line and "ACTIVE" in line:
-                    active_devices.append(disk)
+            for dev in device_list:
+                if dev in line and "ACTIVE" in line:
+                    active_devices.append(dev)
         non_active_device = list(set(device_list) - set(active_devices))
         if non_active_device:
             return False

--- a/io/disk/htx_block_devices.py.data/Readme.txt
+++ b/io/disk/htx_block_devices.py.data/Readme.txt
@@ -15,6 +15,7 @@ Inputs:
 ------
 htx_disk: '/dev/sdb /dev/sdc' or if want to pass mpath disk, then it will be /dev/mapper/mpathX
         : for nvme drives, we need to pass namespaces like /dev/nvme0nX
+        : Also it can take any of the device name like device by-id, by-path or by uuid
 all: True or False (True if all disks in selected mdt needs to be run.
      Overrides disks selected)
 time_limit: 1 (In minutes)


### PR DESCRIPTION
This code change will allow user to provide not only device node name /dev/sdx, but any name of the disk by-id, by-path, by-uuid a mapper device etc which is required in cases where the disks names are not persistent across os installs etc