### PR TITLE
ssd: support any device names of test disk

### DIFF
--- a/io/disk/ssd/blkdiscard.py.data/README
+++ b/io/disk/ssd/blkdiscard.py.data/README
@@ -3,4 +3,4 @@ solid-state drivers (SSDs) and thinly-provisioned storage.
 
 Values to be passed in yaml file:
 
-disk - Name of the device on which this script should run.
+disk - any disk name /dev/ or /dev/disk/by-id or /dev/disk/by-path dir USB/scsi/SAN etc

--- a/io/disk/ssd/ezfiotest.py
+++ b/io/disk/ssd/ezfiotest.py
@@ -23,6 +23,7 @@ SSD performance.
 import os
 from avocado import Test
 from avocado.utils import build
+from avocado.utils import disk
 from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils.software_manager.manager import SoftwareManager
@@ -43,7 +44,10 @@ class EzfioTest(Test):
         """
         Build 'fio and ezfio'.
         """
-        self.disk = self.params.get('disk', default='/dev/nvme0n1')
+        device = self.params.get('disk', default=None)
+        if not device:
+            self.cancel("Please provide valid disk name")
+        self.disk = disk.get_absolute_disk_path(device)
         cmd = 'ls %s' % self.disk
         if process.system(cmd, ignore_status=True) is not 0:
             self.cancel("%s does not exist" % self.disk)

--- a/io/disk/ssd/ezfiotest.py.data/README.txt
+++ b/io/disk/ssd/ezfiotest.py.data/README.txt
@@ -5,5 +5,5 @@ This test needs to be run as root.
 
 Inputs Needed (in multiplexer file):
 ------------------------------------
-Devices -       SSD Block devices
-Utilization -   Amount of drive to test (in percent)
+disk -          SSD Block device like /dev/nvme0n1 or device name by-id or by-path
+utilization -   Amount of drive to test (in percent)

--- a/io/disk/ssd/nvme_cli_selftests.py
+++ b/io/disk/ssd/nvme_cli_selftests.py
@@ -21,6 +21,7 @@ NVM-Express user space tooling for Linux, which handles NVMe devices.
 import os
 import pkgutil
 from avocado import Test
+from avocado.utils import disk
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils.software_manager.manager import SoftwareManager
@@ -40,9 +41,14 @@ class NVMeCliSelfTest(Test):
         """
         Download 'nvme-cli'.
         """
-        self.device = self.params.get('device', default='nvme0')
-        self.device = "/dev/%s" % self.device
-        self.disk = self.params.get('disk', default='/dev/nvme0n1')
+        nvme_node = self.params.get('device', default=None)
+        if not nvme_node:
+            self.cancel("Please provide valid nvme node name")
+        self.device = disk.get_absolute_disk_path(nvme_node)
+        device = self.params.get('disk', default=None)
+        if not device:
+            self.cancel("Please provide valid disk name")
+        self.disk = disk.get_absolute_disk_path(device)
         self.test = self.params.get('test', default='')
         if not self.test:
             self.cancel('no test specified in yaml')

--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -22,6 +22,7 @@ using nvme cli.
 
 import os
 from avocado import Test
+from avocado.utils import disk
 from avocado.utils import process
 from avocado.utils import archive
 from avocado.utils import build
@@ -42,8 +43,10 @@ class NVMeTest(Test):
         """
         Build 'nvme-cli' and setup the device.
         """
-        self.device = self.params.get('device', default='nvme0')
-        self.device = "/dev/%s" % self.device
+        nvme_node = self.params.get('device', default=None)
+        if not nvme_node:
+            self.cancel("Please provide valid nvme node name")
+        self.device = disk.get_absolute_disk_path(nvme_node)
         cmd = 'ls %s' % self.device
         if process.system(cmd, ignore_status=True):
             self.cancel("%s does not exist" % self.device)

--- a/io/disk/ssd/nvmetest.py.data/README.txt
+++ b/io/disk/ssd/nvmetest.py.data/README.txt
@@ -21,4 +21,4 @@ This test needs to be run as root.
 The suite selects first namespace on the device and runs tests on it.
 Inputs Needed (in multiplexer file):
 ------------------------------------
-Device      -       NVMe device / interface (Eg: nvme0)
+device      -       NVMe device (Eg: nvme0 or device by id)


### PR DESCRIPTION
This code change will allow user to provide not only device node name /dev/sdx, but any name of the disk by-id, by-path, by-uuid a mapper device etc which is required in cases where the disks names are not persistent across os installs etc