### PR TITLE
Improve the smt workload sh script

### DIFF
--- a/workload/smt.py.data/smt.sh
+++ b/workload/smt.py.data/smt.sh
@@ -19,10 +19,6 @@ do
 	sleep 2
 	ppc64_cpu --smt
 	time ppc64_cpu --smt=8
-	ppc64_cpu --info
-	sleep 2
-	ppc64_cpu --smt
-        time ppc64_cpu --smt=on
         ppc64_cpu --info
 	sleep 2
 	ppc64_cpu --smt
@@ -30,8 +26,11 @@ do
 	ppc64_cpu --info
 	sleep 2
 	ppc64_cpu --smt
-	time ppc64_cpu --smt=8
+	time ppc64_cpu --smt=on
 	ppc64_cpu --info
 	sleep 2
 	ppc64_cpu --smt
+	time ppc64_cpu --smt=off
+	ppc64_cpu --info
+	sleep 2
 done


### PR DESCRIPTION
1. ppc64_cpu --smt=8 and ppc64_cpu --smt=on mean the same thing. So there is no point running these commands one after another.

2. added ppc64_cpu --smt=on followed by ppc64_cpu --smt=off so that we have an instance where maximum no. of threads in a core (7) go offline at once.