### PR TITLE
Add support to pass common and stressor specific args for stress-ng

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -60,6 +60,7 @@ class Stressng(Test):
         self.exclude = self.params.get('exclude', default=None)
         self.v_stressors = self.params.get('v_stressors', default=None)
         self.parallel = self.params.get('parallel', default=True)
+        self.common_args = self.params.get('common_args', default='')
 
         deps = ['gcc', 'make']
         if detected_distro.name in ['Ubuntu', 'debian']:
@@ -148,6 +149,8 @@ class Stressng(Test):
             args.append('--metrics ')
         if self.times:
             args.append('--times ')
+        if self.common_args:
+            args.append('%s ' % self.common_args)
         cmd = 'stress-ng %s' % " ".join(args)
         if self.parallel:
             if self.ttimeout:
@@ -158,8 +161,9 @@ class Stressng(Test):
                 timeout = ' --timeout %s ' % self.ttimeout
             if self.stressors:
                 for stressor in self.stressors.split(' '):
-                    stress_cmd = ' --%s %s %s' % (stressor,
-                                                  self.workers, timeout)
+                    stressor_params = self.params.get(stressor, default='')
+                    stress_cmd = ' --%s %s %s %s ' % (stressor, self.workers, timeout,
+                                                      stressor_params)
                     process.run("%s %s" % (cmd, stress_cmd),
                                 ignore_status=True, sudo=True)
             if self.ttimeout and self.v_stressors:
@@ -167,8 +171,9 @@ class Stressng(Test):
                     int(self.ttimeout) + int(memory.meminfo.MemTotal.g))
             if self.v_stressors:
                 for stressor in self.v_stressors.split(' '):
-                    stress_cmd = ' --%s %s %s' % (stressor,
-                                                  self.workers, timeout)
+                    stressor_params = self.params.get(stressor, default='')
+                    stress_cmd = ' --%s %s %s %s ' % (stressor, self.workers, timeout,
+                                                      stressor_params)
                     process.run("%s %s" % (cmd, stress_cmd),
                                 ignore_status=True, sudo=True)
         ERROR = []

--- a/generic/stress-ng.py.data/readme.rst
+++ b/generic/stress-ng.py.data/readme.rst
@@ -21,3 +21,13 @@ exclude: 'stack,brk,io'
 To run random 60 test:
 stressors: 'random'
 workers: '60'
+
+For a test run having multiple stressors, Common arguments can be passed using
+"common_args" and stressor specific arguments can be passed using "<stressor_name>"
+parameter.
+for eg. if stressors: "readahead hdd"
+then    readahead: '--readahead-bytes 16M'
+        hdd: '--hdd-opts dsync'
+        common_args: '-k'
+Here "common_agrs" is used for both stressors i.e. readahead and hdd
+but "readahead" is used for readahead stressor and "hdd" is used for hdd stressor.


### PR DESCRIPTION
For a test run having multiple stressors, there are common and stressor specific arguments. Common arguments can be passed using "common_args" and stressor specific arguments can be passed using "<stressor_name>" parameter.

for eg. if stressors: "readahead hdd"
then 	readahead: '--readahead-bytes 16M'
        hdd: '--hdd-opts dsync'
        common_args: '-k'
Here "common_agrs" is used for both stressors i.e. readahead and hdd but "readahead" is used for readahead and "hdd" is used for stressor hdd.