### PR TITLE
add fail condition for invalid perf rawevents and metric events

### DIFF
--- a/perf/perf_metric.py
+++ b/perf/perf_metric.py
@@ -84,7 +84,7 @@ class perf_metric(Test):
         for line in self.list_of_metric_events:
             cmd = "perf stat %s %s -C 0 sleep 1" % (option, line)
             op = process.run(cmd, ignore_status=True, shell=True, verbose=True)
-            output = op.stdout.decode() + op.stderr.decode()
+            output = (op.stdout + op.stderr).decode()
             # When the command failed, checking for expected failure or not.
             if op.exit_status:
                 found_imc = False

--- a/perf/perf_metric.py
+++ b/perf/perf_metric.py
@@ -82,12 +82,11 @@ class perf_metric(Test):
 
     def _run_cmd(self, option):
         for line in self.list_of_metric_events:
-            cmd = "perf stat %s %s sleep 1" % (option, line)
-            rc, op = process.getstatusoutput(cmd, ignore_status=True,
-                                             shell=True, verbose=True)
+            cmd = "perf stat %s %s -C 0 sleep 1" % (option, line)
+            op = process.run(cmd, ignore_status=True, shell=True, verbose=True)
+            output = op.stdout.decode() + op.stderr.decode()
             # When the command failed, checking for expected failure or not.
-            if rc:
-                output = op.stdout.decode() + op.stderr.decode()
+            if op.exit_status:
                 found_imc = False
                 found_hv_24_7 = False
                 for ln in output.splitlines():
@@ -107,6 +106,8 @@ class perf_metric(Test):
                                   " environment" % cmd)
                 else:
                     self.fail_cmd.append(cmd)
+            if ("not counted" in output) or ("not supported" in output):
+                self.fail_cmd.append(cmd)
         if self.fail_cmd:
             self.fail("perf_metric: commands failed are %s" % self.fail_cmd)
 

--- a/perf/perf_rawevents.py
+++ b/perf/perf_rawevents.py
@@ -78,9 +78,10 @@ class PerfRawevents(Test):
     def run_event(self, filename, perf_flags):
         for line in genio.read_all_lines(filename):
             cmd = "%s%s sleep 1" % (perf_flags, line)
-            output = process.run(cmd, shell=True,
-                                 ignore_status=True)
-            if output.exit_status != 0:
+            result = process.run(cmd, shell=True, ignore_status=True)
+            output = (result.stdout + result.stderr).decode()
+            if result.exit_status != 0 or ("not counted" in output) or\
+                    ("not supported" in output):
                 self.fail_cmd.append(cmd)
 
     def error_check(self):


### PR DESCRIPTION
patch1 adds fail condition for invalid metric events
fix error as process.getstatusoutput has no attribute stdout/stderr
changed perf stat metric events to run with cpu 0

patch2 adds fail condition for invalid perf_rawevents

Signed-off-by: Disha Goel <disgoel@linux.ibm.com>

avocado run --test-runner runner perf_rawevents.py
JOB ID     : 050a3688bba2b2fc14e16aa1532a5f9638480c07
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2023-05-10T18.54-050a368/job.log
 (1/2) perf_rawevents.py:PerfRawevents.test_raw_code: FAIL: perf_raw_events: refer log file for failed events (11.41 s)
 (2/2) perf_rawevents.py:PerfRawevents.test_name_event: PASS (13.63 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2023-05-10T18.54-050a368/results.html
JOB TIME   : 33.78 s
[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/11485888/job.log)

avocado run --test-runner runner perf_metric.py
JOB ID     : 8ca83c528ce357d046902a6cf1ddabf59b79aef9
JOB LOG    : /home/disha/avocado-fvt-wrapper/results/job-2023-05-16T14.47-8ca83c5/job.log
 (1/2) perf_metric.py:perf_metric.test_all_metric_events_with_M: PASS (191.68 s)
 (2/2) perf_metric.py:perf_metric.test_all_metric_events_with_metric: PASS (191.57 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/disha/avocado-fvt-wrapper/results/job-2023-05-16T14.47-8ca83c5/results.html
JOB TIME   : 391.84 s
[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/11486148/job.log)
