### PR TITLE
bridge.py: add support for mac address as input

### DIFF
--- a/io/net/bridge.py.data/README.txt
+++ b/io/net/bridge.py.data/README.txt
@@ -10,8 +10,9 @@ Python module 'netifaces' is needed. Install via 'pip install netifaces' (or)
 
 Input Needed (in multiplexer file):
 -----------------------------------
-Interface - Specify the interface with which the bridge interface needs to
-            be created.
+Interfaces - Specify the space separated interface names or mac addresses 
+             with which the bridge interface needs to be created.
+             interfaces: "env3 env4"  or interfaces: '02:xx:xx:xx:xx:03 02:xx:xx:xx:xx:04'
 Peer-IP   - Specify the IP for ping test after bridge interface is created
 host-IP   - Specify the IP for ip configuration for interface.
 Netmask   - Specify the netmask for ip configuration for interface.

--- a/io/net/bridge.py.data/bridge.yaml
+++ b/io/net/bridge.py.data/bridge.yaml
@@ -5,5 +5,5 @@ netmask:
 bridge_interface: "br0"
 peer_interface:
 peer_public_ip:
-peer_password: "********"
+peer_password:
 user_name:


### PR DESCRIPTION
In a contineous test environement setups where device names are not persistent accross os install, having a unique key like mac addr as yaml input which does not change across reboots, dlpar or os install with different linux flavours, also the legacy interface name as input works as is.