### PR TITLE
add pmu selftest

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -114,6 +114,8 @@ class kselftest(Test):
                     self.buldir = os.path.join(self.workdir, l_dir)
                     break
         else:
+            if self.subtest == 'pmu/event_code_tests':
+                self.cancel("selftest not supported on distro")
             # Make sure kernel source repo is configured
             if detected_distro.name in ['centos', 'fedora', 'rhel']:
                 src_name = 'kernel'

--- a/kernel/kselftest.py.data/pmu.yaml
+++ b/kernel/kselftest.py.data/pmu.yaml
@@ -1,0 +1,16 @@
+run_type: !mux
+    distro:
+        type: 'distro'
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"
+component: !mux
+    pmu/ebb:
+       comp: 'powerpc'
+       subtest: 'pmu/ebb'
+    pmu/event_code:
+       comp: 'powerpc'
+       subtest: 'pmu/event_code_tests'
+    pmu/sampling_tests:
+       comp: 'powerpc'
+       subtest: 'pmu/sampling_tests'


### PR DESCRIPTION
patch adds a yaml file to run pmu selftests
also add a condition to cancel the pmu/event_code_tests for distro as its not supported

avocado run --max-parallel-tasks=1 kselftest.py -m kselftest.py.data/pmu.yaml
Fetching asset from kselftest.py:kselftest.test
JOB ID     : 4f5adad8f9c17d6ef2be44ac186f014326e86043
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-05-17T03.02-4f5adad/job.log
 (1/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-distro-77ee: STARTED
 (1/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-distro-77ee: PASS (208.80 s)
 (2/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-distro-109d: STARTED
 (2/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-distro-109d: CANCEL: selftest not supported on distro (0.76 s)
 (3/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-distro-92f3: STARTED
 (3/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-distro-92f3: PASS (60.00 s)
 (4/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-upstream-8ab9: STARTED
 (4/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-upstream-8ab9: PASS (183.44 s)
 (5/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-upstream-01a1: STARTED
 (5/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-upstream-01a1: PASS (39.37 s)
 (6/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-upstream-3a10: STARTED
 (6/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-upstream-3a10: PASS (41.48 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-05-17T03.02-4f5adad/results.html
JOB TIME   : 549.21 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/11495680/job.log)