### PR TITLE
Handle Attribute not found error in teardown

### DIFF
--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -94,6 +94,6 @@ class SoftwareRaid(Test):
         """
         Stop/Remove the raid device.
         """
-        if self.sraid:
+        if hasattr(self, "sraid"):
             self.sraid.stop()
             self.sraid.clear_superblock()


### PR DESCRIPTION
self.raid when not defined, ignoring in teardown and exiting testcase.

Before:
(07/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-1.2-raidlevel-raid0-raidname-spare_disks-bf42: STARTED
(07/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-1.2-raidlevel-raid0-raidname-spare_disks-bf42: PASS (0.63 s)
(08/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-0.9-raidlevel-raid1-raidname-spare_disks-88e8: STARTED
(08/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-0.9-raidlevel-raid1-raidname-spare_disks-88e8: ERROR: 'SoftwareRaid' object has no attribute 'sraid' (0.48 s)

After:
(07/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-1.2-raidlevel-raid0-raidname-spare_disks-bf42: STARTED
(07/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-1.2-raidlevel-raid0-raidname-spare_disks-bf42: PASS (0.63 s)
(08/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-0.9-raidlevel-raid1-raidname-spare_disks-88e8: STARTED
(08/23) softwareraid.py:SoftwareRaid.test;run-metadata-superblock-0.9-raidlevel-raid1-raidname-spare_disks-88e8: CANCEL: Minimum 2 disks required for 1 (0.49 s)