### PR TITLE
htx: keep rpm parameter common accross all test

### DIFF
--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -132,7 +132,7 @@ class HtxTest(Test):
                     self.log.info("Using existing HTX")
                     skip_install = True
             if not skip_install:
-                self.rpm_link = self.params.get("rpm_link", default=None)
+                self.rpm_link = self.params.get("htx_rpm_link", default=None)
                 if self.rpm_link:
                     self.install_htx_rpm()
 

--- a/io/disk/htx_block_devices.py.data/Readme.txt
+++ b/io/disk/htx_block_devices.py.data/Readme.txt
@@ -21,4 +21,4 @@ all: True or False (True if all disks in selected mdt needs to be run.
 time_limit: 1 (In minutes)
 mdt_file: Pass the require mdt file, eg: 'mdt.io', mdt.hd
 run_type: this is to how do we want to install the htx tool eg: 'git' or 'rpm' based
-rpm_link: if you want to install htx through RPM then Pass the rpm link here.
+htx_rpm_link: if you want to install htx through RPM then Pass the rpm link here.

--- a/io/disk/htx_block_devices.py.data/htx_all_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_all_devices.yaml
@@ -3,4 +3,4 @@ all: True
 time_limit: 24
 mdt_file: 'mdt.hd'
 run_type: ''
-rpm_link: ''
+htx_rpm_link: ''

--- a/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+++ b/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
@@ -3,4 +3,4 @@ all: False
 time_limit: 1
 mdt_file: 'mdt.hd'
 run_type: ''
-rpm_link: ''
+htx_rpm_link: ''

--- a/workload/htx_test.py
+++ b/workload/htx_test.py
@@ -155,7 +155,7 @@ class HtxTest(Test):
                     self.log.info("Using existing HTX")
                     skip_install = True
             if not skip_install:
-                self.rpm_link = self.params.get('rpm_link', default=None)
+                self.rpm_link = self.params.get('htx_rpm_link', default=None)
                 if self.rpm_link:
                     self.install_latest_htx_rpm()
                 else:

--- a/workload/htx_test.py.data/htx_pmem.yaml
+++ b/workload/htx_test.py.data/htx_pmem.yaml
@@ -1,5 +1,5 @@
 run_type: 'rpm'
-rpm_link: "null"
+htx_rpm_link: "null"
 time_limit: 60 # in minutes
 mdt: !mux
     bu:


### PR DESCRIPTION
As we have different htx test requires same rpm link so it is better to keep same parameter name to avoid duplicate entries in CI/CR environments