### PR TITLE
Add iteration support and iommu specific yaml for stress-ng test

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -61,6 +61,7 @@ class Stressng(Test):
         self.v_stressors = self.params.get('v_stressors', default=None)
         self.parallel = self.params.get('parallel', default=True)
         self.common_args = self.params.get('common_args', default='')
+        self.iteration = self.params.get('iteration', default=1)
 
         deps = ['gcc', 'make']
         if detected_distro.name in ['Ubuntu', 'debian']:
@@ -159,7 +160,8 @@ class Stressng(Test):
         if self.parallel:
             if self.ttimeout:
                 cmd += ' --timeout %s ' % self.ttimeout
-            process.run(cmd, ignore_status=True, sudo=True)
+            for _ in range(self.iteration):
+                process.run(cmd, ignore_status=True, sudo=True)
         else:
             if self.ttimeout:
                 timeout = ' --timeout %s ' % self.ttimeout
@@ -168,8 +170,9 @@ class Stressng(Test):
                     stressor_params = self.params.get(stressor, default='')
                     stress_cmd = ' --%s %s %s %s ' % (stressor, self.workers, timeout,
                                                       stressor_params)
-                    process.run("%s %s" % (cmd, stress_cmd),
-                                ignore_status=True, sudo=True)
+                    for _ in range(self.iteration):
+                        process.run("%s %s" % (cmd, stress_cmd),
+                                    ignore_status=True, sudo=True)
             if self.ttimeout and self.v_stressors:
                 timeout = ' --timeout %s ' % str(
                     int(self.ttimeout) + int(memory.meminfo.MemTotal.g))
@@ -178,8 +181,9 @@ class Stressng(Test):
                     stressor_params = self.params.get(stressor, default='')
                     stress_cmd = ' --%s %s %s %s ' % (stressor, self.workers, timeout,
                                                       stressor_params)
-                    process.run("%s %s" % (cmd, stress_cmd),
-                                ignore_status=True, sudo=True)
+                    for _ in range(self.iteration):
+                        process.run("%s %s" % (cmd, stress_cmd),
+                                    ignore_status=True, sudo=True)
         ERROR = []
         pattern = ['WARNING: CPU:', 'Oops', 'Segfault', 'soft lockup',
                    'Unable to handle', 'ard LOCKUP']

--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -109,10 +109,14 @@ class Stressng(Test):
             if self.parallel:
                 if self.stressors:
                     for stressor in self.stressors.split(' '):
-                        cmdline += '--%s %s ' % (stressor, self.workers)
+                        stressor_params = self.params.get(stressor, default='')
+                        cmdline += '--%s %s %s ' % (stressor, self.workers,
+                                                    stressor_params)
                 if self.v_stressors:
                     for v_stressor in self.v_stressors.split(' '):
-                        cmdline += '--%s %s ' % (v_stressor, self.workers)
+                        stressor_params = self.params.get(v_stressor, default='')
+                        cmdline += '--%s %s %s ' % (v_stressor, self.workers,
+                                                    stressor_params)
                 args.append(cmdline)
         if self.class_type in ['memory', 'vm', 'all']:
             args.append('--vm-bytes 80% ')

--- a/generic/stress-ng.py.data/stress-ng-iommu.yaml
+++ b/generic/stress-ng.py.data/stress-ng-iommu.yaml
@@ -1,0 +1,15 @@
+workers:
+ttimeout: '60'
+verify: True
+syslog: True
+metrics: True
+maximize: True
+times: True
+aggressive: True
+parallel: True
+iteration: 2
+class: 'io'
+stressors: 'readahead hdd'
+readahead: '--readahead-bytes 16M'
+hdd: '--hdd-opts dsync'
+common_args: '-k'


### PR DESCRIPTION
avocado-misc-tests# avocado run generic/stress-ng.py -m generic/stress-ng.py.data/stress-ng-iommu.yaml --test-runner runner
Fetching asset from generic/stress-ng.py:Stressng.test
JOB ID     : 4f1d9c496d082cb0f8f1de463caec4fcde8bf3a7
JOB LOG    : /root/avocado/job-results/job-2023-05-29T02.11-4f1d9c4/job.log
 (1/2) generic/stress-ng.py:Stressng.test;run-variants-readahead-workers-5a2f: WARN: Test passed but there were warnings during execution. Check the log for details. (135.67 s)
 (2/2) generic/stress-ng.py:Stressng.test;run-variants-hdd-workers-2f47: WARN: Test passed but there were warnings during execution. Check the log for details. (138.15 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 2 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 274.12 s