### PR TITLE
.github/workflows/xfstests: Limit github actions to set branches

### DIFF
--- a/.github/workflows/xfstests.yaml
+++ b/.github/workflows/xfstests.yaml
@@ -3,14 +3,14 @@ name: xfstests
 on:
   push:
     branches:
-      - '**'
+      - 'xfstestsci**'
     paths:
       - 'fs/xfstests.py'
       - 'fs/xfstests.py.data/*/ci.yaml'
       - '.github/workflows/xfstests.yaml'
   pull_request:
     branches:
-      - '**'
+      - 'master'
     paths:
       - 'fs/xfstests.py'
       - 'fs/xfstests.py.data/*/ci.yaml'


### PR DESCRIPTION
Currently github actions will run for push to any branch for changes in fs/xfstests.py*. 
Intead limit it to only master and xfstestsci* branch.