### PR TITLE
modify 24x7 based on pvr value

### DIFF
--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -66,13 +66,13 @@ class EliminateDomainSuffix(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
 
-        self.cpu_family = cpu.get_family()
+        self.rev = cpu.get_revision()
         self.perf_args = "perf stat -v -e"
-        if self.cpu_family == 'power8':
+        if self.rev == '004b':
             self.perf_stat = "%s hv_24x7/HPM_0THRD_NON_IDLE_CCYC" % self.perf_args
-        if self.cpu_family == 'power9':
+        if self.rev == '004e':
             self.perf_stat = "%s hv_24x7/CPM_TLBIE" % self.perf_args
-        if self.cpu_family == 'power10':
+        if self.rev == '0080':
             self.perf_stat = "%s hv_24x7/CPM_TLBIE_FIN" % self.perf_args
         self.event_sysfs = "/sys/bus/event_source/devices/hv_24x7"
 
@@ -153,10 +153,10 @@ class EliminateDomainSuffix(Test):
                               ' format for all 6 domains')
 
     def test_event_w_chip_param(self):
-        if self.cpu_family in ['power8', 'power9']:
+        if self.rev == '004b' or self.rev == '004e':
             event_out = genio.read_file(
                 "%s/events/PM_PB_CYC" % self.event_sysfs).rstrip('\t\r\n\0')
-        if self.cpu_family == 'power10':
+        if self.rev == '0080':
             event_out = genio.read_file(
                 "%s/events/PM_PHB0_0_CYC" % self.event_sysfs).rstrip('\t\r\n\0')
         if "chip=?" in event_out:
@@ -170,9 +170,9 @@ class EliminateDomainSuffix(Test):
             self.fail('chip file does not exist')
 
     def test_event_wo_chip_param(self):
-        if self.cpu_family in ['power8', 'power9']:
+        if self.rev == '004b' or self.rev == '004e':
             cmd = "hv_24x7/PM_PB_CYC,domain=1/ /bin/true"
-        if self.cpu_family == 'power10':
+        if self.rev == '0080':
             cmd = "hv_24x7/PM_PHB0_0_CYC,domain=1/ /bin/true"
         chip_miss = self.event_stat1(cmd)
         if "Required parameter 'chip' not specified" not in chip_miss.stdout.decode("utf-8"):
@@ -180,9 +180,9 @@ class EliminateDomainSuffix(Test):
                       ' parameter missing')
         else:
             self.log.info('perf detected chip parameter missing')
-        if self.cpu_family in ['power8', 'power9']:
+        if self.rev == '004b' or self.rev == '004e':
             cmd = "hv_24x7/PM_PB_CYC,domain=1,chip=1/ /bin/true"
-        if self.cpu_family == 'power10':
+        if self.rev == '0080':
             cmd = "hv_24x7/PM_PHB0_0_CYC,domain=1,chip=1/ /bin/true"
         output_chip = self.event_stat1(cmd)
         if "Performance counter stats for" not in output_chip.stderr.decode("utf-8"):


### PR DESCRIPTION
in P9 compat mode test fails with below error as events are written based on pvr version
'perf unable to recognize it has invalid event'
patch modifies the test to use pvr values instead of power processor version

```
avocado run perf_24x7_hardware_counters.py --max-parallel-tasks=1
JOB ID     : 57b0d143a6d99b18bf90f2a997cb0a4ac8bd0ae9
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-06-12T10.32-57b0d14/job.log
 (01/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_display_domain_indices_in_sysfs: STARTED
 (01/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_display_domain_indices_in_sysfs: PASS (66.50 s)
 (02/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_phys_core_param: STARTED
 (02/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_phys_core_param: CANCEL: HPM_0THRD_NON_IDLE_CCYC__PHYS_CORE not found (20.52 s)
 (03/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_domain_param: STARTED
 (03/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_domain_param: PASS (1.60 s)
 (04/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_w_domain_param: STARTED
 (04/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_w_domain_param: PASS (2.65 s)
 (05/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_domain_not_existing: STARTED
 (05/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_domain_not_existing: PASS (2.61 s)
 (06/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_all_domains: STARTED
 (06/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_all_domains: PASS (6.85 s)
 (07/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_w_chip_param: STARTED
 (07/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_w_chip_param: PASS (1.57 s)
 (08/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_chip_param: STARTED
 (08/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_chip_param: PASS (1.64 s)
 (09/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_domain_chip_offset: STARTED
 (09/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_domain_chip_offset: PASS (102.07 s)
 (10/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_phys_core: STARTED
 (10/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_phys_core: PASS (1.63 s)
 (11/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_vcpu: STARTED
 (11/11) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_vcpu: PASS (1.69 s)
RESULTS    : PASS 10 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-06-12T10.32-57b0d14/results.html
JOB TIME   : 341.88 s
```
[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/11748578/job.log)