### PR TITLE
   Fix event loop logic

### DIFF
--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -67,7 +67,9 @@ class test_generic_events(Test):
         for file in os.listdir(dir):
             events_file = open(file, "r")
             event_code = events_file.readline()
-            val = self.generic_events.get(file, 9)
+            val = self.generic_events.get(file)
+            if val is None:
+                continue
             if 'umask' in event_code:
                 self.log.debug("EventCode: %s" % event_code)
                 event = (event_code.split('0x')[1]).rstrip(',umask=')


### PR DESCRIPTION
   Current event loop logic uses magic number '9' which is not required.
   Instead check if val if none and continue for next event in the loop.


Suggested-by: Sandipan Das <sandipan.das@amd.com>