### PR TITLE
Fetch latest HTX build automatically for Host and peer

### DIFF
--- a/io/net/htx_nic_devices.py.data/README.txt
+++ b/io/net/htx_nic_devices.py.data/README.txt
@@ -12,7 +12,7 @@ This test assumes below packages to be installed on both host & peer
 	htx
 
 The net_id should be >= 100 and  <= 223
-htx_rpm :  provide .rpm url for htx installation
+htx_rpm_link :  provide base url location of .rpm for htx installation
 
 Hostname for the host and the peer servers must always be set to the
 fully qualified domain name of the server IP. If not, set it using

--- a/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+++ b/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
@@ -11,4 +11,4 @@ peer_ips: ""
 net_ids: ""
 # time limit in minutes
 time_limit: 2
-htx_rpm: ""
+htx_rpm_link: ""


### PR DESCRIPTION
RHEL for both Host and Peer as per RHEL OS version.

Ex: 1. For RHEL-8 installs RHEL-8 based HTX rpm.
    2. For RHEL-9 installs RHEL-9 based HTX rpm.
    
    
Tested with
----------------------
Host LPAR as RHEL 8 and Peer LPAR as RHEL 9
Host LPAR as RHEL 8 and Peer LPAR as RHEL 8
Both conditions version based installation getting sucessful.

Currently this code does not support on SLES, for 
1. Host/SLES <--------> Peer/SLES
2. Host/SLES <---------> Peer/RH  

and separate JIRA has been initiated on same.

Run logs:
------------

Host - RH-9.2 <---------->  Peer RH-9.2
------------------------------------------------
[root@ltcden4-lp14 net]# avocado run htx_nic_devices.py -m htx_nic_devices.py.data/htx_nic_devices.yaml --max-parallel-tasks=1
JOB ID     : 298c60412a0a5ea8ba1684759934e6f6c4dc1a6a
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-06-21T06.45-298c604/job.log
 (1/3) htx_nic_devices.py:HtxNicTest.test_start;run-2972: STARTED
 (1/3) htx_nic_devices.py:HtxNicTest.test_start;run-2972: PASS (217.58 s)
 (2/3) htx_nic_devices.py:HtxNicTest.test_check;run-2972: STARTED
 (2/3) htx_nic_devices.py:HtxNicTest.test_check;run-2972: PASS (67.22 s)
 (3/3) htx_nic_devices.py:HtxNicTest.test_stop;run-2972: STARTED
 (3/3) htx_nic_devices.py:HtxNicTest.test_stop;run-2972: PASS (13.06 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-06-21T06.45-298c604/results.html
JOB TIME   : 313.95 s


Host - RH-9.2 <---------->  Peer RH-8.9
------------------------------------------------

[root@ltcden4-lp14 net]# avocado run htx_nic_devices.py -m htx_nic_devices.py.data/htx_nic_devices.yaml --max-parallel-tasks=1
JOB ID     : 0e432096cb3e164aa7aa2aa47b677ee66a38caa6
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-06-22T00.48-0e43209/job.log
 (1/3) htx_nic_devices.py:HtxNicTest.test_start;run-770d: STARTED
 (1/3) htx_nic_devices.py:HtxNicTest.test_start;run-770d: PASS (474.36 s)
 (2/3) htx_nic_devices.py:HtxNicTest.test_check;run-770d: STARTED
 (2/3) htx_nic_devices.py:HtxNicTest.test_check;run-770d: PASS (63.25 s)
 (3/3) htx_nic_devices.py:HtxNicTest.test_stop;run-770d: STARTED
 (3/3) htx_nic_devices.py:HtxNicTest.test_stop;run-770d: PASS (9.88 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-06-22T00.48-0e43209/results.html
JOB TIME   : 565.13 s

