### PR TITLE
Adding -f flag to run blkdiscard.py forcefully.

### DIFF
--- a/io/disk/ssd/blkdiscard.py
+++ b/io/disk/ssd/blkdiscard.py
@@ -57,7 +57,7 @@ class Blkdiscard(Test):
         Sectors are dicarded for the different values of OFFSET and LENGTH.
         """
         size = lv_utils.get_device_total_space(self.disk)
-        cmd = "blkdiscard %s -o 0 -v -l %d" % (self.disk, size)
+        cmd = "blkdiscard %s -o 0 -v -l %d -f" % (self.disk, size)
         process.run(cmd, shell=True)
         cmd = "blkdiscard %s -o %d \
                -v -l %d" % (self.disk, size, size)


### PR DESCRIPTION
if any disk left with some metadata like LVM or fs after running some test and if same disk is used for running blkdiscard, it will fail. So added the force option to over write it and continue to run the test case without any issue.