### PR TITLE
io/net: add support for mac id as input

### DIFF
--- a/io/net/Network_config.py.data/README.txt
+++ b/io/net/Network_config.py.data/README.txt
@@ -4,7 +4,7 @@ This Program to check network configuration details like  speed, driver name, bu
 -----------------------------
 Inputs Needed To Run Tests:
 -----------------------------
-interface --> host interface to perform test
+interface --> test interface name eth2 or mac addr 02:5d:c7:xx:xx:03
 host-IP --> Specify host-IP for ip configuration.
 netmask --> specify netmask for ip configuration.
 -----------------------

--- a/io/net/iperf_test.py.data/README.txt
+++ b/io/net/iperf_test.py.data/README.txt
@@ -5,7 +5,7 @@ bandwidth on IP networks.
 
 Inputs Needed To Run Tests:
 ---------------------------
-interface		- interface on which test run
+interface		- interface name eth1 or interface mac 02:5d:xx:xx:0x:00 
 peer_ip			- IP of the Peer interface to be tested
 peer_user		- Username in Peer system to be used
 IPERF_SERVER_RUN	- Whether to run iperf server in peer or not (1 to run, 0 to not run)

--- a/io/net/multicast.py.data/README.txt
+++ b/io/net/multicast.py.data/README.txt
@@ -6,7 +6,7 @@ Inputs Needed To Run Tests:
 -----------------------------
 peerip ---> IP of the Peer interface to be tested
 user_name---> name of the user
-interface --> host interface through which we get host_ip
+interface --> host test interface name eth1 or mac address 02:5d:xx:xx:xx:xx 
 host-IP  ---> Specify host-IP for ip configuration.
 netmask  ---> specify netmask for ip configuration.
 -----------------------

--- a/io/net/netperf_test.py.data/README.txt
+++ b/io/net/netperf_test.py.data/README.txt
@@ -6,6 +6,7 @@ unidirectional throughput, and end-to-end latency.
 
 Inputs Needed To Run Tests:
 -----------------------------
+interface		- test interface name eth2 or mac addr 02:5d:c7:xx:xx:03
 PEERIP			- IP of the Peer interface to be tested
 PEERUSER		- Username in Peer system to be used
 Iface			- interface on which test run

--- a/io/net/switch_test.py.data/README.txt
+++ b/io/net/switch_test.py.data/README.txt
@@ -4,7 +4,7 @@ This Program to test switch port enable.
 -----------------------------
 Inputs Needed To Run Tests:
 -----------------------------
-interface --> host interface to perform test.
+interface --> host interface name eth3 or mac addr 02:5d:c7:xx:xx:03
 peer_ip --> peer interface to perform test.
 host-IP --> Specify host-IP for ip configuration.
 netmask --> specify netmask for ip configuration.

--- a/io/net/tcpdump.py.data/README.txt
+++ b/io/net/tcpdump.py.data/README.txt
@@ -6,7 +6,7 @@ then test fails.
 
 Inputs
 ------
-interface: interface for which tcpdump is to be run
+interface: test interface name env3 or mac addr 02:5d:c7:xx:xx:03
 count: number of packets
 drop_accepted: interface packet drop accepted in percentage (eg 10 for 10%)
 host-IP : Specify host-IP for ip configuration.

--- a/io/net/uperf_test.py.data/README.txt
+++ b/io/net/uperf_test.py.data/README.txt
@@ -6,7 +6,7 @@ workload profiles
 
 Inputs Needed To Run Tests:
 -----------------------------
-interface		- interface on which test run
+interface		- test interface name eth2 or mac addr 02:5d:c7:xx:xx:03 
 peer_ip			- IP of the Peer interface to be tested
 peer_user		- Username in Peer system to be used
 UPERF_SERVER_RUN	- Whether to run netserver in peer or not (1 to run, 0 to not run)

--- a/io/net/vlan_test.py.data/README.txt
+++ b/io/net/vlan_test.py.data/README.txt
@@ -25,7 +25,7 @@ host_port: 38
 peer_port: 45
 
 Host & Peer Interfaces for the VLAN test
-interface: "enp128s0f4d1"
+interface: "enp128s0f4d1" or mac address
 peer_interface: "enP4p1s0f2"
 
 Peer Details


### PR DESCRIPTION
In a contineous test environement setups where device names are not persistent accross os install, having a unique key like mac addr as yaml input which does not change across reboots, dlpar or os install with different linux flavours, also the legacy interface name still works.