### PR TITLE
htx, multiport: add support for mac base input

### DIFF
--- a/io/net/htx_nic_devices.py.data/README.txt
+++ b/io/net/htx_nic_devices.py.data/README.txt
@@ -26,7 +26,7 @@ Make sure that there is a separate interface configured with Public IP
 and is left untouched.
 
 Please pass these parameters as space spearated values if there are more than one inputts
-host_interfaces: "env2 env5"
+host_interfaces: "env2 env5" or "02:5d:c7:xx:xx:03 02:5d:c7:xx:xx:04"
 peer_interfaces: "eht1 eth2"
 net_ids: "150 151"
 host_ips: "102.10.10.188 202.20.20.188"

--- a/io/net/multiport_stress.py.data/README.txt
+++ b/io/net/multiport_stress.py.data/README.txt
@@ -3,7 +3,7 @@ To begin with, the test runs a Ping test on multiple interfaces parallely
 which is followed by Flood ping
 
 The yaml files has following parameters:
-    host_interfaces takes multiple NIC interface names separated by spaces ex  host_interfaces: "env3 env4"
+    host_interfaces takes multiple NIC interface names separated by spaces ex  host_interfaces: "env3 env4" or mac addresses "02:5d:c7:xx:xx:03  02:5d:c7:xx:xx:04"
     peer_ips takes multiple peer ip's separated by space ex : peer_ips: "102.10.10.188 202.20.20.188"
     count is the number of packets to be transferred. Default value is 1000.
     host-IP is Specify for ip configuration pass space separated host_ips: "102.10.10.188 202.20.20.188"


### PR DESCRIPTION
In a contineous test environement setups where device names are not persistent accross os install, having a unique key like mac addr as yaml input which does not change across reboots, dlpar or os install with different linux flavours, also the legacy interface name still works.