### PR TITLE
Fixing Kselftest run setup and selftests/vm to selftests/mm rename

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -60,7 +60,9 @@ class kselftest(Test):
         self.run_type = self.params.get('type', default='upstream')
         detected_distro = distro.detect()
         deps = ['gcc', 'make', 'automake', 'autoconf', 'rsync']
-
+        if (self.comp == "powerpc"):
+            if (detected_distro.arch != 'ppc64' or detected_distro.arch != 'ppc64le'):
+                self.cancel("Testing on a non powerpc platform")
         if detected_distro.name in ['Ubuntu', 'debian']:
             deps.extend(['libpopt0', 'libc6', 'libc6-dev', 'libcap-dev',
                          'libpopt-dev', 'libcap-ng0', 'libcap-ng-dev',
@@ -113,6 +115,9 @@ class kselftest(Test):
                 if os.path.isdir(l_dir) and 'Makefile' in os.listdir(l_dir):
                     self.buldir = os.path.join(self.workdir, l_dir)
                     break
+            process.system("make headers -C %s" % self.buldir, shell=True, sudo=True)
+            self.sourcedir = os.path.join(self.buldir, self.testdir)
+            process.system("make install -C %s" % self.sourcedir, shell=True, sudo=True)
         else:
             if self.subtest == 'pmu/event_code_tests':
                 self.cancel("selftest not supported on distro")

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -52,7 +52,7 @@ class kselftest(Test):
         smg = SoftwareManager()
         self.comp = self.params.get('comp', default='')
         self.subtest = self.params.get('subtest', default='')
-        if self.comp == "vm" and self.subtest == "ksm_tests":
+        if self.comp == "mm" and self.subtest == "ksm_tests":
             self.test_type = self.params.get('test_type', default='-H')
             self.Size_flag = self.params.get('Size', default='-s')
             self.Dup_MM_Area = self.params.get('Dup_MM_Area', default='100')
@@ -200,7 +200,7 @@ class kselftest(Test):
         Run the different ksm test types:
         Ex: -M (page merging)
         """
-        ksm_test_dir = self.sourcedir + "/vm/"
+        ksm_test_dir = self.sourcedir + "/mm"
         ksm_test_bin = ksm_test_dir+"/ksm_tests"
         self.test_list = ["-M", "-Z", "-N", "-U", "-C"]
         if os.path.exists(ksm_test_bin):

--- a/kernel/kselftest.py.data/README
+++ b/kernel/kselftest.py.data/README
@@ -18,7 +18,7 @@ KSM Test Documentation :-
 
 kernel/kselftest.py.data/ksmtest.yaml contains YAML parameters that can
 be used to control ksm_tests behaviour. The following parameters are to
-be added under vm component. 
+be added under mm component. 
 1. subtest     -> To specify ksm_tests
 2. test_type   -> Kself supported test types.
 3. Size        -> Size of duplicated memory area(in MiB) must be provided using -s option.
@@ -26,8 +26,8 @@ be added under vm component.
 
 To run ksm_tests with -P and -H test types, following section can be added to
 the YAML file
-    vm:
-        comp: "vm"
+    mm:
+        comp: "mm"
         subtest: "ksm_tests"
         test_type: "-H"
         Size: "-s"
@@ -37,8 +37,8 @@ Note: The value of Dup_MM_Area depends on the use case.
 To run with  -M, -Z, -N, -U and -C test types, there is no need to pass the
 "Size" and "Dup_MM_Area" parameters.
 Eample YAML section:
-    vm:
-        comp: "vm"
+    mm:
+        comp: "mm"
         subtest: "ksm_tests"
         test_type: "-M"
         Size: ""
@@ -50,8 +50,8 @@ other kselftests
 To run only ksm_tests with upstream code:
 
 component: !mux
-    vm:
-        comp: "vm"
+    mm:
+        comp: "mm"
         subtest: "ksm_tests"
         test_type: "-H"
         Size: "-s"
@@ -80,8 +80,8 @@ component: !mux
         comp: "powerpc"
         subtest: "alignment"
         kself_args: "summary=1"
-    vm:
-        comp: "vm"
+    mm:
+        comp: "mm"
         subtest: "ksm_tests"
         test_type: "-H"
         Size: "-s"
@@ -97,8 +97,8 @@ component: !mux
     power:
         comp: "powerpc"
         kself_args: "summary=1"
-    vm:
-        comp: "vm"
+    mm:
+        comp: "mm"
         subtest: "ksm_tests"
         test_type: "-H"
         Size: "-s"

--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -1,6 +1,6 @@
 component: !mux
-    vm:
-        comp: "vm"
+    mm:
+        comp: "mm"
     power:
         comp: "powerpc"
         kself_args: "summary=1"

--- a/kernel/kselftest.py.data/ksmtest.yaml
+++ b/kernel/kselftest.py.data/ksmtest.yaml
@@ -1,7 +1,7 @@
 component: !mux
-    vm:
-        comp: "vm"
+    mm:
+        comp: "mm"
         subtest: "ksm_tests"
-        test_type: ""
-        Size: ""
-        Dup_MM_Area: ""
+        test_type:
+        Size:
+        Dup_MM_Area:


### PR DESCRIPTION
Component vm renamed to mm on upstream kernel
On upstream kernel component vm renamed to mm by commit id
commit baa489fabd01 ("selftests/vm: rename selftests/vm to
selftests/mm") [Link](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=baa489fabd0159)
Handling the same in testfile ,yaml and updating README
accordingly.

Fix kseleftest run setup on a SUT
Make headers and install kselftest in SUT before run_tests.
Skip powerpc related tests on any non ppc64 and ppc64le platform.


Before:
`
JOB ID     : 5a558f521c16aebe15c90261dc2727ab555db411
JOB LOG    : /root/AvocadoTests_src/results/job-2023-07-26T09.48-5a558f5/job.log
 (1/6) kselftest.py:kselftest.test;run-component-vm-run_type-distro-9ddb: STARTED
 (1/6) kselftest.py:kselftest.test;run-component-vm-run_type-distro-9ddb:  ERROR: expected str, bytes or os.PathLike object, not NoneType (11.92 s)
 (2/6) kselftest.py:kselftest.test;run-component-vm-run_type-upstream-5fab: STARTED
 (2/6) kselftest.py:kselftest.test;run-component-vm-run_type-upstream-5fab:  ERROR: Command 'make -C vm' failed.\nstdout: b''\nstderr: b'make: *** vm: No such file or directory.  Stop.\n'\nadditional_info: None (39.80 s)
 (3/6) kselftest.py:kselftest.test;run-component-power-run_type-distro-fab0: STARTED
 (3/6) kselftest.py:kselftest.test;run-component-power-run_type-distro-fab0:  ERROR: expected str, bytes or os.PathLike object, not NoneType (12.41 s)
 (4/6) kselftest.py:kselftest.test;run-component-power-run_type-upstream-fa90: STARTED
 (4/6) kselftest.py:kselftest.test;run-component-power-run_type-upstream-fa90:  ERROR: Command 'make -C powerpc' failed.\nstdout: b"make: Entering directory '/root/AvocadoTests_src/results/job-2023-07-26T09.48-5a558f5/test-results/4-kselftest.py_kselftest.test_run-component-power-run_type-upstream-fa90/tmp_dir3s95rf6o/1-kselftest.py_kselftes... (42.01 s)
 (5/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-distro-9bf2: STARTED
 (5/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-distro-9bf2:  ERROR: expected str, bytes or os.PathLike object, not NoneType (11.50 s)
 (6/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-upstream-f954: STARTED
 (6/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-upstream-f954:  ERROR: Command 'make -C memory-hotplug' failed.\nstdout: b"make: Entering directory '/root/AvocadoTests_src/results/job-2023-07-26T09.48-5a558f5/test-results/6-kselftest.py_kselftest.test_run-component-mem_plug-run_type-upstream-f954/tmp_diru38f26_j/1-kselftest.p... (39.16 s)

`

After:
`
JOB ID     : e32d1f7c9a5427a5c4dca1407be985206b7f437f
JOB LOG    : /root/AvocadoTests_src/results/job-2023-07-23T12.24-e32d1f7/job.log
 (1/6) kselftest.py:kselftest.test;run-component-mm-run_type-distro-24d5: STARTED
 (1/6) kselftest.py:kselftest.test;run-component-mm-run_type-distro-24d5:  ERROR: Command 'make -C mm' failed.\nstdout: b''\nstderr: b'make: *** mm: No such file or directory.  Stop.\n'\nadditional_info: None (343.33 s)
 (2/6) kselftest.py:kselftest.test;run-component-mm-run_type-upstream-f225: STARTED
 (2/6) kselftest.py:kselftest.test;run-component-mm-run_type-upstream-f225:  FAIL: Testcase failed during selftests (496.28 s)
 (3/6) kselftest.py:kselftest.test;run-component-power-run_type-distro-fab0: STARTED
 (3/6) kselftest.py:kselftest.test;run-component-power-run_type-distro-fab0:  CANCEL: Testing on a non powerpc platform (0.02 s)
 (4/6) kselftest.py:kselftest.test;run-component-power-run_type-upstream-fa90: STARTED
 (4/6) kselftest.py:kselftest.test;run-component-power-run_type-upstream-fa90:  CANCEL: Testing on a non powerpc platform (0.02 s)
 (5/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-distro-9bf2: STARTED
 (5/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-distro-9bf2:  PASS (353.79 s)
 (6/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-upstream-f954: STARTED
 (6/6) kselftest.py:kselftest.test;run-component-mem_plug-run_type-upstream-f954:  PASS (169.68 s)
RESULTS    : PASS 2 | ERROR 1 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 2
JOB HTML   : /root/AvocadoTests_src/results/job-2023-07-23T12.24-e32d1f7/results.html
JOB TIME   : 1481.56 s

Test summary:
kselftest.py:kselftest.test;run-component-mm-run_type-distro-24d5: ERROR
kselftest.py:kselftest.test;run-component-mm-run_type-upstream-f225: FAIL
`