### PR TITLE
fix perf_sdt_probe to add sleep

### DIFF
--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -80,6 +80,7 @@ class PerfSDT(Test):
         self.run_cmd(perf_libc_add)
         if self.is_fail:
             self.fail("Unable to add %s to builid-cache" % self.libc)
+        time.sleep(10)
         # Check if libpthread has valid SDT markers
         new_val = 0
         result = self.run_cmd_out("perf list")


### PR DESCRIPTION
sometimes after adding libpthread event not reflected in perf list immediately and test fails.
patch adds sleep for 10s before checking perf list

Signed-off-by: Disha Goel <disgoel@linux.ibm.com>

before fix
10:02:20 INFO    : Running Host Tests Suite perf_sanity_perf_sdt_probe
10:02:20 INFO    : Running: /usr/local/bin/avocado run -nrunner-max-parallel-tasks=1 /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_sdt_probe.py --force-job-id 56a226744188d16c99b3198bcd8cbb417f0f96b8  -job-results-dir /home/avocado-fvt-wrapper/results
JOB ID     : 56a226744188d16c99b3198bcd8cbb417f0f96b8
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2022-12-08T10.02-56a2267/job.log
 (1/1) /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_sdt_probe.py:PerfSDT.test: STARTED
 (1/1) /home/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_sdt_probe.py:PerfSDT.test:  FAIL: No SDT markers available in the /lib64/libpthread.so.0 (41.28 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2022-12-08T10.02-56a2267/results.html
JOB TIME   : 118.72 s

after fix
[root@ ]# avocado run perf_sdt_probe.py
JOB ID     : 357b0a3a6db3fe0e0319d2d4b7f7101bf143794b
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-07-26T05.48-357b0a3/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: STARTED
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (107.29 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-07-26T05.48-357b0a3/results.html
JOB TIME   : 150.66 s