### PR TITLE
 add_upstream_ftrace

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -100,6 +100,7 @@ class kselftest(Test):
         if self.run_type == 'upstream':
             location = self.params.get('location', default='https://github.c'
                                        'om/torvalds/linux/archive/master.zip')
+            git_branch = self.params.get('branch', default='master')
             path = ''
             match = next(
                 (ext for ext in [".zip", ".tar"] if ext in location), None)
@@ -109,7 +110,7 @@ class kselftest(Test):
                 archive.extract(tarball, self.workdir)
                 path = glob.glob(os.path.join(self.workdir, "linux*"))
             else:
-                git.get_repo(location, destination_dir=self.workdir)
+                git.get_repo(location, branch=git_branch, destination_dir=self.workdir)
                 path = glob.glob(self.workdir)
             for l_dir in path:
                 if os.path.isdir(l_dir) and 'Makefile' in os.listdir(l_dir):

--- a/kernel/kselftest.py.data/ftrace_powerpc.yaml
+++ b/kernel/kselftest.py.data/ftrace_powerpc.yaml
@@ -1,0 +1,9 @@
+component: !mux
+    ftrace:
+        comp: 'ftrace'
+
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: 'git://git.kernel.org/pub/scm/linux/kernel/git/powerpc/linux.git'
+        branch: 'merge'

--- a/kernel/kselftest.py.data/trace_tests.yaml
+++ b/kernel/kselftest.py.data/trace_tests.yaml
@@ -14,3 +14,6 @@ component: !mux
 run_type: !mux
     distro:
         type: 'distro'
+    upstream:
+        type: 'upstream'
+        location: 'https://github.com/torvalds/linux/archive/master.zip'


### PR DESCRIPTION

[debug.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/12273177/debug.log)
Modify kselftest.py to run upstream ftracetest from 'merge' branch or powerpc tree. Add ftrace.yaml to run the test.