### PR TITLE
perf/perf_metrics: Improve parsing logic

### DIFF
--- a/perf/perf_metric.py
+++ b/perf/perf_metric.py
@@ -38,7 +38,7 @@ class perf_metric(Test):
             ln = ln.strip()
             # Skipping empty line, header and comment
             if not ln or "List of pre-defined events" in ln or "[" in ln or\
-               "Metrics:" in ln or "Metric Groups:" in ln:
+               "Metrics:" in ln or "Metric Groups:" in ln or not ln.isupper():
                 continue
             else:
                 self.list_of_metric_events.append(ln)


### PR DESCRIPTION
perf mertrics test parses the o/p of perf list command to identify
list of metrics that are then passed to perf stat command. The
parsing logic does not work correctly which causes failures as
mentioned:

perf stat -M executing in the branch unit] -C 0 sleep 1'
 [stderr] Cannot find metric or group `executing'
 [stderr] Workload failed: No such file or directory
Command 'perf stat -M executing in the branch unit] -C 0 sleep 1' 
finished with 255 after 0.072842537s

Update the parsing logic to also look for lines which has all
upper case characters.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>