### PR TITLE
add perf trace test

### DIFF
--- a/perf/perf_trace.py
+++ b/perf/perf_trace.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2023 IBM
+# Author: Disha Goel <disgoel@linux.ibm.com>
+
+import os
+import platform
+import tempfile
+from avocado import Test
+from avocado.utils import distro, process, dmesg
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class perf_trace(Test):
+
+    """
+    Tests perf trace and it's options with all
+    possible flags with the help of yaml file
+    :avocado: tags=perf,trace
+    """
+
+    def setUp(self):
+        '''
+        Install the basic packages to support perf
+        '''
+
+        # Check for basic utilities
+        smm = SoftwareManager()
+        detected_distro = distro.detect()
+        self.distro_name = detected_distro.name
+
+        deps = ['gcc', 'make']
+        if 'Ubuntu' in self.distro_name:
+            deps.extend(['linux-tools-common', 'linux-tools-%s' %
+                         platform.uname()[2]])
+        elif 'debian' in detected_distro.name:
+            deps.extend(['linux-perf'])
+        elif self.distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
+            deps.extend(['perf'])
+        else:
+            self.cancel("Install the package for perf supported \
+                         by %s" % detected_distro.name)
+        for package in deps:
+            if not smm.check_installed(package) and not smm.install(package):
+                self.cancel('%s is needed for the test to be run' % package)
+
+        # Creating temporary file to collect the perf.data
+        self.temp_file = tempfile.NamedTemporaryFile().name
+
+        # Getting the parameters from yaml file
+        self.option = self.params.get('option', default='')
+
+        # Clear the dmesg by that we can capture delta at the end of the test
+        dmesg.clear_dmesg()
+
+    def run_cmd(self, cmd):
+        try:
+            process.run(cmd, ignore_status=False, sudo=True)
+        except process.CmdError as details:
+            self.fail("Command %s failed: %s" % (cmd, details))
+
+    def test_trace(self):
+        record_cmd = "perf trace record -o %s -- sleep 1" % self.temp_file
+        self.run_cmd(record_cmd)
+        if os.path.exists(self.temp_file):
+            if not os.stat(self.temp_file).st_size:
+                self.fail("%s sample not captured" % self.temp_file)
+            else:
+                report_cmd = "perf trace -i %s %s" % (self.temp_file,
+                                                      self.option)
+                if self.option == "--input":
+                    report_cmd = "perf trace %s %s" % (self.option,
+                                                       self.temp_file)
+                self.run_cmd(report_cmd)
+        dmesg.collect_errors_dmesg(['WARNING: CPU:', 'Oops', 'Segfault',
+                                    'soft lockup', 'Unable to handle'])
+
+    def tearDown(self):
+        # Delete the temporary file
+        if os.path.isfile(self.temp_file):
+            process.run('rm -f %s' % self.temp_file)

--- a/perf/perf_trace.py.data/perf_trace.yaml
+++ b/perf/perf_trace.py.data/perf_trace.yaml
@@ -1,0 +1,81 @@
+variants: !mux
+    all_cpus:
+        option: -a
+    all_cpus_full:
+        option: --all-cpus
+    cpu:
+        option: -C 0
+    cpu_full:
+        option: --cpu 0
+    delay:
+        option: -D 5
+    delay_full:
+        option: --delay 5
+    event:
+        option: -e L1-dcache-load-misses
+    event_full:
+        option: --event L1-dcache-load-misses
+    force:
+        option: -f
+    force_full:
+        option: --force
+    pagefault:
+        option: -F
+    pagefault_full:
+        option: --pf
+    cgroup:
+        option: -G A
+    cgroup_full:
+        option: --cgroup A
+    input:
+        option: --input
+    mmap_pages:
+        option: -m 1
+    mmap_pages_full:
+        option: --mmap-pages 1
+    output:
+        option: -o perf.data.trace
+    output_full:
+        option: --output perf.data.trace
+    pid:
+        option: -p 10
+    pid_full:
+        option: --pid 10
+    summary:
+        option: -s
+    summary_full:
+        option: --summary
+    with-summary:
+        option: -S
+    with-summary_full:
+        option: --with-summary
+    tid:
+        option: -t 10
+    tid_full:
+        option: --tid 10
+    time:
+        option: -T
+    time_full:
+        option: --time
+    uid:
+        option: -u 1
+    uid_full:
+        option: --uid 1
+    verbose:
+        option: -v
+    verbose_full:
+        option: --verbose
+    call-graph:
+        option: --call-graph dwarf
+    comm:
+        option: --comm
+    duration:
+        option: --duration 10
+    errno-summary:
+        option: --errno-summary
+    expr:
+        option: --expr L1-dcache-load-misses
+    failure:
+        option: --failure
+    no-inherit:
+        option: --no-inherit


### PR DESCRIPTION
add test to run perf trace record and perf trace report with different options
ref bz197236 perf trace -i SEGFAULT when perf.data is provided

avocado run perf_trace.py
JOB ID     : 72277427bf00047a6976115aa441bee18dda1806
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-08-09T06.04-7227742/job.log
 (1/1) perf_trace.py:perf_trace.test_trace: STARTED
 (1/1) perf_trace.py:perf_trace.test_trace: PASS (3.11 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-08-09T06.04-7227742/results.html
JOB TIME   : 5.49 s

avocado run perf_trace.py -m perf_trace.py.data/perf_trace.yaml --max-parallel-tasks=1
JOB ID     : bc43aa4ad38b541df7bf95bbafe4ec91336815e5
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-08-09T05.11-bc43aa4/job.log
 (01/40) perf_trace.py:perf_trace.test_trace;run-variants-all_cpus-640d: STARTED
 (01/40) perf_trace.py:perf_trace.test_trace;run-variants-all_cpus-640d: PASS (3.12 s)
 (02/40) perf_trace.py:perf_trace.test_trace;run-variants-all_cpus_full-15dd: STARTED
 (02/40) perf_trace.py:perf_trace.test_trace;run-variants-all_cpus_full-15dd: PASS (3.09 s)
 (03/40) perf_trace.py:perf_trace.test_trace;run-variants-cpu-6c86: STARTED
 (03/40) perf_trace.py:perf_trace.test_trace;run-variants-cpu-6c86: PASS (3.06 s)
 (04/40) perf_trace.py:perf_trace.test_trace;run-variants-cpu_full-d3f1: STARTED
 (04/40) perf_trace.py:perf_trace.test_trace;run-variants-cpu_full-d3f1: PASS (3.08 s)
 (05/40) perf_trace.py:perf_trace.test_trace;run-variants-delay-1d21: STARTED
 (05/40) perf_trace.py:perf_trace.test_trace;run-variants-delay-1d21: PASS (3.07 s)
 (06/40) perf_trace.py:perf_trace.test_trace;run-variants-delay_full-76fc: STARTED
 (06/40) perf_trace.py:perf_trace.test_trace;run-variants-delay_full-76fc: PASS (3.11 s)
 (07/40) perf_trace.py:perf_trace.test_trace;run-variants-event-feab: STARTED
 (07/40) perf_trace.py:perf_trace.test_trace;run-variants-event-feab: PASS (3.14 s)
 (08/40) perf_trace.py:perf_trace.test_trace;run-variants-event_full-f05e: STARTED
 (08/40) perf_trace.py:perf_trace.test_trace;run-variants-event_full-f05e: PASS (3.12 s)
 (09/40) perf_trace.py:perf_trace.test_trace;run-variants-force-5cbe: STARTED
 (09/40) perf_trace.py:perf_trace.test_trace;run-variants-force-5cbe: PASS (3.07 s)
 (10/40) perf_trace.py:perf_trace.test_trace;run-variants-force_full-c38a: STARTED
 (10/40) perf_trace.py:perf_trace.test_trace;run-variants-force_full-c38a: PASS (3.12 s)
 (11/40) perf_trace.py:perf_trace.test_trace;run-variants-pagefault-7b7a: STARTED
 (11/40) perf_trace.py:perf_trace.test_trace;run-variants-pagefault-7b7a: PASS (3.08 s)
 (12/40) perf_trace.py:perf_trace.test_trace;run-variants-pagefault_full-f001: STARTED
 (12/40) perf_trace.py:perf_trace.test_trace;run-variants-pagefault_full-f001: PASS (3.11 s)
 (13/40) perf_trace.py:perf_trace.test_trace;run-variants-cgroup-4fd1: STARTED
 (13/40) perf_trace.py:perf_trace.test_trace;run-variants-cgroup-4fd1: PASS (3.17 s)
 (14/40) perf_trace.py:perf_trace.test_trace;run-variants-cgroup_full-c792: STARTED
 (14/40) perf_trace.py:perf_trace.test_trace;run-variants-cgroup_full-c792: PASS (3.09 s)
 (15/40) perf_trace.py:perf_trace.test_trace;run-variants-input-6c29: STARTED
 (15/40) perf_trace.py:perf_trace.test_trace;run-variants-input-6c29: PASS (3.15 s)
 (16/40) perf_trace.py:perf_trace.test_trace;run-variants-mmap_pages-6022: STARTED
 (16/40) perf_trace.py:perf_trace.test_trace;run-variants-mmap_pages-6022: PASS (3.09 s)
 (17/40) perf_trace.py:perf_trace.test_trace;run-variants-mmap_pages_full-a41d: STARTED
 (17/40) perf_trace.py:perf_trace.test_trace;run-variants-mmap_pages_full-a41d: PASS (3.09 s)
 (18/40) perf_trace.py:perf_trace.test_trace;run-variants-output-c2f0: STARTED
 (18/40) perf_trace.py:perf_trace.test_trace;run-variants-output-c2f0: PASS (3.09 s)
 (19/40) perf_trace.py:perf_trace.test_trace;run-variants-output_full-c4f2: STARTED
 (19/40) perf_trace.py:perf_trace.test_trace;run-variants-output_full-c4f2: PASS (3.11 s)
 (20/40) perf_trace.py:perf_trace.test_trace;run-variants-pid-22ac: STARTED
 (20/40) perf_trace.py:perf_trace.test_trace;run-variants-pid-22ac: PASS (3.12 s)
 (21/40) perf_trace.py:perf_trace.test_trace;run-variants-pid_full-a8b2: STARTED
 (21/40) perf_trace.py:perf_trace.test_trace;run-variants-pid_full-a8b2: PASS (3.13 s)
 (22/40) perf_trace.py:perf_trace.test_trace;run-variants-summary-4e14: STARTED
 (22/40) perf_trace.py:perf_trace.test_trace;run-variants-summary-4e14: PASS (3.11 s)
 (23/40) perf_trace.py:perf_trace.test_trace;run-variants-summary_full-be0f: STARTED
 (23/40) perf_trace.py:perf_trace.test_trace;run-variants-summary_full-be0f: PASS (3.06 s)
 (24/40) perf_trace.py:perf_trace.test_trace;run-variants-with-summary-0ca2: STARTED
 (24/40) perf_trace.py:perf_trace.test_trace;run-variants-with-summary-0ca2: PASS (3.12 s)
 (25/40) perf_trace.py:perf_trace.test_trace;run-variants-with-summary_full-b63f: STARTED
 (25/40) perf_trace.py:perf_trace.test_trace;run-variants-with-summary_full-b63f: PASS (3.10 s)
 (26/40) perf_trace.py:perf_trace.test_trace;run-variants-tid-759c: STARTED
 (26/40) perf_trace.py:perf_trace.test_trace;run-variants-tid-759c: PASS (3.10 s)
 (27/40) perf_trace.py:perf_trace.test_trace;run-variants-tid_full-e11d: STARTED
 (27/40) perf_trace.py:perf_trace.test_trace;run-variants-tid_full-e11d: PASS (3.06 s)
 (28/40) perf_trace.py:perf_trace.test_trace;run-variants-time-6d8f: STARTED
 (28/40) perf_trace.py:perf_trace.test_trace;run-variants-time-6d8f: PASS (3.13 s)
 (29/40) perf_trace.py:perf_trace.test_trace;run-variants-time_full-4232: STARTED
 (29/40) perf_trace.py:perf_trace.test_trace;run-variants-time_full-4232: PASS (3.14 s)
 (30/40) perf_trace.py:perf_trace.test_trace;run-variants-uid-57b4: STARTED
 (30/40) perf_trace.py:perf_trace.test_trace;run-variants-uid-57b4: PASS (3.15 s)
 (31/40) perf_trace.py:perf_trace.test_trace;run-variants-uid_full-48ab: STARTED
 (31/40) perf_trace.py:perf_trace.test_trace;run-variants-uid_full-48ab: PASS (3.07 s)
 (32/40) perf_trace.py:perf_trace.test_trace;run-variants-verbose-6f91: STARTED
 (32/40) perf_trace.py:perf_trace.test_trace;run-variants-verbose-6f91: PASS (3.10 s)
 (33/40) perf_trace.py:perf_trace.test_trace;run-variants-verbose_full-2b22: STARTED
 (33/40) perf_trace.py:perf_trace.test_trace;run-variants-verbose_full-2b22: PASS (3.12 s)
 (34/40) perf_trace.py:perf_trace.test_trace;run-variants-call-graph-43ae: STARTED
 (34/40) perf_trace.py:perf_trace.test_trace;run-variants-call-graph-43ae: PASS (3.12 s)
 (35/40) perf_trace.py:perf_trace.test_trace;run-variants-comm-495b: STARTED
 (35/40) perf_trace.py:perf_trace.test_trace;run-variants-comm-495b: PASS (3.15 s)
 (36/40) perf_trace.py:perf_trace.test_trace;run-variants-duration-c70d: STARTED
 (36/40) perf_trace.py:perf_trace.test_trace;run-variants-duration-c70d: PASS (3.11 s)
 (37/40) perf_trace.py:perf_trace.test_trace;run-variants-errno-summary-2662: STARTED
 (37/40) perf_trace.py:perf_trace.test_trace;run-variants-errno-summary-2662: PASS (3.06 s)
 (38/40) perf_trace.py:perf_trace.test_trace;run-variants-expr-cdbe: STARTED
 (38/40) perf_trace.py:perf_trace.test_trace;run-variants-expr-cdbe: PASS (3.12 s)
 (39/40) perf_trace.py:perf_trace.test_trace;run-variants-failure-0eb0: STARTED
 (39/40) perf_trace.py:perf_trace.test_trace;run-variants-failure-0eb0: PASS (3.11 s)
 (40/40) perf_trace.py:perf_trace.test_trace;run-variants-no-inherit-b44f: STARTED
 (40/40) perf_trace.py:perf_trace.test_trace;run-variants-no-inherit-b44f: PASS (3.14 s)
RESULTS    : PASS 40 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-08-09T05.11-bc43aa4/results.html
JOB TIME   : 172.45 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/12301863/job.log)