### PR TITLE
vethdlpar: add support for mac id base test

### DIFF
--- a/io/net/virt-net/veth_dlpar.py.data/README.txt
+++ b/io/net/virt-net/veth_dlpar.py.data/README.txt
@@ -1,0 +1,13 @@
+VETH DLPAR TEST
+--------------
+The test performs veth device add and remove from vios 
+
+interface : Provide veth nterface name or mac address like "c2:33:44:64:66" of interface to be tested 
+host_ip: IP address to be configured
+netmask: Netmask like 255.255.255.255
+peer_ip: Peer IP address to ping peer network
+vios_ip: VIOS LPAR IP address 
+vios_username: VIOS username
+vios_pwd:  VIOS password
+num_of_dlpar: Number of times test to be repeated
+


### PR DESCRIPTION
In a contineous test environement setups where device names are not persistent accross os, having a unique key like mac addr as yaml input which does not change across reboots,dlpar or os install with different linux flavours, also the legacy interface name still works.