### PR TITLE
modify test to use pvr values and get number of chips available to run chip events

### DIFF
--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -56,13 +56,13 @@ class hv_24x7_all_events(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
 
-        cpu_family = cpu.get_family()
+        self.rev = cpu.get_revision()
         perf_args = "perf stat -v -e"
-        if cpu_family == 'power8':
+        if self.rev == '004b':
             perf_stat = "%s hv_24x7/HPM_0THRD_NON_IDLE_CCYC" % perf_args
-        elif cpu_family == 'power9':
+        elif self.rev == '004e':
             perf_stat = "%s hv_24x7/CPM_TLBIE" % perf_args
-        elif cpu_family == 'power10':
+        elif self.rev == '0080':
             perf_stat = "%s hv_24x7/CPM_TLBIE_FIN" % perf_args
         event_sysfs = "/sys/bus/event_source/devices/hv_24x7"
 


### PR DESCRIPTION
in P9 compat mode test fails with below error as events are written based on pvr version
'perf unable to recognize it has invalid event'
modify the test to use pvr values instead of power processor version

correct code to get number of chips available in the machine from lscpu output and run chip events in that range
also added condition to check for events which are not supported in exit criteria

[root@ perf]# avocado run perf_24x7_all_events.py
JOB ID     : 538c80afef6de6c4a155b910c686d18a4103c51d
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-08-31T06.45-538c80a/job.log
 (1/1) perf_24x7_all_events.py:hv_24x7_all_events.test_all_events: STARTED
 (1/1) perf_24x7_all_events.py:hv_24x7_all_events.test_all_events: PASS (3306.99 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-08-31T06.45-538c80a/results.html
JOB TIME   : 3308.39 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/12486629/job.log)