### PR TITLE
Output validation for perf_c2c and perf_sched

### DIFF
--- a/perf/perf_c2c.py
+++ b/perf/perf_c2c.py
@@ -99,7 +99,12 @@ class perf_c2c(Test):
         self.run_cmd(record_cmd)
         # Report command
         report_cmd = "perf c2c report %s" % self.report
-        self.run_cmd(report_cmd)
+        # Validate the output of perf c2c
+        if os.path.exists(output_file):
+            if not os.stat(output_file).st_size:
+                self.fail("%s sample not captured" % output_file)
+            else:
+                self.run_cmd(report_cmd)
         # Verify dmesg
         dmesg.collect_errors_dmesg(['WARNING: CPU:', 'Oops', 'Segfault',
                                     'soft lockup', 'Unable to handle'])

--- a/perf/perf_sched.py
+++ b/perf/perf_sched.py
@@ -59,7 +59,7 @@ class perf_sched(Test):
         self.temp_file = tempfile.NamedTemporaryFile().name
 
         # Getting the parameters from yaml file
-        self.optname = self.params.get('name', default='')
+        self.optname = self.params.get('name', default='latency')
         self.option = self.params.get('option', default='')
 
         # Clear the dmesg by that we can capture delta at the end of the test

--- a/perf/perf_sched.py
+++ b/perf/perf_sched.py
@@ -83,6 +83,14 @@ class perf_sched(Test):
 
         record_cmd = "perf sched record -o %s ls" % self.temp_file
         self.run_cmd(record_cmd)
+
+        # Validate the output of perf sched
+        if os.path.exists(self.temp_file):
+            if not os.stat(self.temp_file).st_size:
+                self.fail("%s sample not captured" % self.temp_file)
+            else:
+                self.run_cmd("perf report --stdio -i %s" % self.temp_file)
+
         report_cmd = "perf sched -i %s %s %s" % (self.temp_file, self.optname,
                                                  self.option)
         self.run_cmd(report_cmd)


### PR DESCRIPTION
[perf_sched_job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/12523401/perf_sched_job.log)
[perf_c2c_job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/12523415/perf_c2c_job.log)

[root@ perf]# avocado run --max-parallel-tasks=1 perf_c2c.py -m perf_c2c.py.data/record_report.yaml
JOB ID     : a385aaeb517c3bb0d58f112ece1e9e74a6132043
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-09-05T07.04-a385aae/job.log
 (001/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-coalesce-ec55: STARTED
 (001/210) perf_c2c.py:perf_c2c.test_c2c;run-record-event_load-report-coalesce-ec55: PASS (2.04 s)
... 
(210/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-stdio-97a2: STARTED
 (210/210) perf_c2c.py:perf_c2c.test_c2c;run-record-all_user_full-report-stdio-97a2: PASS (1.88 s)
RESULTS    : PASS 210 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-09-05T07.04-a385aae/results.html
JOB TIME   : 1094.28 s

[root@ perf]# avocado run --max-parallel-tasks=1 perf_sched.py -m perf_sched.py.data/perf_sched.yaml
JOB ID     : 9b83583dd286b38092d0d3f33a03f2d57ea441bf
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-09-05T07.16-9b83583/job.log
 (01/36) perf_sched.py:perf_sched.test_sched;run-subsystem-latency-1953: STARTED
 (01/36) perf_sched.py:perf_sched.test_sched;run-subsystem-latency-1953: PASS (3.31 s)
 (02/36) perf_sched.py:perf_sched.test_sched;run-subsystem-script-1269: STARTED
 (02/36) perf_sched.py:perf_sched.test_sched;run-subsystem-script-1269: PASS (3.40 s)
 (03/36) perf_sched.py:perf_sched.test_sched;run-subsystem-replay-9bfb: STARTED
 (03/36) perf_sched.py:perf_sched.test_sched;run-subsystem-replay-9bfb: PASS (3.71 s)
 (04/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-compact-1ddc: STARTED
 (04/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-compact-1ddc: PASS (3.10 s)
 (05/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-cpus-860b: STARTED
 (05/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-cpus-860b: PASS (3.17 s)
 (06/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-color-cpus-bf2a: STARTED
 (06/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-color-cpus-bf2a: PASS (3.19 s)
 (07/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-color-pids-16d7: STARTED
 (07/36) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-color-pids-16d7: PASS (3.18 s)
 (08/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph-f285: STARTED
 (08/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph-f285: PASS (3.38 s)
 (09/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph_full-f3b8: STARTED
 (09/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph_full-f3b8: PASS (3.32 s)
 (10/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-max-stack-2e8b: STARTED
 (10/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-max-stack-2e8b: PASS (3.36 s)
 (11/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-10f5: STARTED
 (11/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-10f5: PASS (3.22 s)
 (12/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu_full-ba63: STARTED
 (12/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu_full-ba63: PASS (3.24 s)
 (13/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-pid-efda: STARTED
 (13/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-pid-efda: PASS (3.34 s)
 (14/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-pid_full-00fc: STARTED
 (14/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-pid_full-00fc: PASS (3.30 s)
 (15/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-tid-e7e2: STARTED
 (15/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-tid-e7e2: PASS (3.44 s)
 (16/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-tid_full-39c5: STARTED
 (16/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-tid_full-39c5: PASS (3.22 s)
 (17/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary-a1ad: STARTED
 (17/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary-a1ad: PASS (3.39 s)
 (18/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary_full-6ab1: STARTED
 (18/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary_full-6ab1: PASS (3.26 s)
 (19/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-with-summary-82c8: STARTED
 (19/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-with-summary-82c8: PASS (3.49 s)
 (20/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-with-summary_full-5e4b: STARTED
 (20/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-with-summary_full-5e4b: PASS (3.30 s)
 (21/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-symfs-fd98: STARTED
 (21/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-symfs-fd98: PASS (3.09 s)
 (22/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-visual-4afb: STARTED
 (22/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-visual-4afb: PASS (3.47 s)
 (23/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-visual_full-09ea: STARTED
 (23/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-cpu-visual_full-09ea: PASS (3.18 s)
 (24/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-wakeups-c719: STARTED
 (24/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-wakeups-c719: PASS (3.28 s)
 (25/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-wakeups_full-bd47: STARTED
 (25/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-wakeups_full-bd47: PASS (3.27 s)
 (26/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-migrations-6ae9: STARTED
 (26/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-migrations-6ae9: PASS (3.20 s)
 (27/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-migrations_full-388b: STARTED
 (27/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-migrations_full-388b: PASS (3.37 s)
 (28/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-next-521e: STARTED
 (28/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-next-521e: PASS (3.36 s)
 (29/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-next_full-4bcf: STARTED
 (29/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-next_full-4bcf: PASS (3.19 s)
 (30/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-idle-hist-721f: STARTED
 (30/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-idle-hist-721f: PASS (3.31 s)
 (31/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-idle-hist_full-3648: STARTED
 (31/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-idle-hist_full-3648: PASS (3.17 s)
 (32/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-time-9875: STARTED
 (32/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-time-9875: PASS (3.39 s)
 (33/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-state-91c9: STARTED
 (33/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-state-91c9: PASS (3.41 s)
 (34/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-vmlinux-83d4: STARTED
 (34/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-vmlinux-83d4: PASS (3.05 s)
 (35/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-vmlinux_full-26ca: STARTED
 (35/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-vmlinux_full-26ca: PASS (3.00 s)
 (36/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-kallsyms-0889: STARTED
 (36/36) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-kallsyms-0889: PASS (3.22 s)
RESULTS    : PASS 36 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-09-05T07.16-9b83583/results.html
JOB TIME   : 268.45 s
