### PR TITLE
Duration period argument should be integer instead of string

### DIFF
--- a/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_bw_extended_roce.yaml
@@ -12,8 +12,8 @@ PEERCA: ""
 PEERPORT: "1"
 TIMEOUT: "600"
 test_opt: !mux
-    -D_10s:
-        test_opt: -D 10s
+    -D_10:
+        test_opt: -D 10
     -l_4:
         test_opt: -l 4
     -Q_5:
@@ -38,10 +38,10 @@ test_opt: !mux
         test_opt: -R -b
     -R_-c_RC:
         test_opt: -R -c RC
-    -R_-D_30s:
-        test_opt: -R -D 30s
-    -R_-f_5s_-D_11s:
-        test_opt: -R -f 5s -D 11s
+    -R_-D_30:
+        test_opt: -R -D 30
+    -R_-f_5_-D_11:
+        test_opt: -R -f 5 -D 11
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_1024:

--- a/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_read_lat_extended_roce.yaml
@@ -14,8 +14,8 @@ TIMEOUT: "600"
 test_opt: !mux
     -c_RC:
         test_opt: -c RC
-    -D_10s:
-        test_opt: -D 10s
+    -D_10:
+        test_opt: -D 10
     -Q_5:
         test_opt: -Q 5
     -w_100M:
@@ -32,10 +32,10 @@ test_opt: !mux
         test_opt: -R -a
     -R_-c_RC:
         test_opt: -R -c RC
-    -R_-D_30s:
-        test_opt: -R -D 30s
-    -R_-f_5s_-D_11s:
-        test_opt: -R -f 5s -D 11s
+    -R_-D_30:
+        test_opt: -R -D 30
+    -R_-f_5_-D_11:
+        test_opt: -R -f 5 -D 11
     -R_-m_1024:
         test_opt: -R -m 1024
     -R_-n_100000:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_bw_extended_roce.yaml
@@ -28,8 +28,8 @@ test_opt: !mux
         test_opt: -y 10G
     -z:
         test_opt: -z
-    -D_10s:
-        test_opt: -D 10s
+    -D_10:
+        test_opt: -D 10
     -l_4:
         test_opt: -l 4
     -a:
@@ -52,8 +52,8 @@ test_opt: !mux
         test_opt: -R -b
     -R_-c_RC:
         test_opt: -R -c RC
-    -R_-D_30s:
-        test_opt: -R -D 30s
+    -R_-D_30:
+        test_opt: -R -D 30
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_1024:

--- a/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_send_lat_extended_roce.yaml
@@ -24,8 +24,8 @@ test_opt: !mux
         test_opt: -y 10G
     -z:
         test_opt: -z
-    -D_10s:
-        test_opt: -D 10s
+    -D_10:
+        test_opt: -D 10
     -a:
         test_opt: -a
     -c_XRC:
@@ -42,10 +42,10 @@ test_opt: !mux
         test_opt: -R -a
     -R_-c_RC:
         test_opt: -R -c RC
-    -R_-D_30s:
-        test_opt: -R -D 30s
-    -R_-f_5s_-D_11s:
-        test_opt: -R -f 5s -D 11s
+    -R_-D_30:
+        test_opt: -R -D 30
+    -R_-f_5_-D_11:
+        test_opt: -R -f 5 -D 11
     -R_-m_1024:
         test_opt: -R -m 1024
     -R_-n_100000:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_bw_extended_roce.yaml
@@ -20,8 +20,8 @@ test_opt: !mux
         test_opt: -c UC
     -c_RC:
         test_opt: -c RC
-    -D_10s:
-        test_opt: -D 10s
+    -D_10:
+        test_opt: -D 10
     -l_4:
         test_opt: -l 4
     -Q_5:
@@ -40,10 +40,10 @@ test_opt: !mux
         test_opt: -R -b
     -R_-c_RC:
         test_opt: -R -c RC
-    -R_-D_30s:
-        test_opt: -R -D 30s
-    -R_-f_5s_-D_11s:
-        test_opt: -R -f 5s -D 11s
+    -R_-D_30:
+        test_opt: -R -D 30
+    -R_-f_5_-D_11:
+        test_opt: -R -f 5 -D 11
     -R_-l_2:
         test_opt: -R -l 2
     -R_-m_1024:

--- a/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended_roce.yaml
+++ b/io/net/infiniband/rdma_tests.py.data/ib_write_lat_extended_roce.yaml
@@ -12,8 +12,8 @@ PEERCA: ""
 PEERPORT: "1"
 TIMEOUT: "600"
 test_opt: !mux
-    -D_10s:
-        test_opt: -D 10s
+    -D_10:
+        test_opt: -D 10
     -Q_5:
         test_opt: -Q 5
     -w_100M:
@@ -30,10 +30,10 @@ test_opt: !mux
         test_opt: -R -a
     -R_-c_RC:
         test_opt: -R -c RC
-    -R_-D_30s:
-        test_opt: -R -D 30s
-    -R_-f_5s_-D_11s:
-        test_opt: -R -f 5s -D 11s
+    -R_-D_30:
+        test_opt: -R -D 30
+    -R_-f_5_-D_11:
+        test_opt: -R -f 5 -D 11
     -R_-m_1024:
         test_opt: -R -m 1024
     -R_-n_100000:


### PR DESCRIPTION
Fixing the parameter values passed in yaml files to be integers

fail case logs

 (001/261) rdma_tests.py:RDMA.test;run-ib_read_bw_extended-mtu-1500-test_opt--D_10s-0b64: STARTED
 (001/261) rdma_tests.py:RDMA.test;run-ib_read_bw_extended-mtu-1500-test_opt--D_10s-0b64: FAIL: Client cmd: ib_read_bw -D 10s (5.47 s)
 (002/261) rdma_tests.py:RDMA.test;run-ib_read_bw_extended-mtu-2000-test_opt--D_10s-57a4: STARTED
 (002/261) rdma_tests.py:RDMA.test;run-ib_read_bw_extended-mtu-2000-test_opt--D_10s-57a4: FAIL: Client cmd: ib_read_bw -D 10s (4.13 s)
 (003/261) rdma_tests.py:RDMA.test;run-ib_read_bw_extended-mtu-3000-test_opt--D_10s-268d: STARTED