### PR TITLE
fix LTP aio-stress test

### DIFF
--- a/perf/aiostress.py.data/aiostress.yaml
+++ b/perf/aiostress.py.data/aiostress.yaml
@@ -1,1 +1,1 @@
-url : 'https://github.com/linux-test-project/ltp/blob/master/testcases/kernel/io/ltp-aiodio/aio-stress.c'
+url : 'https://github.com/linux-test-project/ltp/archive/master.zip'


### PR DESCRIPTION
remove libaio package as not needed anymore
fix below compilation error by building and compiling LTP first and then run aio-stress test
"ERROR: Command 'gcc -Wall -o aio-stress /root/avocado/data/cache/by_location/1045d5a4350b89433ad0cb55a0f87cb8ba4fc0b2/aio-stress.c -laio -lpthread' failed."

[root@]# avocado run aiostress.py
JOB ID     : 75bcbb78787102a2196015ae7802892f00a01ea6
JOB LOG    : /home/geet/avocado-fvt-wrapper/results/job-2023-09-14T08.15-75bcbb7/job.log
 (1/1) aiostress.py:Aiostress.test: STARTED
 (1/1) aiostress.py:Aiostress.test: PASS (36.41 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/geet/avocado-fvt-wrapper/results/job-2023-09-14T08.15-75bcbb7/results.html
JOB TIME   : 56.44 s