### PR TITLE
interfaces: use common name accross all tests

### DIFF
--- a/io/common/bootlist_test.py
+++ b/io/common/bootlist_test.py
@@ -43,7 +43,7 @@ class BootlisTest(Test):
         local = LocalHost()
         interfaces = os.listdir('/sys/class/net')
         disks = self.params.get("disks", default=None)
-        ifaces = self.params.get("host_interfaces", default=None)
+        ifaces = self.params.get("interfaces", default=None)
         if ifaces:
             for device in ifaces.split(" "):
                 if device in interfaces:

--- a/io/common/bootlist_test.py.data/bootlist_test_network.yaml
+++ b/io/common/bootlist_test.py.data/bootlist_test_network.yaml
@@ -1,1 +1,1 @@
-host_interfaces: ""
+interfaces: ""

--- a/io/net/multiport_stress.py
+++ b/io/net/multiport_stress.py
@@ -35,7 +35,7 @@ class MultiportStress(Test):
         self.host_interfaces = []
         interfaces = os.listdir('/sys/class/net')
         self.local = LocalHost()
-        devices = self.params.get("host_interfaces", default=None)
+        devices = self.params.get("interfaces", default=None)
         for device in devices.split(" "):
             if device in interfaces:
                 self.host_interfaces.append(device)

--- a/io/net/multiport_stress.py.data/README.txt
+++ b/io/net/multiport_stress.py.data/README.txt
@@ -3,7 +3,7 @@ To begin with, the test runs a Ping test on multiple interfaces parallely
 which is followed by Flood ping
 
 The yaml files has following parameters:
-    host_interfaces takes multiple NIC interface names separated by spaces ex  host_interfaces: "env3 env4" or mac addresses "02:5d:c7:xx:xx:03  02:5d:c7:xx:xx:04"
+    interfaces takes multiple NIC interface names separated by spaces ex  interfaces: "env3 env4" or mac addresses "02:5d:c7:xx:xx:03  02:5d:c7:xx:xx:04"
     peer_ips takes multiple peer ip's separated by space ex : peer_ips: "102.10.10.188 202.20.20.188"
     count is the number of packets to be transferred. Default value is 1000.
     host-IP is Specify for ip configuration pass space separated host_ips: "102.10.10.188 202.20.20.188"

--- a/io/net/multiport_stress.py.data/multiport_stress.yaml
+++ b/io/net/multiport_stress.py.data/multiport_stress.yaml
@@ -1,4 +1,4 @@
-host_interfaces: ""
+interfaces: ""
 peer_ips: ""
 peer_public_ip: ""
 peer_user: ""

--- a/io/net/multiport_stress.py.data/multiport_stress_virt.yaml
+++ b/io/net/multiport_stress.py.data/multiport_stress_virt.yaml
@@ -1,4 +1,4 @@
-host_interfaces: ""
+interfaces: ""
 peer_ips: ""
 peer_public_ip: ""
 peer_user: ""


### PR DESCRIPTION
To simplify and avoid extra parameters, keep a common input parameter name across all network test i.e rename host_interface to just interfaces