### PR TITLE
Use built latest numatop binary only

### DIFF
--- a/cpu/numatop.py
+++ b/cpu/numatop.py
@@ -79,8 +79,10 @@ class Numatop(Test):
 
         mgen_flag = False
         mgen = os.path.join(self.sourcedir, 'mgen')
+        numatop = os.path.join(self.sourcedir, 'numatop')
+        cmd = numatop+" -d result_file"
         self.numa_pid = process.SubProcess(
-            'numatop -d result_file', shell=True)
+            cmd, shell=True)
         self.numa_pid.start()
 
         # Run mgen for 5 seconds to generate a single snapshot of numatop


### PR DESCRIPTION
Using custom built latest numatop binary for test

As distro built numatop doesnt support on AMD cpu's

> $numatop
> CPU is not supported!

--BEFORE--
> (1/1) numatop.py:Numatop.test: STARTED
> (1/1) numatop.py:Numatop.test: FAIL: Numatop failed to record mgen latency. Please check the record file: /home//results/job-2023-09-27T05.11-4b6470f/test-results/1-numatop.py_Numatop.test/tmp_dirz9h_td2_/1-numatop.py_Numatop.test/num... (43.59 s)

--AFTER--
> Fetching asset from numatop.py:Numatop.test
> JOB ID     : 046a8ac1d6165e2ed1f0a099506f105c8f777f11
> JOB LOG    : /home/AvocadoTests_src/results/job-2023-09-27T05.57-046a8ac/job.log
> (1/1) numatop.py:Numatop.test: STARTED
> (1/1) numatop.py:Numatop.test: PASS (42.93 s)
> RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
> JOB HTML   : /home/AvocadoTests_src/results/job-2023-09-27T05.57-046a8ac/results.html
> JOB TIME   : 47.28 s
