### PR TITLE
correct syntax in yaml "=" to ":"

### DIFF
--- a/memory/memhotplug.py.data/memhotplug.yaml
+++ b/memory/memhotplug.py.data/memhotplug.yaml
@@ -1,4 +1,4 @@
-stress_tar_url = 'https://fossies.org/linux/privat/old/stress-1.0.5.tar.gz'
+stress_tar_url: 'https://fossies.org/linux/privat/old/stress-1.0.5.tar.gz'
 iteration: 1
 stresstime: 10
 vmcount: 4


### PR DESCRIPTION
In yaml "=" is not supported, updating to ":"

Before:
avocado run --max-parallel-tasks 1 memhotplug.py -m memhotplug.py.data/memhotplug.yaml
JOB HTML : /home/AvocadoTests_src/results/job-2023-10-11T05.23-3e7f92e/results.html
JOB TIME : 434.15 s
JOB ID : a7793f2978f3fa74b9b234b1d51f34f4f43375d6
JOB LOG : /home/AvocadoTests_src/results/job-2023-10-11T05.36-a7793f2/job.log
(1/4) memhotplug.py:MemStress.test_hotplug_loop;run-fb7c: STARTED
Invalid multiplex file 'memhotplug.py.data/memhotplug.yaml': mapping values are not allowed in this context
in "memhotplug.py.data/memhotplug.yaml", line 2, column 10
Make sure !tags and colons are separated by a space (eg. !include :) : memhotplug.py.data/memhotplug.yaml

After:
JOB ID     : 3e7f92e7642c6d9e43fc9e27acc1a4325c1414d9
JOB LOG    : /home/AvocadoTests_src/results/job-2023-10-11T05.23-3e7f92e/job.log
 (1/4) memhotplug.py:MemStress.test_hotplug_loop;run-3742: STARTED
 (1/4) memhotplug.py:MemStress.test_hotplug_loop;run-3742:  PASS (212.26 s)
 (2/4) memhotplug.py:MemStress.test_hotplug_toggle;run-3742: STARTED
 (2/4) memhotplug.py:MemStress.test_hotplug_toggle;run-3742:  PASS (193.72 s)
 (3/4) memhotplug.py:MemStress.test_dlpar_mem_hotplug;run-3742: STARTED
 (3/4) memhotplug.py:MemStress.test_dlpar_mem_hotplug;run-3742:  PASS (0.53 s)
 (4/4) memhotplug.py:MemStress.test_hotplug_per_numa_node;run-3742: STARTED
 (4/4) memhotplug.py:MemStress.test_hotplug_per_numa_node;run-3742:  PASS (21.92 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/AvocadoTests_src/results/job-2023-10-11T05.23-3e7f92e/results.html
JOB TIME   : 434.15 s

====debug.log====
[stdlog] 2023-10-11 06:08:13,509 avocado.test DEBUG| PARAMS (key=stress_tar_url, path=*, default=https://fossies.org/linux/privat/old/stress-1.0.5.tar.gz) => 'https://fossies.org/linux/privat/old/stress-1.0.5.tar.gz'
