### PR TITLE
Exclude memory_failure from memory hotplug

### DIFF
--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -220,7 +220,7 @@ class MemStress(Test):
             node = node.strip('\n')
             self.log.info("Hotplug all memory in Numa Node %s", node)
             mem_blocks = get_hotpluggable_blocks((
-                '/sys/devices/system/node/node%s/memory*' % node), self.memratio)
+                '/sys/devices/system/node/node%s/memory[0-9]*' % node), self.memratio)
             for block in mem_blocks:
                 self.log.info(
                     "offline memory%s in numa node%s", block, node)


### PR DESCRIPTION
After Commit 44b8f8bf2438 ("mm: memory-failure: add memory failure stats to sysfs") got merged /sys/devices/system/node/node${X}/memory_failure was intoduced, resulted in Out of Index error in get_hotpluggable_blocks().

Solving it by looking for only memory[0-9]* files and ignoring others.

Before:
[stdlog] 2023-10-12 00:16:27,777 avocado.test INFO | Hotplug all memory in Numa Node 0
[stdlog] 2023-10-12 00:16:27,778 avocado.test ERROR|
[stdlog] 2023-10-12 00:16:27,778 avocado.test ERROR| Reproduced traceback from: /usr/local/lib/python3.9/site-packages/avocado/core/test.py:631
[stdlog] 2023-10-12 00:16:27,778 avocado.test ERROR| Traceback (most recent call last):
[stdlog] 2023-10-12 00:16:27,779 avocado.test ERROR|   File "/root/avocado-misc-tests/memory/memhotplug.py", line 222, in test_hotplug_per_numa_node
[stdlog] 2023-10-12 00:16:27,779 avocado.test ERROR|     mem_blocks = get_hotpluggable_blocks((
[stdlog] 2023-10-12 00:16:27,779 avocado.test ERROR|   File "/root/avocado-misc-tests/memory/memhotplug.py", line 61, in get_hotpluggable_blocks
[stdlog] 2023-10-12 00:16:27,779 avocado.test ERROR|     block = re.findall(r"\d+", os.path.basename(mem_blk))[0]
[stdlog] 2023-10-12 00:16:27,779 avocado.test ERROR| IndexError: list index out of range
[stdlog] 2023-10-12 00:16:27,779 avocado.test ERROR|

After:
[stdlog] 2023-10-12 04:20:34,157 avocado.test INFO | Hotplug all memory in Numa Node 0
[stdlog] 2023-10-12 04:20:34,160 avocado.test INFO | offline memory32 in numa node0
[stdlog] 2023-10-12 04:20:34,168 avocado.test ERROR| memory32 : Resource is busy
[stdlog] 2023-10-12 04:20:34,169 avocado.utils.process INFO | Running 'stress --cpu 64 --io 4 --vm 4 --vm-bytes 124042M --timeout 10s'
[stdlog] 2023-10-12 04:20:34,181 avocado.utils.process DEBUG| [stdout] stress: info: [25705] dispatching hogs: 64 cpu, 4 io, 4 vm, 0 hdd
[stdlog] 2023-10-12 04:20:45,073 avocado.utils.process DEBUG| [stdout] stress: info: [25705] successful run completed in 11s
[stdlog] 2023-10-12 04:20:45,074 avocado.utils.process INFO | Command 'stress --cpu 64 --io 4 --vm 4 --vm-bytes 124042M --timeout 10s' finished with 0 after 10.896656598s
[stdlog] 2023-10-12 04:20:45,074 avocado.test INFO | Hotplug all memory in Numa Node 7
[stdlog] 2023-10-12 04:20:45,077 avocado.test INFO | offline memory234 in numa node7
[stdlog] 2023-10-12 04:20:55,218 avocado.utils.process INFO | Running 'stress --cpu 64 --io 4 --vm 4 --vm-bytes 123552M --timeout 10s'
[stdlog] 2023-10-12 04:20:55,230 avocado.utils.process DEBUG| [stdout] stress: info: [26071] dispatching hogs: 64 cpu, 4 io, 4 vm, 0 hdd
[stdlog] 2023-10-12 04:21:06,132 avocado.utils.process DEBUG| [stdout] stress: info: [26071] successful run completed in 11s
[stdlog] 2023-10-12 04:21:06,133 avocado.utils.process INFO | Command 'stress --cpu 64 --io 4 --vm 4 --vm-bytes 123552M --timeout 10s' finished with 0 after 10.906402337s
[stdlog] 2023-10-12 04:21:06,133 avocado.utils.process INFO | Running 'dmesg -Txl 1,2,3,4'
[stdlog] 2023-10-12 04:21:06,145 avocado.utils.process DEBUG| [stdout] kern  :warn  : [Thu Oct 12 04:20:46 2023] PEFILE: Unsigned PE binary
[stdlog] 2023-10-12 04:21:06,146 avocado.utils.process INFO | Command 'dmesg -Txl 1,2,3,4' finished with 0 after 0.003001073s
[stdlog] 2023-10-12 04:21:16,183 avocado.test INFO | PASS 1-memhotplug.py:MemStress.test_hotplug_per_numa_node;run-90b1