### PR TITLE
Test error out due to undefind variable name

### DIFF
--- a/toolchain/binutils.py
+++ b/toolchain/binutils.py
@@ -44,7 +44,7 @@ class Binutils(Test):
         """
         if (not self._sm.check_installed(package) and
                 not self._sm.install(package)):
-            self.cancel('Please install %s for the test to run' % self.package)
+            self.cancel('Please install %s for the test to run' % package)
 
     def setUp(self):
         # Check for basic utilities


### PR DESCRIPTION
Patch fix issue the issue undefind variable

without this patch

[stdlog] 2023-10-16 07:45:46,510 stacktrace       L0040 ERROR|
[stdlog] 2023-10-16 07:45:46,510 stacktrace       L0045 ERROR| Reproduced traceback from: /usr/local/lib/python3.6/site-packages/avocado_framework-102.0-py3.6.egg/avocado/core/test.py:616
[stdlog] 2023-10-16 07:45:46,510 stacktrace       L0049 ERROR| Traceback (most recent call last):
[stdlog] 2023-10-16 07:45:46,510 stacktrace       L0049 ERROR|   File "/root/avocado-fvt-wrapper/tests/avocado-misc-tests/toolchain/binutils.py", line 60, in setUp
[stdlog] 2023-10-16 07:45:46,510 stacktrace       L0049 ERROR|     self.check_install(pkg)
[stdlog] 2023-10-16 07:45:46,510 stacktrace       L0049 ERROR|   File "/root/avocado-fvt-wrapper/tests/avocado-misc-tests/toolchain/binutils.py", line 47, in check_install
[stdlog] 2023-10-16 07:45:46,511 stacktrace       L0049 ERROR|     self.cancel('Please install %s for the test to run' % self.package)
[stdlog] 2023-10-16 07:45:46,511 stacktrace       L0049 ERROR| AttributeError: 'Binutils' object has no attribute 'package'
[stdlog] 2023-10-16 07:45:46,511 stacktrace       L0050 ERROR|