### PR TITLE
fix 24x7 attribute error

### DIFF
--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -95,8 +95,8 @@ class hv_24x7_all_events(Test):
                 self.physical_sockets = int(line.split(':')[1].strip())
             if 'Physical chips:' in line:
                 self.physical_chips = int(line.split(':')[1].strip())
-            # chip = physical socket x physical chip
-            self.chip = int(self.physical_sockets*self.physical_chips)
+        # chip = physical socket x physical chip
+        self.chip = int(self.physical_sockets*self.physical_chips)
 
         # Collect all hv_24x7 events
         self.list_of_hv_24x7_events = []


### PR DESCRIPTION
test gives error saying 'hv_24x7_all_events' object has no attribute 'physical_sockets'. 
Fix this by defining the attributes before attempting to access.

avocado run perf_24x7_all_events.py
JOB ID     : 84266c5177555061f9e97e16781fbff2b35717f8
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2023-11-16T14.36-84266c5/job.log
 (1/1) perf_24x7_all_events.py:hv_24x7_all_events.test_all_events: STARTED
 (1/1) perf_24x7_all_events.py:hv_24x7_all_events.test_all_events: PASS (2163.66 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2023-11-16T14.36-84266c5/results.html
JOB TIME   : 2167.29 s