### PR TITLE
cpu/schbench: fix schbench test to incorporate the latest updates

### DIFF
--- a/cpu/schbench.py
+++ b/cpu/schbench.py
@@ -11,6 +11,7 @@
 #
 # See LICENSE for more details.
 # Author: Abhishek Goel<huntbag@linux.vnet.ibm.com>
+# Update: Aboorva Devarajan<aboorvad@linux.vnet.ibm.com>
 
 import json
 import os
@@ -55,69 +56,137 @@ class Schbench(Test):
                 self.cancel("%s is needed for the test to be run" % package)
         url = 'https://git.kernel.org/pub/scm/linux/kernel/git/mason/schbench.git'
         schbench_url = self.params.get("schbench_url", default=url)
-        git.get_repo(schbench_url, destination_dir=self.workdir)
 
+        git.get_repo(schbench_url, destination_dir=self.workdir)
         os.chdir(self.workdir)
         build.make(self.workdir)
 
-    def test(self):
+    def parse_schbench_data(self, data):
+        results = {}
+        current_category = None
+        current_percentiles = None
+        category_mapping = {
+            "Wakeup Latencies percentiles": "wakeup_latencies_percentiles",
+            "Request Latencies percentiles": "request_latencies_percentiles",
+            "RPS percentiles (requests)": "rps_percentiles",
+        }
+        # Find the last occurrence of "Wakeup Latencies percentiles"
+        last_occurrence_index = -1
+        for i, line in enumerate(data):
+            if "Wakeup Latencies percentiles" in line:
+                last_occurrence_index = i
+        # Process data starting from the last occurrence
+        if last_occurrence_index != -1:
+            current_category = None
+            current_percentiles = None
+            data = data[last_occurrence_index:]
+            for line in data:
+                for category_name, category_key in category_mapping.items():
+                    if category_name in line:
+                        current_category = category_key
+                        current_percentiles = results.setdefault(
+                            current_category, {
+                                "percentiles": [],
+                                "min_max": {}
+                            })
+                        break  # Exit the loop once a match is found
+                if current_category and line.strip():
+                    match = re.match(
+                        r'\s*(\*?)\s*(\d+\.\d+)th: (\d+)\s+\((\d+) samples\)',
+                        line)
+                    if match:
+                        percentile, latency, samples = match.group(
+                            2), match.group(3), match.group(4)
+                        current_percentile = {
+                            f"percentile_{percentile}": {
+                                "latency": latency,
+                                "samples": samples
+                            }
+                        }
+                        current_percentiles["percentiles"].append(
+                            current_percentile)
+                    elif "min=" in line:
+                        min_max_match = re.match(r'\s*min=(\d+), max=(\d+)',
+                                                 line)
+                        if min_max_match:
+                            current_percentiles["min_max"][
+                                "min"] = min_max_match.group(1)
+                            current_percentiles["min_max"][
+                                "max"] = min_max_match.group(2)
+                    elif "average rps:" in line:
+                        average_rps_match = re.match(
+                            r'average rps: (\d+\.\d+)', line)
+                        if average_rps_match:
+                            results["average_rps"] = float(
+                                average_rps_match.group(1))
+        return results
 
-        perfstat = self.params.get('perfstat', default='')
-        if perfstat:
-            perfstat = 'perf stat ' + perfstat
-        taskset = self.params.get('taskset', default='')
-        if taskset:
-            taskset = 'taskset -c ' + taskset
-        num_threads = self.params.get('num_threads', default=10)
-        num_workers = self.params.get('num_workers', default=10)
-        bytes = self.params.get('bytes', default=1000)
-        runtime = self.params.get('runtime', default=100)
-        cputime = self.params.get('cputime', default=10000)
-        autobench = self.params.get('autobench', default=False)
-        args = '-m %s -t %s -p %s -r %s -s %s ' % (num_threads, num_workers,
-                                                   bytes, runtime, cputime)
-
-        if autobench:
-            args += '-a'
-
-        cmd = "%s %s %s/schbench %s" % (perfstat, taskset, self.workdir, args)
-        res = process.run(cmd, ignore_status=True, shell=True)
-        if res.exit_status:
-            self.fail("The test failed. Failed command is %s" % cmd)
-
-        records = {'runtime': runtime}
-        lines = res.stdout.decode().splitlines()
-        pattern = re.compile(r'transfer: (.*?) ops/sec (.*?)MB/s')
-        avg_rec = pattern.findall(lines[0])[0]
-        records['ops'] = avg_rec[0]
-        records['ops_rate'] = avg_rec[1]
-
-        parsed_lines = []
-        count = 0
-        erlines = res.stderr.decode().splitlines()
-        for line in erlines:
-            if count:
-                parsed_lines.append(line)
-                count += 1
-                # gather logs till 99.9th percentile
-                if count == 8:
-                    break
+    def parse_perf_data(self, data):
+        # Initialize variables to store parsed data
+        results = {}
+        in_performance_stats = False
+        # Use regular expressions to extract the desired information
+        for line in data:
+            if "Performance counter stats" in line:
+                in_performance_stats = True
                 continue
-            if line.startswith('Latency percentiles'):
-                count = 1
-                parsed_lines.append(line)
-        pattern = re.compile(r'\(s\) \((.*?) total samples\)')
-        records['total_samples'] = pattern.findall(parsed_lines[0])[0]
-        parsed_lines = parsed_lines[1:]
+            if in_performance_stats and line.strip():
+                match = re.match(
+                    r'\s*([\d,.]+)\s+([^#]+)\s+#\s*([\d,.]+)\s*([^#]+)?', line)
+                if match:
+                    raw_value = match.group(1).replace(',', '').strip()
+                    key = match.group(2).strip()
+                    unit_value = match.group(3).replace(',', '').strip()
+                    unit = match.group(4).strip() if match.group(4) else ""
+                    if key not in results:
+                        results[key] = {}
+                    results[key]["raw"] = float(raw_value)
+                    if unit:
+                        results[key][unit] = float(unit_value)
+        # Print the JSON data
+        return results
 
-        pattern = re.compile(r'(.*?)th: (.*?) \((.*?) samples\)')
-        for line in parsed_lines:
-            values = pattern.findall(line)[0]
-            key = values[0].replace('\t', '')
-            records[key] = values[1]
-            records['samples_%s' % key] = values[2]
-
-        json_object = json.dumps(records)
+    def test(self):
+        # Extract parameters from self.params with defaults
+        perf_stat = self.params.get('perf_stat', default='')
+        taskset = self.params.get('taskset', default='')
+        locking_enabled = self.params.get('locking', default=False)
+        num_threads = self.params.get('num_threads', default=1)
+        num_workers = self.params.get('num_workers', default=1)
+        cache_footprint = self.params.get('cache_footprint', default=256)
+        num_operations = self.params.get('num_operations', default=5)
+        byte_size = self.params.get('bytes', default=0)
+        requests_per_second = self.params.get('rps', default=100)
+        runtime = self.params.get('runtime', default=5)
+        warmup_time = self.params.get('warmuptime', default=0)
+        autobench_enabled = self.params.get('autobench', default=False)
+        # Construct the args string using a formatted string
+        args = (
+            f'-m {num_threads} -t {num_workers} -p {byte_size} -r {runtime} '
+            f'-i {runtime} -F {cache_footprint} -n {num_operations} -R {requests_per_second} '
+            f'-w {warmup_time} {"-A" if autobench_enabled else ""} {"-L" if locking_enabled else ""}'
+        )
+        # Build the command string for running the benchmark
+        cmd = " ".join(
+            filter(None, [
+                'perf stat' if perf_stat else None,
+                f'taskset -c {taskset}' if taskset else None,
+                f"{self.workdir}/schbench", args
+            ])
+        )
+        # Run the benchmark command
+        res = process.run(cmd, ignore_status=True, shell=True)
+        # Check for failure and handle accordingly
+        if res.exit_status:
+            self.fail(f"The test failed. Failed command is {cmd}")
+        # Parse schbench data
+        data = res.stderr.decode().splitlines()
+        result = self.parse_schbench_data(data)
+        # Include perf data if perf_stat is enabled
+        if perf_stat:
+            result.update(self.parse_perf_data(data))
+        # Write result to JSON file
+        json_object = json.dumps(result, indent=4)
         logfile = os.path.join(self.logdir, "schbench.json")
         with open(logfile, "w") as outfile:
             outfile.write(json_object)

--- a/cpu/schbench.py.data/schbench.yaml
+++ b/cpu/schbench.py.data/schbench.yaml
@@ -1,25 +1,39 @@
-schbench_url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mason/schbench.git'
-perf:
+schbench_url: !mux
+    default: 
+        schbench_url: 'https://git.kernel.org/pub/scm/linux/kernel/git/mason/schbench.git'
+perf_stat: !mux
     default:
-        perfstat: '-a'
-pin: !mux
+        perf_stat: ''
+taskset: !mux
     default:
-        taskset: '0'
-threads: !mux
+        taskset: ''
+locking: !mux
     default:
-        num_threads: 10
-workers: !mux
+        locking: True
+num_threads: !mux
     default:
-        num_workers: 10
+        num_threads: 1
+num_workers: !mux
+    default:
+        num_workers: 1
+cache_footprint:
+    default:
+        cache_footprint: 256
 bytes: !mux
     default:
-        bytes: 1000
-duration: !mux
+        bytes: 0
+runtime: !mux
     default:
-        runtime: 100
-cpu_duration: !mux
-    default:
-        cputime: 10000
-mode:
+        runtime: 10
+autobench: !mux
     default:
         autobench: False
+rps: !mux
+    default:
+        rps: 0
+num_operations: !mux
+    default:
+        num_operations: 5
+warmuptime: !mux
+    default:
+        warmuptime: 0


### PR DESCRIPTION
This patch is intended to revise the script by integrating the most recent updates from latest schbench (upstream).


**Before Patch:**

```
# avocado run cpu/schbench.py
JOB ID     : e0a0a4c0718efe23a57a0c890c5d52b15a88d85f
JOB LOG    : /root/avocado/job-results/job-2023-11-24T01.42-e0a0a4c/job.log
 (1/1) cpu/schbench.py:Schbench.test: STARTED
 (1/1) cpu/schbench.py:Schbench.test: FAIL: The test failed. Failed command is   /root/avocado/job-results/job-2023-11-24T01.42-e0a0a4c/test-results/1-cpu_schbench.py_Schbench.test/tmp_dirqc2plqkc/1-cpu_schbench.py_Schbench.test/schbench -m 10 -t 10 -p 1000 -r 100 -s 10000  (0.96 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 3.54 s

Test summary:
cpu/schbench.py:Schbench.test: FAIL
```

**After Patch:**


```
# avocado run cpu/schbench.py
JOB ID     : 2e3c8a2a34189965dd859fea3c06c0462e133304
JOB LOG    : /root/avocado/job-results/job-2023-11-23T23.55-2e3c8a2/job.log
 (1/1) cpu/schbench.py:Schbench.test: STARTED
 (1/1) cpu/schbench.py:Schbench.test: PASS (6.97 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 18.22 s
```

**Raw Logs:**

```
[stdlog] 2023-11-23 23:55:26,142 avocado.utils.process INFO | Running '  /root/avocado/job-results/job-2023-11-23T23.55-2e3c8a2/test-results/1-cpu_schbench.py_Schbench.test/tmp_dirxjcryda_/1-cpu_schbench.py_Schbench.test/schbench -m 1 -t 1 -p 0 -r 5 -i 5                 -F 256 -n 5 -R 100 -w 0 -L '
 DEBUG| [stderr] Wakeup Latencies percentiles (usec) runtime 5 (s) (64 total samples)
 DEBUG| [stderr] 	  50.0th: 13         (30 samples)
 DEBUG| [stderr] 	  90.0th: 13         (0 samples)
 DEBUG| [stderr] 	* 99.0th: 21         (3 samples)
 DEBUG| [stderr] 	  99.9th: 21         (0 samples)
 DEBUG| [stderr] 	  min=12, max=21
 DEBUG| [stderr] Request Latencies percentiles (usec) runtime 5 (s) (500 total samples)
 DEBUG| [stderr] 	  50.0th: 5288       (0 samples)
 DEBUG| [stderr] 	  90.0th: 5304       (135 samples)
 DEBUG| [stderr] 	* 99.0th: 6888       (38 samples)
 DEBUG| [stderr] 	  99.9th: 8400       (5 samples)
 DEBUG| [stderr] 	  min=5284, max=8396
 DEBUG| [stderr] RPS percentiles (requests) runtime 5 (s) (6 total samples)
 DEBUG| [stderr] 	  20.0th: 99         (6 samples)
 DEBUG| [stderr] 	* 50.0th: 99         (0 samples)
 DEBUG| [stderr] 	  90.0th: 99         (0 samples)
 DEBUG| [stderr] 	  min=99, max=99
 DEBUG| [stderr] current rps: 99.99
 DEBUG| [stderr] Wakeup Latencies percentiles (usec) runtime 5 (s) (65 total samples)
 DEBUG| [stderr] 	  50.0th: 13         (30 samples)
 DEBUG| [stderr] 	  90.0th: 13         (0 samples)
 DEBUG| [stderr] 	* 99.0th: 21         (3 samples)
 DEBUG| [stderr] 	  99.9th: 21         (0 samples)
 DEBUG| [stderr] 	  min=12, max=21
 DEBUG| [stderr] Request Latencies percentiles (usec) runtime 5 (s) (508 total samples)
 DEBUG| [stderr] 	  50.0th: 5288       (0 samples)
 DEBUG| [stderr] 	  90.0th: 5304       (135 samples)
 DEBUG| [stderr] 	* 99.0th: 6888       (38 samples)
 DEBUG| [stderr] 	  99.9th: 8400       (5 samples)
 DEBUG| [stderr] 	  min=5284, max=8396
 DEBUG| [stderr] RPS percentiles (requests) runtime 5 (s) (6 total samples)
 DEBUG| [stderr] 	  20.0th: 99         (6 samples)
 DEBUG| [stderr] 	* 50.0th: 99         (0 samples)
 DEBUG| [stderr] 	  90.0th: 99         (0 samples)
 DEBUG| [stderr] 	  min=99, max=99
 DEBUG| [stderr] average rps: 101.60
```

**Parsed Output**
```
# cat ./test-results/1-cpu_schbench.py_Schbench.test/schbench.json
{
    "wakeup_latencies_percentiles": {
        "percentiles": [
            {
                "percentile_50.0": {
                    "latency": "13",
                    "samples": "30"
                }
            },
            {
                "percentile_90.0": {
                    "latency": "13",
                    "samples": "0"
                }
            },
            {
                "percentile_99.0": {
                    "latency": "21",
                    "samples": "3"
                }
            },
            {
                "percentile_99.9": {
                    "latency": "21",
                    "samples": "0"
                }
            }
        ],
        "min_max": {
            "min": "12",
            "max": "21"
        }
    },
    "request_latencies_percentiles": {
        "percentiles": [
            {
                "percentile_50.0": {
                    "latency": "5288",
                    "samples": "0"
                }
            },
            {
                "percentile_90.0": {
                    "latency": "5304",
                    "samples": "135"
                }
            },
            {
                "percentile_99.0": {
                    "latency": "6888",
                    "samples": "38"
                }
            },
            {
                "percentile_99.9": {
                    "latency": "8400",
                    "samples": "5"
                }
            }
        ],
        "min_max": {
            "min": "5284",
            "max": "8396"
        }
    },
    "rps_percentiles": {
        "percentiles": [
            {
                "percentile_20.0": {
                    "latency": "99",
                    "samples": "6"
                }
            },
            {
                "percentile_50.0": {
                    "latency": "99",
                    "samples": "0"
                }
            },
            {
                "percentile_90.0": {
                    "latency": "99",
                    "samples": "0"
                }
            }
        ],
        "min_max": {
            "min": "99",
            "max": "99"
        }
    },
    "average_rps": 101.6
}
```