### PR TITLE
fix package dependency for aiostress

### DIFF
--- a/perf/aiostress.py
+++ b/perf/aiostress.py
@@ -23,7 +23,7 @@
 import os
 
 from avocado import Test
-from avocado.utils import process, archive, build
+from avocado.utils import process, archive, build, distro
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -41,7 +41,14 @@ class Aiostress(Test):
          testcases/kernel/io/ltp-aiodio/aio-stress.c
         """
         smm = SoftwareManager()
-        packages = ['make', 'gcc']
+        packages = ['make', 'gcc', 'autoconf', 'automake', 'pkg-config']
+        dist_name = distro.detect().name.lower()
+        if dist_name == 'ubuntu':
+            packages.extend(['libaio1', 'libaio-dev'])
+        elif dist_name in ['centos', 'fedora', 'rhel']:
+            packages.extend(['libaio', 'libaio-devel'])
+        elif dist_name == 'suse':
+            packages.extend(['libaio1', 'libaio-devel'])
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)


### PR DESCRIPTION
aiostress test compilation fails with libaio and other pkg dependency. 
Add dependent pkgs to compile ltp first and run aiostress test.

before fix:
avocado run aiostress.py
JOB ID : a7d12e0a55835858a27871d458b3abb21607e718
JOB LOG : /home/avocado-fvt-wrapper/results/job-2023-11-28T03.47-a7d12e0/job.log
(1/1) aiostress.py:Aiostress.test: STARTED
(1/1) aiostress.py:Aiostress.test: ERROR: Command 'make autotools' failed.\nstdout: b"sed -n '1 {s:LTP-:m4_define([LTP_VERSION],[:;s:$:]):;p;q}
' VERSION > m4/ltp-version.m4\nmake -C testcases/realtime autotools\nmake -C testcases/open_posix_testsuite autotools\naclocal -I m4\nmake[1]: Entering dire... (2.99 s)
RESULTS : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML : /home/avocado-fvt-wrapper/results/job-2023-11-28T03.47-a7d12e0/results.html
JOB TIME : 94.10 s

avocado run aiostress.py
JOB ID : ad7dff39d865d9a93b07ed8def66cd7abe6ce979
JOB LOG : /home/avocado-fvt-wrapper/results/job-2023-11-28T03.55-ad7dff3/job.log
(1/1) aiostress.py:Aiostress.test: STARTED
(1/1) aiostress.py:Aiostress.test: ERROR: Command './aio-stress' failed.\nstdout: b''\nstderr: b'tst_test.c:1149: TCONF: test requires libaio and its development packages\n'\nadditional_info: None (19.78 s)
RESULTS : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML : /home/avocado-fvt-wrapper/results/job-2023-11-28T03.55-ad7dff3/results.html
JOB TIME : 44.11 s

after fix:
avocado run aiostress.py
JOB ID     : 90f7b332c289a9006ec4e92a7b3166d97422bf6a
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2023-11-28T04.03-90f7b33/job.log
 (1/1) aiostress.py:Aiostress.test: STARTED
 (1/1) aiostress.py:Aiostress.test: PASS (14.15 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2023-11-28T04.03-90f7b33/results.html
JOB TIME   : 37.35 s

[debug.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/13486050/debug.log)