### PR TITLE
Rename test 'test' to 'test_basic' in order to run singly

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -166,7 +166,7 @@ class Numactl(Test):
         if " 0% packet loss" not in output:
             self.cancel("failed due to packet loss")
 
-    def test(self):
+    def test_basic(self):
 
         if build.make(self.sourcedir, extra_args='-k -j 1'
                       ' test', ignore_status=True):


### PR DESCRIPTION
On running 'avocado run numactl.py:test' all the tests are being executed. As per docuemntation, when the test references are about Instrumented Tests, Avocado will find any Instrumented test that starts with the reference, like a “wildcard”.

Thus renaming 'test' to 'test_basic' in order to be able to run it singly.