### PR TITLE
ltp_fs : resolve interactive user check

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -218,7 +218,13 @@ class LTP(Test):
                          skipfilepath))
         if self.mem_leak:
             self.args += " -M %s" % self.mem_leak
-        cmd = "%s %s" % (os.path.join(self.ltpbin_dir, 'runltp'), self.args)
+        self.ltpbin_path = os.path.join(self.ltpbin_dir, 'runltp')
+        with open(self.ltpbin_path, 'r') as lfile:
+            data = lfile.read()
+            data = data.replace("    ${LTPROOT}/IDcheck.sh || \\", "    echo -e \"y\" | ${LTPROOT}/IDcheck.sh || \\")
+        with open(self.ltpbin_path, 'w') as ofile:
+            ofile.write(data)
+        cmd = '%s %s' % (self.ltpbin_path, self.args)
         process.run(cmd, ignore_status=True)
         # Walk the ltp.log and try detect failed tests from lines like these:
         # msgctl04                                           FAIL       2

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -316,8 +316,13 @@ class LtpFs(Test):
         self.args += (" -q -p -l %s -C %s -d %s"
                       % (logfile, failcmdfile, self.dir))
         self.log.info("Args = %s", self.args)
-        cmd = '%s %s' % (os.path.join(self.ltpbin_dir, 'runltp'),
-                         self.args)
+        self.ltpbin_path = os.path.join(self.ltpbin_dir, 'runltp')
+        with open(self.ltpbin_path, 'r') as lfile:
+            data = lfile.read()
+            data = data.replace("    ${LTPROOT}/IDcheck.sh || \\", "    echo -e \"y\" | ${LTPROOT}/IDcheck.sh || \\")
+        with open(self.ltpbin_path, 'w') as ofile:
+            ofile.write(data)
+        cmd = '%s %s' % (self.ltpbin_path, self.args)
         result = process.run(cmd, ignore_status=True)
         # Walk the stdout and try detect failed tests from lines
         # like these:


### PR DESCRIPTION
With latest ltp source, a user id check has been added causing the test to wait for user response to this check

..user ids and/or groups are missing, would you like these created? [y/N]

This code solves this check by passing the 'y' string to automatically proceed the test