### PR TITLE
fix ltp fsx test

### DIFF
--- a/generic/ltp.py.data/ltp-fs.yaml
+++ b/generic/ltp.py.data/ltp-fs.yaml
@@ -5,7 +5,9 @@ runltp: !mux
         args: '-f fs'
     fs_perms_simple:
         args: '-f fs_perms_simple'
-    fsx:
-        args: '-f fsx'
+    fsx-linux:
+        args: '-f ltp-aiodio.part3'
     fs_bind:
         args: '-f fs_bind'
+    fs_readonly:
+        args: '-f fs_readonly'


### PR DESCRIPTION
fsx test has been removed from runtest suite in LTP. So renaming fsx to ltp-aiodio.part3 which covers fsx-linux tests.
Also add fs_readonly tests.
https://github.com/linux-test-project/ltp/commit/fb2b6a0b3c840aa80229acf4360b7bdc3ced5edb

avocado run --max-parallel-tasks=1 ltp.py -m ltp.py.data/ltp-fs.yaml
Fetching asset from ltp.py:LTP.test
Fetching asset from ltp.py:LTP.test
JOB ID     : 6ec078fe0e728bb3e828c91317d52c5e5218f7b1
JOB LOG    : /home/siri/avocado-fvt-wrapper/results/job-2024-01-08T18.28-6ec078f/job.log
 (1/5) ltp.py:LTP.test;run-runltp-fs-a975: STARTED
 (1/5) ltp.py:LTP.test;run-runltp-fs-a975:  PASS (1599.48 s)
 (2/5) ltp.py:LTP.test;run-runltp-fs_perms_simple-1a00: STARTED
 (2/5) ltp.py:LTP.test;run-runltp-fs_perms_simple-1a00:  PASS (207.43 s)
 (3/5) ltp.py:LTP.test;run-runltp-fsx-linux-f1c1: STARTED
 (3/5) ltp.py:LTP.test;run-runltp-fsx-linux-f1c1:  FAIL: LTP tests failed: ['fsx22'] (1070.76 s)
 (4/5) ltp.py:LTP.test;run-runltp-fs_bind-6af3: STARTED
 (4/5) ltp.py:LTP.test;run-runltp-fs_bind-6af3:  PASS (249.36 s)
 (5/5) ltp.py:LTP.test;run-runltp-fs_readonly-5c13: STARTED
 (5/5) ltp.py:LTP.test;run-runltp-fs_readonly-5c13:  PASS (207.76 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/siri/avocado-fvt-wrapper/results/job-2024-01-08T18.28-6ec078f/results.html
JOB TIME   : 3479.21 s

[job.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/13863083/job.log)