### PR TITLE
network_stress: support hw addr as input name

### DIFF
--- a/cpu/numactl.py
+++ b/cpu/numactl.py
@@ -69,23 +69,24 @@ class Numactl(Test):
         process.run('./configure', shell=True)
 
         build.make(self.sourcedir)
-
-        self.iface = self.params.get("interface", default="")
+        self.localhost = LocalHost()
+        self.interface = None
+        interfaces = os.listdir('/sys/class/net')
+        iface = self.params.get("interface", default="")
         self.disk = self.params.get("disk", default="")
-
-        if self.iface:
+        if iface:
+            if iface in interfaces:
+                self.interface = iface
+            elif self.localhost.validate_mac_addr(iface) and iface in self.localhost.get_all_hwaddr():
+                self.interface = self.localhost.get_interface_by_hwaddr(iface).name
+            else:
+                self.cancel("Please check the network device")
             self.ping_count = self.params.get("ping_count", default=100)
             self.peer = self.params.get("peer_ip", default="")
-            interfaces = os.listdir('/sys/class/net')
-            if not self.iface:
-                self.cancel("Please specify interface to be used")
-            if self.iface not in interfaces:
-                self.cancel("%s interface is not available" % self.iface)
             if not self.peer:
                 self.cancel("peer ip need to specify in YAML")
             self.ipaddr = self.params.get("host_ip", default="")
-            self.localhost = LocalHost()
-            self.networkinterface = NetworkInterface(self.iface,
+            self.networkinterface = NetworkInterface(self.interface,
                                                      self.localhost)
             if not self.networkinterface.validate_ipv4_format(self.ipaddr):
                 self.cancel("Host IP formatt in YAML is incorrect,"
@@ -178,11 +179,11 @@ class Numactl(Test):
         '''
         To check memory interleave on NUMA nodes.
         '''
-        if not self.iface and not self.disk:
+        if not self.interface and not self.disk:
             self.cancel("Network inferface or disk/device input missing")
-        if self.iface:
+        if self.interface:
             cmd = "numactl --interleave=all ping -I %s %s -c %s -f"\
-                % (self.iface, self.peer, self.ping_count)
+                % (self.interface, self.peer, self.ping_count)
             self.numa_ping(cmd)
 
         if self.disk:
@@ -198,11 +199,11 @@ class Numactl(Test):
         '''
         Test memory allocation on the current node
         '''
-        if not self.iface and not self.disk:
+        if not self.interface and not self.disk:
             self.cancel("Network inferface or disk/device input missing")
-        if self.iface:
+        if self.interface:
             cmd = "numactl --localalloc ping -I %s %s -c %s -f"\
-                % (self.iface, self.peer, self.ping_count)
+                % (self.interface, self.peer, self.ping_count)
             self.numa_ping(cmd)
 
         if self.disk:
@@ -218,17 +219,17 @@ class Numactl(Test):
         '''
         Test Preferably allocate memory on node
         '''
-        if not self.iface and not self.disk:
+        if not self.interface and not self.disk:
             self.cancel("Network inferface or disk/device input missing")
 
         if self.check_numa_nodes():
 
             self.node_number = [key for key in self.numa_dict.keys()][1]
 
-            if self.iface:
+            if self.interface:
                 cmd = "numactl --preferred=%s  ping -I %s %s -c %s -f" \
                         % (self.node_number,
-                           self.iface,
+                           self.interface,
                            self.peer,
                            self.ping_count)
                 self.numa_ping(cmd)
@@ -247,7 +248,7 @@ class Numactl(Test):
         '''
         Test CPU and memory bind
         '''
-        if not self.iface and not self.disk:
+        if not self.interface and not self.disk:
             self.cancel("Network inferface or disk/device input missing")
         if self.check_numa_nodes():
             self.first_cpu_node_number = [key
@@ -259,13 +260,13 @@ class Numactl(Test):
             self.membind_node_number = [key
                                         for key
                                         in self.numa_dict.keys()][1]
-            if self.iface:
+            if self.interface:
                 for cpu in [self.first_cpu_node_number,
                             self.second_cpu_node_number]:
                     cmd = "numactl --cpunodebind=%s --membind=%s ping -I %s \
                            %s -c %s -f" % (cpu,
                                            self.membind_node_number,
-                                           self.iface,
+                                           self.interface,
                                            self.peer,
                                            self.ping_count)
                     self.numa_ping(cmd)
@@ -286,16 +287,16 @@ class Numactl(Test):
         '''
         Test physcial  CPU binds
         '''
-        if not self.iface and not self.disk:
+        if not self.interface and not self.disk:
             self.cancel("Network inferface or disk/device input missing")
         if self.check_numa_nodes():
             self.cpu_number = [value
                                for value
                                in self.numa_dict.values()][0][1]
-            if self.iface:
+            if self.interface:
 
                 cmd = "numactl --physcpubind=%s ping -I %s %s -c %s -f"\
-                    % (self.cpu_number, self.iface, self.peer, self.ping_count)
+                    % (self.cpu_number, self.interface, self.peer, self.ping_count)
                 self.numa_ping(cmd)
 
             if self.disk:
@@ -325,7 +326,7 @@ class Numactl(Test):
         '''
         Cleaning up Host IP address
         '''
-        if self.iface:
+        if self.interface:
             if self.networkinterface:
                 self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
                 try:

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -23,7 +23,6 @@ test lro and gro and interface
 
 import os
 import hashlib
-import netifaces
 from avocado import Test
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import process
@@ -56,21 +55,25 @@ class NetworkTest(Test):
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel("%s package is need to test" % pkg)
-        interfaces = netifaces.interfaces()
-        interface = self.params.get("interface")
-        if interface not in interfaces:
-            self.cancel("%s interface is not available" % interface)
-        self.iface = interface
+        interfaces = os.listdir('/sys/class/net')
+        local = LocalHost()
+        device = self.params.get("interface")
+        if device in interfaces:
+            self.interface = device
+        elif local.validate_mac_addr(device) and device in local.get_all_hwaddr():
+            self.interface = local.get_interface_by_hwaddr(device).name
+        else:
+            self.interface = None
+            self.cancel("Please check the network device")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
         self.ip_config = self.params.get("ip_config", default=True)
         self.hbond = self.params.get("hbond", default=False)
-        local = LocalHost()
         if self.hbond:
             self.networkinterface = NetworkInterface(
-                self.iface, local, if_type='Bond')
+                self.interface, local, if_type='Bond')
         else:
-            self.networkinterface = NetworkInterface(self.iface, local)
+            self.networkinterface = NetworkInterface(self.interface, local)
         if self.ip_config:
             try:
                 self.networkinterface.add_ipaddr(self.ipaddr, self.netmask)
@@ -149,7 +152,7 @@ class NetworkTest(Test):
         '''
         ro_type = "lro"
         ro_type_full = "large-receive-offload"
-        path = '/sys/class/net/%s/device/uevent' % self.iface
+        path = '/sys/class/net/%s/device/uevent' % self.interface
         if os.path.exists(path):
             output = open(path, 'r').read()
             for line in output.splitlines():
@@ -250,8 +253,8 @@ class NetworkTest(Test):
         '''
         Test Statistics
         '''
-        rx_file = "/sys/class/net/%s/statistics/rx_packets" % self.iface
-        tx_file = "/sys/class/net/%s/statistics/tx_packets" % self.iface
+        rx_file = "/sys/class/net/%s/statistics/rx_packets" % self.interface
+        tx_file = "/sys/class/net/%s/statistics/tx_packets" % self.interface
         rx_before = genio.read_file(rx_file)
         tx_before = genio.read_file(tx_file)
         self.networkinterface.ping_check(self.peer, self.count, options='-f')
@@ -289,7 +292,7 @@ class NetworkTest(Test):
         '''
         Change the state of LRO / GRO / GSO / TSO to specified state
         '''
-        cmd = "ethtool -K %s %s %s" % (self.iface, ro_type, state)
+        cmd = "ethtool -K %s %s %s" % (self.interface, ro_type, state)
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             return False
         if self.offload_state(ro_type_full) != state:
@@ -302,7 +305,7 @@ class NetworkTest(Test):
         If the state can not be changed, we return 'fixed'.
         If any other error, we return ''.
         '''
-        cmd = "ethtool -k %s" % self.iface
+        cmd = "ethtool -k %s" % self.interface
         output = process.system_output(cmd, shell=True,
                                        ignore_status=True).decode("utf-8")
         for line in output.splitlines():
@@ -316,11 +319,11 @@ class NetworkTest(Test):
         '''
         promisc mode testing
         '''
-        cmd = "ip link set %s promisc on" % self.iface
+        cmd = "ip link set %s promisc on" % self.interface
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("failed to enable promisc mode")
         self.networkinterface.ping_check(self.peer, self.count, options='-f')
-        cmd = "ip link set %s promisc off" % self.iface
+        cmd = "ip link set %s promisc off" % self.interface
         if process.system(cmd, shell=True, ignore_status=True) != 0:
             self.fail("failed to disable promisc mode")
         self.networkinterface.ping_check(self.peer, count=5)


### PR DESCRIPTION
Add support for mac addr as input, in case if the
device names are not persistent across os install
the test should still run via unique mac addr in
end to end automated environment