### PR TITLE
perf_duplicate: fix package dependency

### DIFF
--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -34,14 +34,8 @@ class PerfDuplicateProbe(Test):
         if 'Ubuntu' in distro_name:
             deps.extend(['linux-tools-common', 'linux-tools-%s' %
                          platform.uname()[2]])
-        elif 'rhel' in distro_name:
+        elif distro_name in ['rhel', 'SuSE']:
             deps.extend(['perf'])
-            if run_type == 'distro':
-                deps.extend(['kernel-debuginfo'])
-        elif 'SuSE' in distro_name:
-            deps.extend(['perf'])
-            if run_type == 'distro':
-                deps.extend(['kernel-default-debuginfo'])
         else:
             self.cancel("Install the package for perf supported\
                       by %s" % distro_name)


### PR DESCRIPTION
remove kernel-default-debuginfo package as it's not required to run the test.

on rhel
avocado run perf_duplicate_probe.py
JOB ID     : a475d0454a40ec7433a46c014c9c4382a2e0383c
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-01-17T02.37-a475d04/job.log
 (1/1) perf_duplicate_probe.py:PerfDuplicateProbe.test_duplicate_probe: STARTED
 (1/1) perf_duplicate_probe.py:PerfDuplicateProbe.test_duplicate_probe: PASS (0.93 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-01-17T02.37-a475d04/results.html
JOB TIME   : 5.16 s

on suse
avocado run perf_duplicate_probe.py
JOB ID     : 432a65c768efb31dce3478e05260a20cfec5d578
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-01-17T03.47-432a65c/job.log
 (1/1) perf_duplicate_probe.py:PerfDuplicateProbe.test_duplicate_probe: STARTED
 (1/1) perf_duplicate_probe.py:PerfDuplicateProbe.test_duplicate_probe: PASS (0.54 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-01-17T03.47-432a65c/results.html
JOB TIME   : 28.42 s

[debug.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/13960698/debug.log)