### PR TITLE
perf/perf_top: fix group option

### DIFF
--- a/perf/perf_top.py
+++ b/perf/perf_top.py
@@ -74,9 +74,11 @@ class perf_top(Test):
         child = pexpect.spawn("perf top %s" % self.option, encoding='utf-8')
         time.sleep(10)
         child.logfile = sys.stdout
-        err = child.expect_exact(['Error: unknown option', pexpect.TIMEOUT])
+        err = child.expect_exact(
+            ['Error: ', 'perf: Segmentation fault', pexpect.TIMEOUT])
         child.send('q')
-        if err == 0:
+        exit_status = child.wait()
+        if exit_status != 0 or err == 0:
             self.fail("Unknown option %s" % self.option)
         dmesg.collect_errors_dmesg(['WARNING: CPU:', 'Oops', 'Segfault',
                                     'soft lockup', 'Unable to handle'])

--- a/perf/perf_top.py.data/perf_top.yaml
+++ b/perf/perf_top.py.data/perf_top.yaml
@@ -27,8 +27,6 @@ variants: !mux
         option: -f 5
     count-filter_full:
         option: --count-filter 5
-    group:
-        option: --group
     group-sort-idx:
         option: --group-sort-idx 1
     freq:


### PR DESCRIPTION
--group option has been removed from perf top, so remove the option from yaml file.
Enhance test to fail if exit status is non zero, any error message and when hit segmentation fault.

example of segfault error:
./perf top -g
perf: Segmentation fault
-------- backtrace --------
./perf[0x102aa6f8]
linux-vdso64.so.1(__kernel_sigtramp_rt64+0x0)[0x7fff83a10444]
./perf[0x1018e43c]
[0x7fff2debd7f0]
./perf[0x1012466c]
./perf[0x10288444]
./perf[0x10183b5c]
./perf[0x1017d83c]
./perf[0x101d3d48]
./perf[0x1003cb68]
./perf[0x1019cbc8]
./perf[0x1003c1b0]
/lib64/glibc-hwcaps/power10/libc.so.6(+0xaa0b0)[0x7fff824aa0b0]
/lib64/glibc-hwcaps/power10/libc.so.6(clone+0xa0)[0x7fff82552f48]

avocado run perf_top.py -m perf_top.py.data/perf_top.yaml --max-parallel-tasks=1
JOB ID     : 2a94f65e0b1a4bc51d5e6f00b02f230f0bc7ba74
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-01-17T08.39-2a94f65/job.log
 (01/82) perf_top.py:perf_top.test_top;run-variants-all_cpus-640d: STARTED
 (01/82) perf_top.py:perf_top.test_top;run-variants-all_cpus-640d:  PASS (44.85 s)
 (02/82) perf_top.py:perf_top.test_top;run-variants-all_cpus_full-15dd: STARTED
 (02/82) perf_top.py:perf_top.test_top;run-variants-all_cpus_full-15dd:  PASS (41.39 s)
 (03/82) perf_top.py:perf_top.test_top;run-variants-count-cce5: STARTED
 (03/82) perf_top.py:perf_top.test_top;run-variants-count-cce5:  PASS (40.37 s)
 (04/82) perf_top.py:perf_top.test_top;run-variants-count_full-dd4d: STARTED
 (04/82) perf_top.py:perf_top.test_top;run-variants-count_full-dd4d:  PASS (40.38 s)
 (05/82) perf_top.py:perf_top.test_top;run-variants-cpu-6c86: STARTED
 (05/82) perf_top.py:perf_top.test_top;run-variants-cpu-6c86:  PASS (40.37 s)
 (06/82) perf_top.py:perf_top.test_top;run-variants-cpu_full-d3f1: STARTED
 (06/82) perf_top.py:perf_top.test_top;run-variants-cpu_full-d3f1:  PASS (40.37 s)
 (07/82) perf_top.py:perf_top.test_top;run-variants-delay-fa60: STARTED
 (07/82) perf_top.py:perf_top.test_top;run-variants-delay-fa60:  PASS (40.37 s)
 (08/82) perf_top.py:perf_top.test_top;run-variants-delay_full-76fc: STARTED
 (08/82) perf_top.py:perf_top.test_top;run-variants-delay_full-76fc:  PASS (41.38 s)
 (09/82) perf_top.py:perf_top.test_top;run-variants-event-feab: STARTED
 (09/82) perf_top.py:perf_top.test_top;run-variants-event-feab:  PASS (40.40 s)
 (10/82) perf_top.py:perf_top.test_top;run-variants-event_full-f05e: STARTED
 (10/82) perf_top.py:perf_top.test_top;run-variants-event_full-f05e:  PASS (40.40 s)
 (11/82) perf_top.py:perf_top.test_top;run-variants-entries-b2ef: STARTED
 (11/82) perf_top.py:perf_top.test_top;run-variants-entries-b2ef:  PASS (40.38 s)
 (12/82) perf_top.py:perf_top.test_top;run-variants-entries_full-b44b: STARTED
 (12/82) perf_top.py:perf_top.test_top;run-variants-entries_full-b44b:  PASS (40.38 s)
 (13/82) perf_top.py:perf_top.test_top;run-variants-count-filter-a14f: STARTED
 (13/82) perf_top.py:perf_top.test_top;run-variants-count-filter-a14f:  PASS (40.38 s)
 (14/82) perf_top.py:perf_top.test_top;run-variants-count-filter_full-a3e4: STARTED
 (14/82) perf_top.py:perf_top.test_top;run-variants-count-filter_full-a3e4:  PASS (40.38 s)
 (15/82) perf_top.py:perf_top.test_top;run-variants-group-sort-idx-92e9: STARTED
 (15/82) perf_top.py:perf_top.test_top;run-variants-group-sort-idx-92e9:  PASS (40.38 s)
 (16/82) perf_top.py:perf_top.test_top;run-variants-freq-e983: STARTED
 (16/82) perf_top.py:perf_top.test_top;run-variants-freq-e983:  PASS (40.37 s)
 (17/82) perf_top.py:perf_top.test_top;run-variants-freq_full-080e: STARTED
 (17/82) perf_top.py:perf_top.test_top;run-variants-freq_full-080e:  PASS (40.38 s)
 (18/82) perf_top.py:perf_top.test_top;run-variants-inherit-f27f: STARTED
 (18/82) perf_top.py:perf_top.test_top;run-variants-inherit-f27f:  PASS (40.38 s)
 (19/82) perf_top.py:perf_top.test_top;run-variants-inherit_full-8699: STARTED
 (19/82) perf_top.py:perf_top.test_top;run-variants-inherit_full-8699:  PASS (40.38 s)
 (20/82) perf_top.py:perf_top.test_top;run-variants-vmlinux-a988: STARTED
 (20/82) perf_top.py:perf_top.test_top;run-variants-vmlinux-a988:  PASS (40.38 s)
 (21/82) perf_top.py:perf_top.test_top;run-variants-vmlinux_full-408b: STARTED
 (21/82) perf_top.py:perf_top.test_top;run-variants-vmlinux_full-408b:  PASS (40.38 s)
 (22/82) perf_top.py:perf_top.test_top;run-variants-ignore-vmlinux-cbcb: STARTED
 (22/82) perf_top.py:perf_top.test_top;run-variants-ignore-vmlinux-cbcb:  PASS (40.38 s)
 (23/82) perf_top.py:perf_top.test_top;run-variants-kallsyms-a36e: STARTED
 (23/82) perf_top.py:perf_top.test_top;run-variants-kallsyms-a36e:  PASS (40.37 s)
 (24/82) perf_top.py:perf_top.test_top;run-variants-mmap-pages-d58f: STARTED
 (24/82) perf_top.py:perf_top.test_top;run-variants-mmap-pages-d58f:  PASS (40.38 s)
 (25/82) perf_top.py:perf_top.test_top;run-variants-mmap-pages_full-48c3: STARTED
 (25/82) perf_top.py:perf_top.test_top;run-variants-mmap-pages_full-48c3:  PASS (40.38 s)
 (26/82) perf_top.py:perf_top.test_top;run-variants-pid-b5dd: STARTED
 (26/82) perf_top.py:perf_top.test_top;run-variants-pid-b5dd:  PASS (40.45 s)
 (27/82) perf_top.py:perf_top.test_top;run-variants-pid_full-2f6f: STARTED
 (27/82) perf_top.py:perf_top.test_top;run-variants-pid_full-2f6f:  PASS (40.43 s)
 (28/82) perf_top.py:perf_top.test_top;run-variants-tid-1026: STARTED
 (28/82) perf_top.py:perf_top.test_top;run-variants-tid-1026:  PASS (40.42 s)
 (29/82) perf_top.py:perf_top.test_top;run-variants-tid_full-1578: STARTED
 (29/82) perf_top.py:perf_top.test_top;run-variants-tid_full-1578:  PASS (40.44 s)
 (30/82) perf_top.py:perf_top.test_top;run-variants-uid-57b4: STARTED
 (30/82) perf_top.py:perf_top.test_top;run-variants-uid-57b4:  PASS (41.35 s)
 (31/82) perf_top.py:perf_top.test_top;run-variants-uid_full-48ab: STARTED
 (31/82) perf_top.py:perf_top.test_top;run-variants-uid_full-48ab:  PASS (41.35 s)
 (32/82) perf_top.py:perf_top.test_top;run-variants-realtime-64b4: STARTED
 (32/82) perf_top.py:perf_top.test_top;run-variants-realtime-64b4:  PASS (40.38 s)
 (33/82) perf_top.py:perf_top.test_top;run-variants-realtime_full-43a2: STARTED
 (33/82) perf_top.py:perf_top.test_top;run-variants-realtime_full-43a2:  PASS (40.38 s)
 (34/82) perf_top.py:perf_top.test_top;run-variants-sym-annotate-da20: STARTED
 (34/82) perf_top.py:perf_top.test_top;run-variants-sym-annotate-da20:  PASS (40.39 s)
 (35/82) perf_top.py:perf_top.test_top;run-variants-hide_kernel_symbols-13b2: STARTED
 (35/82) perf_top.py:perf_top.test_top;run-variants-hide_kernel_symbols-13b2:  PASS (40.36 s)
 (36/82) perf_top.py:perf_top.test_top;run-variants-hide_kernel_symbols_full-4465: STARTED
 (36/82) perf_top.py:perf_top.test_top;run-variants-hide_kernel_symbols_full-4465:  PASS (40.36 s)
 (37/82) perf_top.py:perf_top.test_top;run-variants-hide_user_symbols-db2c: STARTED
 (37/82) perf_top.py:perf_top.test_top;run-variants-hide_user_symbols-db2c:  PASS (40.37 s)
 (38/82) perf_top.py:perf_top.test_top;run-variants-hide_user_symbols_full-e72c: STARTED
 (38/82) perf_top.py:perf_top.test_top;run-variants-hide_user_symbols_full-e72c:  PASS (40.37 s)
 (39/82) perf_top.py:perf_top.test_top;run-variants-demangle-kernel-9461: STARTED
 (39/82) perf_top.py:perf_top.test_top;run-variants-demangle-kernel-9461:  PASS (41.38 s)
 (40/82) perf_top.py:perf_top.test_top;run-variants-dump-symtab-bca3: STARTED
 (40/82) perf_top.py:perf_top.test_top;run-variants-dump-symtab-bca3:  PASS (40.38 s)
 (41/82) perf_top.py:perf_top.test_top;run-variants-dump-symtab_full-ae9c: STARTED
 (41/82) perf_top.py:perf_top.test_top;run-variants-dump-symtab_full-ae9c:  PASS (41.38 s)
 (42/82) perf_top.py:perf_top.test_top;run-variants-verbose-6f91: STARTED
 (42/82) perf_top.py:perf_top.test_top;run-variants-verbose-6f91:  PASS (40.38 s)
 (43/82) perf_top.py:perf_top.test_top;run-variants-verbose_full-2b22: STARTED
 (43/82) perf_top.py:perf_top.test_top;run-variants-verbose_full-2b22:  PASS (41.38 s)
 (44/82) perf_top.py:perf_top.test_top;run-variants-zero-3cdd: STARTED
 (44/82) perf_top.py:perf_top.test_top;run-variants-zero-3cdd:  PASS (40.38 s)
 (45/82) perf_top.py:perf_top.test_top;run-variants-zero_full-34bd: STARTED
 (45/82) perf_top.py:perf_top.test_top;run-variants-zero_full-34bd:  PASS (40.38 s)
 (46/82) perf_top.py:perf_top.test_top;run-variants-sort-271d: STARTED
 (46/82) perf_top.py:perf_top.test_top;run-variants-sort-271d:  PASS (40.38 s)
 (47/82) perf_top.py:perf_top.test_top;run-variants-sort_full-70e4: STARTED
 (47/82) perf_top.py:perf_top.test_top;run-variants-sort_full-70e4:  PASS (40.38 s)
 (48/82) perf_top.py:perf_top.test_top;run-variants-fields-b66d: STARTED
 (48/82) perf_top.py:perf_top.test_top;run-variants-fields-b66d:  PASS (40.37 s)
 (49/82) perf_top.py:perf_top.test_top;run-variants-timehist-68b5: STARTED
 (49/82) perf_top.py:perf_top.test_top;run-variants-timehist-68b5:  PASS (40.38 s)
 (50/82) perf_top.py:perf_top.test_top;run-variants-show-nr-samples-7825: STARTED
 (50/82) perf_top.py:perf_top.test_top;run-variants-show-nr-samples-7825:  PASS (40.38 s)
 (51/82) perf_top.py:perf_top.test_top;run-variants-show-total-period-3bc2: STARTED
 (51/82) perf_top.py:perf_top.test_top;run-variants-show-total-period-3bc2:  PASS (41.38 s)
 (52/82) perf_top.py:perf_top.test_top;run-variants-dsos-be98: STARTED
 (52/82) perf_top.py:perf_top.test_top;run-variants-dsos-be98:  PASS (40.38 s)
 (53/82) perf_top.py:perf_top.test_top;run-variants-comms-0b4f: STARTED
 (53/82) perf_top.py:perf_top.test_top;run-variants-comms-0b4f:  PASS (41.39 s)
 (54/82) perf_top.py:perf_top.test_top;run-variants-symbols-1d7d: STARTED
 (54/82) perf_top.py:perf_top.test_top;run-variants-symbols-1d7d:  PASS (41.38 s)
 (55/82) perf_top.py:perf_top.test_top;run-variants-disassembler-style-2386: STARTED
 (55/82) perf_top.py:perf_top.test_top;run-variants-disassembler-style-2386:  PASS (40.38 s)
 (56/82) perf_top.py:perf_top.test_top;run-variants-prefix-903b: STARTED
 (56/82) perf_top.py:perf_top.test_top;run-variants-prefix-903b:  PASS (40.38 s)
 (57/82) perf_top.py:perf_top.test_top;run-variants-prefix-strip-3b01: STARTED
 (57/82) perf_top.py:perf_top.test_top;run-variants-prefix-strip-3b01:  PASS (40.38 s)
 (58/82) perf_top.py:perf_top.test_top;run-variants-source-878d: STARTED
 (58/82) perf_top.py:perf_top.test_top;run-variants-source-878d:  PASS (40.38 s)
 (59/82) perf_top.py:perf_top.test_top;run-variants-asm-raw-2884: STARTED
 (59/82) perf_top.py:perf_top.test_top;run-variants-asm-raw-2884:  PASS (40.38 s)
 (60/82) perf_top.py:perf_top.test_top;run-variants-call-graph-8da1: STARTED
 (60/82) perf_top.py:perf_top.test_top;run-variants-call-graph-8da1:  PASS (40.45 s)
 (61/82) perf_top.py:perf_top.test_top;run-variants-call-graph_full-aa8a: STARTED
 (61/82) perf_top.py:perf_top.test_top;run-variants-call-graph_full-aa8a:  PASS (40.46 s)
 (62/82) perf_top.py:perf_top.test_top;run-variants-children-1b93: STARTED
 (62/82) perf_top.py:perf_top.test_top;run-variants-children-1b93:  PASS (40.38 s)
 (63/82) perf_top.py:perf_top.test_top;run-variants-max-stack-ab39: STARTED
 (63/82) perf_top.py:perf_top.test_top;run-variants-max-stack-ab39:  PASS (40.38 s)
 (64/82) perf_top.py:perf_top.test_top;run-variants-percent-limit-16db: STARTED
 (64/82) perf_top.py:perf_top.test_top;run-variants-percent-limit-16db:  PASS (41.38 s)
 (65/82) perf_top.py:perf_top.test_top;run-variants-percentage-e855: STARTED
 (65/82) perf_top.py:perf_top.test_top;run-variants-percentage-e855:  PASS (40.38 s)
 (66/82) perf_top.py:perf_top.test_top;run-variants-column-widths-35ff: STARTED
 (66/82) perf_top.py:perf_top.test_top;run-variants-column-widths-35ff:  PASS (40.38 s)
 (67/82) perf_top.py:perf_top.test_top;run-variants-column-widths_full-a314: STARTED
 (67/82) perf_top.py:perf_top.test_top;run-variants-column-widths_full-a314:  PASS (40.38 s)
 (68/82) perf_top.py:perf_top.test_top;run-variants-proc-map-timeout-3622: STARTED
 (68/82) perf_top.py:perf_top.test_top;run-variants-proc-map-timeout-3622:  PASS (40.37 s)
 (69/82) perf_top.py:perf_top.test_top;run-variants-branch-any-9a57: STARTED
 (69/82) perf_top.py:perf_top.test_top;run-variants-branch-any-9a57:  PASS (40.38 s)
 (70/82) perf_top.py:perf_top.test_top;run-variants-branch-any_full-8625: STARTED
 (70/82) perf_top.py:perf_top.test_top;run-variants-branch-any_full-8625:  PASS (41.38 s)
 (71/82) perf_top.py:perf_top.test_top;run-variants-branch-filter-2be6: STARTED
 (71/82) perf_top.py:perf_top.test_top;run-variants-branch-filter-2be6:  PASS (40.38 s)
 (72/82) perf_top.py:perf_top.test_top;run-variants-branch-filter_full-c9f5: STARTED
 (72/82) perf_top.py:perf_top.test_top;run-variants-branch-filter_full-c9f5:  PASS (40.38 s)
 (73/82) perf_top.py:perf_top.test_top;run-variants-raw-trace-b3c1: STARTED
 (73/82) perf_top.py:perf_top.test_top;run-variants-raw-trace-b3c1:  PASS (40.38 s)
 (74/82) perf_top.py:perf_top.test_top;run-variants-hierarchy-2803: STARTED
 (74/82) perf_top.py:perf_top.test_top;run-variants-hierarchy-2803:  PASS (40.37 s)
 (75/82) perf_top.py:perf_top.test_top;run-variants-overwrite-7195: STARTED
 (75/82) perf_top.py:perf_top.test_top;run-variants-overwrite-7195:  PASS (40.38 s)
 (76/82) perf_top.py:perf_top.test_top;run-variants-force-b3c8: STARTED
 (76/82) perf_top.py:perf_top.test_top;run-variants-force-b3c8:  PASS (41.38 s)
 (77/82) perf_top.py:perf_top.test_top;run-variants-num-thread-synthesize-f9ee: STARTED
 (77/82) perf_top.py:perf_top.test_top;run-variants-num-thread-synthesize-f9ee:  PASS (40.38 s)
 (78/82) perf_top.py:perf_top.test_top;run-variants-namespaces-d15c: STARTED
 (78/82) perf_top.py:perf_top.test_top;run-variants-namespaces-d15c:  PASS (40.38 s)
 (79/82) perf_top.py:perf_top.test_top;run-variants-all-cgroups-2d41: STARTED
 (79/82) perf_top.py:perf_top.test_top;run-variants-all-cgroups-2d41:  PASS (41.38 s)
 (80/82) perf_top.py:perf_top.test_top;run-variants-switch-on-957c: STARTED
 (80/82) perf_top.py:perf_top.test_top;run-variants-switch-on-957c:  PASS (40.38 s)
 (81/82) perf_top.py:perf_top.test_top;run-variants-switch-off-389c: STARTED
 (81/82) perf_top.py:perf_top.test_top;run-variants-switch-off-389c:  PASS (40.38 s)
 (82/82) perf_top.py:perf_top.test_top;run-variants-show-on-off-events-372b: STARTED
 (82/82) perf_top.py:perf_top.test_top;run-variants-show-on-off-events-372b:  PASS (40.39 s)
RESULTS    : PASS 82 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-01-17T08.39-2a94f65/results.html
JOB TIME   : 3649.74 s