### PR TITLE
perf/perf_test: fix package dependency

### DIFF
--- a/perf/perf_test.py
+++ b/perf/perf_test.py
@@ -64,7 +64,7 @@ class Perftest(Test):
             elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos']:
                 deps.extend(['perf', 'gcc-c++'])
                 if 'SuSE' in detected_distro.name:
-                    deps.extend(['kernel-default-debuginfo'])
+                    deps.extend(['kernel-default-devel'])
                 else:
                     deps.extend(['clang', 'kernel-debuginfo',
                                  'perf-debuginfo'])


### PR DESCRIPTION
Test fails on suse as kernel-default-debuginfo pkg is not found.
Fix the testcase by using correct package name as kernel-default-devel.