### PR TITLE
Fix perf stress ng

### DIFF
--- a/perf/perf_stress_ng.py
+++ b/perf/perf_stress_ng.py
@@ -39,7 +39,7 @@ class Stressng(Test):
         self.timeout = self.params.get('timeout', default='1')
         self.cpu_per = self.params.get("cpu_load", default='10')
         self.profile_dur = int(self.params.get("profile_duration", default=1))
-        run_type = self.params.get('type', default='upstream')
+        run_type = self.params.get('type', default='distro')
         dmesg.clear_dmesg()
 
         deps = ['gcc', 'perf']
@@ -232,7 +232,7 @@ class Stressng(Test):
                            (load, change_percent))
             else:
                 self.log.info(
-                       "stress-ng is ether not running or all the process are now killed ")
+                       "stress-ng is either not running or all the process are now killed ")
 
         self.log.info("=====================================================")
         if failed == 1:
@@ -240,7 +240,7 @@ class Stressng(Test):
 
     def tearDown(self):
         """
-        removes the log files and collectes the dmesg data
+        removes the log files and collects the dmesg data
         :param: none
         """
 
@@ -248,5 +248,5 @@ class Stressng(Test):
         try:
             os.remove(file_name)
         except OSError:
-            self.log.warn("Files do not exsists")
+            self.log.warn("Files do not exist")
         dmesg.collect_dmesg()


### PR DESCRIPTION
Changed default run_type to distro. Corrected typos and spelling errors.

avocado run perf_stress_ng.py -m perf_stress_ng.py.data/perf_stress_ng.yaml
Fetching asset from perf_stress_ng.py:Stressng.test
JOB ID     : 07960e1d2974035fd5c85fc0eb1d5c730a532394
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-01-19T01.25-07960e1/job.log
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: STARTED
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: FAIL:  CPU load 10 50 80 combination's failed with percentage difference {'50': 11.799999999999997, '80': 17.4} (235.61 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-01-19T01.25-07960e1/results.html
JOB TIME   : 263.85 s

Test summary:
1-perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: FAIL