### PR TITLE
fs/xfstest: exclude ext4/048 test

### DIFF
--- a/fs/xfstests.py.data/ext4/64k_adv_auto.yaml
+++ b/fs/xfstests.py.data/ext4/64k_adv_auto.yaml
@@ -12,6 +12,6 @@ loop_type: !mux
 fs_type: !mux
     fs_ext4_64k_adv_auto:
         fs: 'ext4'
-        args: '-R xunit -g auto'
+        args: '-R xunit -e ext4/048 -g auto'
         mkfs_opt: '-b 65536 -O inline_data,fast_commit'
         mount_opt: '-o block_validity'

--- a/fs/xfstests.py.data/ext4/64k_auto.yaml
+++ b/fs/xfstests.py.data/ext4/64k_auto.yaml
@@ -12,6 +12,6 @@ loop_type: !mux
 fs_type: !mux
     fs_ext4_64k_auto:
         fs: 'ext4'
-        args: '-R xunit -g auto'
+        args: '-R xunit -e ext4/048 -g auto'
         mkfs_opt: '-b 65536'
         mount_opt: '-o block_validity'

--- a/fs/xfstests.py.data/ext4/64k_ext3.yaml
+++ b/fs/xfstests.py.data/ext4/64k_ext3.yaml
@@ -12,6 +12,6 @@ loop_type: !mux
 fs_type: !mux
     fs_ext4_64k_ext3:
         fs: 'ext4'
-        args: '-R xunit -g quick'
+        args: '-R xunit -e ext4/048 -g quick'
         mkfs_opt: '-b 65536 -O ^extents,^flex_bg,^uninit_bg,^64bit,^metadata_csum,^huge_file,^dir_nlink,^extra_isize'
         mount_opt: '-o block_validity'


### PR DESCRIPTION
Exclude ext4/048 test from 64k block size yaml files as test gets stuck which results in timeout and blocks test run.

Link to CR run log:
http://9.40.192.188/DistroCR/246/results/TestRunner/log

[ 3055.512082] run fstests ext4/048 at 2023-12-01 15:18:06
[ 3055.516181] Lockdown: check: debugfs access is restricted; see man kernel_lockdown.7
[ 3055.620194] EXT4-fs (loop1): mounted filesystem with ordered data mode. Quota mode: none.
[ 3055.635937] EXT4-fs (loop1): unmounting filesystem.
[ 3055.657436] EXT4-fs (loop1): mounted filesystem with ordered data mode. Quota mode: none.
[ 3055.660966] EXT4-fs (loop1): unmounting filesystem.
[ 3055.669196] EXT4-fs (loop1): mounted filesystem with ordered data mode. Quota mode: none.
[ 3055.672608] EXT4-fs (loop1): unmounting filesystem.
[ 3055.689216] EXT4-fs (loop1): mounted filesystem with ordered data mode. Quota mode: none.
 (1/1) /home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/fs/xfstests.py:Xfstests.test;run-fs_type-fs_ext4_64k_auto-loop_type-1cd0:  INTERRUPTED: timeout (86400.01 s)