### PR TITLE
dlpar_vscsi: get device node for lscfg

### DIFF
--- a/io/disk/dlpar_vscsi.py
+++ b/io/disk/dlpar_vscsi.py
@@ -17,6 +17,7 @@
 DLPAR operations
 """
 
+import os
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import disk
@@ -34,7 +35,8 @@ class DlparTest(Test):
         Gather necessary test inputs.
         '''
         device = self.params.get('disk', default=None)
-        self.disk = disk.get_absolute_disk_path(device)
+        dev_path = disk.get_absolute_disk_path(device)
+        self.disk = os.path.basename(os.path.realpath(dev_path))
         self.num_of_dlpar = int(self.params.get("num_of_dlpar", default='1'))
         self.vios_ip = self.params.get('vios_ip', '*', default=None)
         self.vios_user = self.params.get('vios_username', '*', default=None)


### PR DESCRIPTION
lscfg -vl do not support device id input, so
get the node name for given device id to fix
device not found error