### PR TITLE
Run filebench with addr_no_randomize

### DIFF
--- a/fs/filebench.py
+++ b/fs/filebench.py
@@ -65,6 +65,13 @@ class Filebench(Test):
         testfile = self.params.get('testfile', default='fileserver.f')
         testfile_path = os.path.join(self.install_prefix, 'share', 'filebench',
                                      'workloads', testfile)
-        cmd = '%s -f %s' % (binary_path, testfile_path)
+
+        # Due to compatibility issues with filebench, ASLR (Address Space
+        # Layout Randomization) is disabled in the process personality.
+        # Filebench does not work properly when ASLR is enabled.
+        # Disabling ASLR ensures consistent behavior and reliable execution
+        # of filebench benchmarks.
+
+        cmd = 'setarch --addr-no-randomize %s -f %s' % (binary_path, testfile_path)
         out = process.system_output(cmd)
         self.log.info(b"result:" + out)


### PR DESCRIPTION
Filebench causes segmentation fault on system when ASLR is enabled as memory starts to overlap when many processes are defined with same binary of filebench. So running benchmark with addr_no_randomize personality making the benchmark to run cleanly.

------------------Before------------------
```
 kernel: [ 2289.327296] filebench[20097]: segfault at 55f32aecd0f0 ip 000055f32aecd0f0 sp 00007fa0d09ffde8 error 14 likely on CPU 33 (core 33, socket 0)
 kernel: [ 2289.327318] Code: Unable to access opcode bytes at 0x55f32aecd0c6.
```
------------------After------------------
```
avocado run filebench.py
Fetching asset from filebench.py:Filebench.test
JOB ID     : 8eac884d619047d3dbdb6859c3cf6f5f847bddf5
JOB LOG    : /root/AvocadoTests_src/results/job-2024-02-19T18.35-8eac884/job.log
 (1/1) filebench.py:Filebench.test: STARTED
 (1/1) filebench.py:Filebench.test: PASS (73.40 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/AvocadoTests_src/results/job-2024-02-19T18.35-8eac884/results.html
JOB TIME   : 76.38 s

debug.log

[stdlog] 2024-02-19 18:35:51,489 avocado.utils.process process          L0657 INFO | Running 'setarch --addr-no-randomize /root/AvocadoTests_src/results/job-2024-02-19T18.35-8eac884/test-results/1-filebench.py_Filebench.test/tmp_dirro3naids/1-filebench.py_Filebench.test/install_prefix/bin/filebench -f /root/AvocadoTests_src/results/job-2024-02-19T18.35-8eac884/test-results/1-filebench.py_Filebench.test/tmp_dirro3naids/1-filebench.py_Filebench.test/install_prefix/share/filebench/workloads/fileserver.f'
[stdlog] 2024-02-19 18:35:51,530 avocado.utils.process process          L0473 DEBUG| [stdout] Filebench Version 1.5-alpha3
[stdlog] 2024-02-19 18:35:51,530 avocado.utils.process process          L0473 DEBUG| [stdout] 0.000: Allocated 173MB of shared memory
[stdlog] 2024-02-19 18:35:51,532 avocado.utils.process process          L0473 DEBUG| [stdout] 0.002: File-server Version 3.0 personality successfully loaded
[stdlog] 2024-02-19 18:35:51,532 avocado.utils.process process          L0473 DEBUG| [stdout] 0.002: Populating and pre-allocating filesets
[stdlog] 2024-02-19 18:35:51,536 avocado.utils.process process          L0473 DEBUG| [stdout] 0.006: bigfileset populated: 10000 files, avg. dir. width = 20, avg. dir. depth = 3.1, 0 leafdirs, 1240.757MB total size
[stdlog] 2024-02-19 18:35:51,536 avocado.utils.process process          L0473 DEBUG| [stdout] 0.006: Removing bigfileset tree (if exists)
[stdlog] 2024-02-19 18:35:51,975 avocado.utils.process process          L0473 DEBUG| [stdout] 0.445: Pre-allocating directories in bigfileset tree
[stdlog] 2024-02-19 18:35:51,989 avocado.utils.process process          L0473 DEBUG| [stdout] 0.459: Pre-allocating files in bigfileset tree
[stdlog] 2024-02-19 18:35:52,767 avocado.utils.process process          L0473 DEBUG| [stdout] 1.237: Waiting for pre-allocation to finish (in case of a parallel pre-allocation)
[stdlog] 2024-02-19 18:35:52,767 avocado.utils.process process          L0473 DEBUG| [stdout] 1.237: Population and pre-allocation of filesets completed
[stdlog] 2024-02-19 18:35:52,767 avocado.utils.process process          L0473 DEBUG| [stdout] 1.237: Starting 1 filereader instances
[stdlog] 2024-02-19 18:35:53,772 avocado.utils.process process          L0473 DEBUG| [stdout] 2.242: Running...
[stdlog] 2024-02-19 18:36:53,777 avocado.utils.process process          L0473 DEBUG| [stdout] 62.247: Run took 60 seconds...
[stdlog] 2024-02-19 18:36:53,779 avocado.utils.process process          L0473 DEBUG| [stdout] 62.249: Per-Operation Breakdown
[stdlog] 2024-02-19 18:36:53,779 avocado.utils.process process          L0473 DEBUG| [stdout] statfile1            2172476ops    36206ops/s   0.0mb/s      0.0ms/op [0.00ms -  0.29ms]
[stdlog] 2024-02-19 18:36:53,779 avocado.utils.process process          L0473 DEBUG| [stdout] deletefile1          2172484ops    36206ops/s   0.0mb/s      0.1ms/op [0.02ms -  2.58ms]
[stdlog] 2024-02-19 18:36:53,779 avocado.utils.process process          L0473 DEBUG| [stdout] closefile3           2172489ops    36206ops/s   0.0mb/s      0.0ms/op [0.00ms -  0.29ms]
[stdlog] 2024-02-19 18:36:53,779 avocado.utils.process process          L0473 DEBUG| [stdout] readfile1            2172490ops    36206ops/s 4773.1mb/s      0.0ms/op [0.00ms -  1.97ms]
[stdlog] 2024-02-19 18:36:53,779 avocado.utils.process process          L0473 DEBUG| [stdout] openfile2            2172495ops    36206ops/s   0.0mb/s      0.1ms/op [0.00ms - 11.46ms]
[stdlog] 2024-02-19 18:36:53,779 avocado.utils.process process          L0473 DEBUG| [stdout] closefile2           2172500ops    36206ops/s   0.0mb/s      0.0ms/op [0.00ms -  0.28ms]
[stdlog] 2024-02-19 18:36:53,780 avocado.utils.process process          L0473 DEBUG| [stdout] appendfilerand1      2172501ops    36206ops/s 282.7mb/s      0.0ms/op [0.00ms - 16.18ms]
[stdlog] 2024-02-19 18:36:53,780 avocado.utils.process process          L0473 DEBUG| [stdout] openfile1            2172505ops    36207ops/s   0.0mb/s      0.1ms/op [0.00ms -  3.37ms]
[stdlog] 2024-02-19 18:36:53,780 avocado.utils.process process          L0473 DEBUG| [stdout] closefile1           2172512ops    36207ops/s   0.0mb/s      0.0ms/op [0.00ms -  0.28ms]
[stdlog] 2024-02-19 18:36:53,780 avocado.utils.process process          L0473 DEBUG| [stdout] wrtfile1             2172518ops    36207ops/s 4491.0mb/s      0.1ms/op [0.01ms - 13.73ms]
[stdlog] 2024-02-19 18:36:53,780 avocado.utils.process process          L0473 DEBUG| [stdout] createfile1          2172523ops    36207ops/s   0.0mb/s      0.1ms/op [0.02ms -  3.12ms]
[stdlog] 2024-02-19 18:36:53,780 avocado.utils.process process          L0473 DEBUG| [stdout] 62.249: IO Summary: 23897493 ops 398270.793 ops/s 36206/72413 rd/wr 9546.8mb/s   0.2ms/op
[stdlog] 2024-02-19 18:36:53,780 avocado.utils.process process          L0473 DEBUG| [stdout] 62.249: Shutting down processes
```