### PR TITLE
dmesg error level check for lpm test

### DIFF
--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -311,7 +311,7 @@ class LPM(Test):
         error = ['uevent: failed to send synthetic uevent', 'failed to send uevent', 'registration failed']
         self.log.info("Gathering kernel errors if any")
         try:
-            dmesg.collect_errors_by_level(skip_errors=error)
+            dmesg.collect_errors_by_level(level_check=4, skip_errors=error)
         except Exception as exc:
             self.log.info(exc)
             self.fail("test failed,check dmesg log in debug log")


### PR DESCRIPTION
checking the error levels up to level 4 for LPM tests than the default level 5
        1 - emerg
        2 - emerg,alert
        3 - emerg,alert,crit
        4 - emerg,alert,crit,err
        5 - emerg,alert,crit,err,warn