### PR TITLE
fix tear down and add readme file

### DIFF
--- a/perf/perf_stress_ng.py
+++ b/perf/perf_stress_ng.py
@@ -247,8 +247,5 @@ class Stressng(Test):
                            "/tmp/stressng_output*"]
         for file_path in files_to_remove:
             if os.path.exists(file_path):
-                try:
-                    os.remove(file_path)
-                except OSError:
-                    self.log.warn("Files do not exist")
+                os.remove(file_path)
         dmesg.collect_dmesg()

--- a/perf/perf_stress_ng.py
+++ b/perf/perf_stress_ng.py
@@ -243,10 +243,12 @@ class Stressng(Test):
         removes the log files and collects the dmesg data
         :param: none
         """
-
-        file_name = "rm -rf /tmp/stdout /tmp/stderr /tmp/data* /tmp/stressng_output*"
-        try:
-            os.remove(file_name)
-        except OSError:
-            self.log.warn("Files do not exist")
+        files_to_remove = ["/tmp/stdout", "/tmp/stderr", "/tmp/data*",
+                           "/tmp/stressng_output*"]
+        for file_path in files_to_remove:
+            if os.path.exists(file_path):
+                try:
+                    os.remove(file_path)
+                except OSError:
+                    self.log.warn("Files do not exist")
         dmesg.collect_dmesg()

--- a/perf/perf_stress_ng.py.data/README.txt
+++ b/perf/perf_stress_ng.py.data/README.txt
@@ -1,0 +1,16 @@
+Description:
+This test is to compare CPU load percentage from vmstat and perf
+command by running stress-ng in background.
+The test collects vmstat and perf record data with CPU load
+10, 50 and 80 by running it for 5 iterations.
+
+Steps followed:
+Run stress-ng in background with CPU load 10, 50 and 80.
+Run perf record to collect CPU load for 5 iterations.
+Run vmstat to collect CPU load for 5 iterations.
+Compare both results.
+
+Pre-requisite:
+1. Install psutil using pip
+   # pip3 install psutil
+2. Install perf, gcc and stress-ng packages


### PR DESCRIPTION
Commit 1
The test result shows test passed with warning when test did not ran. Fix the tear down by adding a check to ensure removal of files only occurs if they exist.

Before fix:
avocado run perf_stress_ng.py -m perf_stress_ng.py.data/perf_stress_ng.yaml
Fetching asset from perf_stress_ng.py:Stressng.test
JOB ID     : 2abafaa0af699b4a3918c7838dff061c9e774aaf
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2024-03-06T04.10-2abafaa/job.log
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: STARTED
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: WARN: Test passed but there were warnings during execution. Check the log for details. (1.31 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 1 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2024-03-06T04.10-2abafaa/results.html
JOB TIME   : 26.02 s

After fix:
avocado run perf_stress_ng.py -m perf_stress_ng.py.data/perf_stress_ng.yaml
Fetching asset from perf_stress_ng.py:Stressng.test
JOB ID     : 4d8aed2110dd9338cb85d0d77649e9029cc8df14
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2024-03-06T04.23-4d8aed2/job.log
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: STARTED
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: CANCEL: stress-ng is needed for the test to be run (0.74 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2024-03-06T04.23-4d8aed2/results.html
JOB TIME   : 23.57 s
[debug1.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/14539415/debug1.log)

avocado run perf_stress_ng.py -m perf_stress_ng.py.data/perf_stress_ng.yaml
Fetching asset from perf_stress_ng.py:Stressng.test
JOB ID     : 5e80e55d96efad7e1a655b4ed3baf3eb6d0c3ba0
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-03-08T08.31-5e80e55/job.log
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: STARTED
 (1/1) perf_stress_ng.py:Stressng.test;run-coverage-run_type-df37: FAIL:  CPU load 10 50 80 combination's failed with percentage difference {'50': 4.599999999999994, '80': 8.599999999999994} (201.27 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-03-08T08.31-5e80e55/results.html
JOB TIME   : 214.81 s
[debug2.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/14539418/debug2.log)

Commit 2
This commit introduces a README.txt file. The README provides a description of the test, outlines the steps followed during the test execution and lists the prerequisites necessary for running the test successfully.