### PR TITLE
kernel/kselftest: Modify kselftest to run cpufreq testcases

### DIFF
--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -6,6 +6,9 @@ component: !mux
         kself_args: "summary=1"
     mem_plug:
         comp: "memory-hotplug"
+    cpufreq:
+        comp: "cpufreq"
+        test_mode: "basic"
 run_type: !mux
     distro:
         type: 'distro'

--- a/kernel/kselftest.py.data/kselftest_cpufreq.yaml
+++ b/kernel/kselftest.py.data/kselftest_cpufreq.yaml
@@ -1,0 +1,18 @@
+component: !mux
+    cpufreq:
+        comp: "cpufreq"
+        test_modes: !mux
+            basic:
+                test_mode: "basic"
+            sptest1:
+                test_mode: "sptest1"
+            sptest2:
+                test_mode: "sptest2"
+            sptest3:
+                test_mode: "sptest3"
+            sptest4:
+                test_mode: "sptest4"
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"

--- a/kernel/kselftest.py.data/kselftest_upstream.yaml
+++ b/kernel/kselftest.py.data/kselftest_upstream.yaml
@@ -1,0 +1,22 @@
+component: !mux
+    cpufreq:
+        comp: "cpufreq"
+        test_modes: !mux
+            basic:
+                test_mode: "basic"
+            sptest1:
+                test_mode: "sptest1"
+            sptest2:
+                test_mode: "sptest2"
+            sptest3:
+                test_mode: "sptest3"
+            sptest4:
+                test_mode: "sptest4"
+    mm:
+        comp: "mm"
+    mem_plug:
+        comp: "memory-hotplug"
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"


### PR DESCRIPTION
Modify kselftest.py to run upstream cpufreq testcase
Adding kselftest_cpufreq.yaml and modified kselftest.yaml
to run with basic mode of cpufreq.yaml.
Tests to run with upstream kernel only.