### PR TITLE
ras/sosreport.py: Fix errors/false-results

### DIFF
--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -57,16 +57,15 @@ class Sosreport(Test):
             self.sos_cmd = "sosreport"
         elif dist.name in ['rhel', 'centos', 'fedora']:
             sos_pkg = 'sos'
+            self.sos_cmd = "sos report"
+            if dist.name == "rhel" and dist.version <= "7" and dist.release <= "4":
+                self.sos_cmd = "sosreport"
         else:
             self.cancel("sosreport is not supported on %s" % dist.name)
         for package in (sos_pkg, 'java'):
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel(
                     "Package %s is missing and could not be installed" % (package))
-        if dist.name == "rhel":
-            self.sos_cmd = "sos report"
-            if dist.version <= "7" and dist.release <= "4":
-                self.sos_cmd = "sosreport"
 
     def test_short(self):
         """


### PR DESCRIPTION
### ras/sosreport.py: Fix errors/false-results for Fedora and CentOS

- Missing: self.sos_cmd = "sos report" for Fedora, Rhel and CentOS while checking distro name
- This was leading to 10 ERRORS, 1 PASS in test-cases causing FALSE TEST RESULTS
- This simple patch will result in 8 PASS, 1 ERROR, 2 FAILURES

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)

