### PR TITLE
Fix inspekt errors for TravisCI build

### DIFF
--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -97,4 +97,3 @@ class Hwinfo(Test):
         if "failed" in process.system_output("hwinfo --disk --save-config=all",
                                              shell=True).decode("utf-8"):
             self.fail("hwinfo: --save-config=all option failed")
-


### PR DESCRIPTION
Fix inspekt errors for TravisCI build

- TravisCI build is failing for new PRs due to bad
python code formatting on some programs.

- This patch will fix the inspekt errors so
that new TravisCI PR builds will pass

Formatting includes: multi-import, whitespaces,
line formatting and basic redundancy errors

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)