### PR TITLE
trace: Add Fedora Support to trace testing

### DIFF
--- a/trace/dawr.py
+++ b/trace/dawr.py
@@ -68,6 +68,10 @@ class Dawr(Test):
         executing the program
         """
         child, return_value = self.run_cmd('dawr_v1')
+        i = 0
+        if self.distro_name == "fedora":
+            child.sendline('set debuginfod enabled on')
+            child.expect_exact([pexpect.TIMEOUT, ''])
         child.sendline('awatch a')
         return_value.append(child.expect_exact(['watchpoint 1: a',
                                                 pexpect.TIMEOUT]))
@@ -88,6 +92,9 @@ class Dawr(Test):
         """
         child, return_value = self.run_cmd('dawr_v2')
         i = 0
+        if self.distro_name == "fedora":
+            child.sendline('set debuginfod enabled on')
+            child.expect_exact([pexpect.TIMEOUT, ''])
         for value in ['a', 'b']:
             i = i+1
             child.sendline('awatch %s' % value)

--- a/trace/perf_uprobe.py
+++ b/trace/perf_uprobe.py
@@ -98,7 +98,8 @@ class PerfUprobe(Test):
         if (self.distro_name == "rhel" and self.detected_distro.version > "7")\
            or (self.distro_name == "SuSE" and
                self.detected_distro.version >= 15 and
-               self.detected_distro.release >= 2):
+               self.detected_distro.release >= 2)\
+           or (self.distro_name == "fedora"):
             output = self.cmd_verify('%s__return -- ./uprobe_test'
                                      % self.recProbe)
         else:

--- a/trace/trace_UDT_probes.py
+++ b/trace/trace_UDT_probes.py
@@ -36,7 +36,7 @@ class TraceUDT(Test):
         if 'Ubuntu' in self.distro_name:
             deps.extend(['linux-tools-common', 'linux-tools-%s' %
                          platform.uname()[2]])
-        elif self.distro_name in ['rhel', 'SuSE']:
+        elif self.distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
             deps.extend(['perf', 'systemtap-sdt-devel.ppc64le'])
         else:
             self.cancel("Install the package for perf supported\


### PR DESCRIPTION
### trace: Add Fedora Support to trace testing

- Added distros "fedora", "centos" in trace_UDT_probes.py for installing packages: "perf", "systemtap-sdt-devel.ppc64le"
- Added self.distro_name == "fedora" in perf_uprobe.py for testing of "perf record .." command
- Added self.distro_name == "fedora" in dawr.py to enable extra setting required to run gdb for fedora

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)