### PR TITLE
RX TX queue tuning before running iperf test

### DIFF
--- a/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
@@ -22,3 +22,5 @@ mac_id:
 user_name: ""
 host_public_ip: ""
 host_password: ""
+peer_user: ""
+peer_password: ""


### PR DESCRIPTION
The patch enables runnign of irqbalance service, tuning rx tx queue values before starting iperf tests.

The command to run iperf test from client side is improvised to include parallel threads, interval between periodic bandwidth reports and time in seconds to transmit for values