### PR TITLE
ras/hwinfo: Fix travis reported code style issue

### DIFF
--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -97,4 +97,3 @@ class Hwinfo(Test):
         if "failed" in process.system_output("hwinfo --disk --save-config=all",
                                              shell=True).decode("utf-8"):
             self.fail("hwinfo: --save-config=all option failed")
-


### PR DESCRIPTION
Travis reports following issue with hwinfo
ras/hwinfo.py:100:1: W391 blank line at end of file

This is preventing merge of other PR's.
Fix by removing blank line.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>