### PR TITLE
Added ebizzy workload to run with YAML parameters

### DIFF
--- a/workload/ebizzy_workload.py
+++ b/workload/ebizzy_workload.py
@@ -1,0 +1,66 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2024 IBM
+# Author: Krishan Gopal Saraswat <krishang@linux.ibm.com>
+
+
+import os
+
+from avocado import Test
+from avocado.utils import distro, process, archive, build
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class ebizzy(Test):
+
+    """
+    ebizzy workload
+    """
+
+    def setUp(self):
+        '''
+        Build ebizzy
+        Source:
+        https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3
+        /ebizzy-0.3.tar.gz
+        '''
+        if 'ppc' not in distro.detect().arch:
+            self.cancel("Processor is not powerpc")
+        sm = SoftwareManager()
+        deps = ['tar', 'make']
+        for package in deps:
+            if not sm.check_installed(package) and not sm.install(package):
+                self.cancel("%s is needed for the test to be run" % package)
+        url = 'https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz'
+        tarball = self.fetch_asset(self.params.get("ebizy_url", default=url))
+        archive.extract(tarball, self.workdir)
+        version = os.path.basename(tarball.split('.tar.')[0])
+        self.sourcedir = os.path.join(self.workdir, version)
+        os.chdir(self.sourcedir)
+        process.run("./configure")
+        build.make(self.sourcedir, extra_args='LDFLAGS=-static')
+        # Get the arguments for ebizzy workload from YAML file
+        self.args = self.params.get('ebizzy_args', default='-S 20')
+
+    def test_start_ebizzy_workload(self):
+        # Run ebizzy workload for time duration taken from YAML file
+        process.run("nohup ./ebizzy {0} &".format(self.args))
+
+    def test_stop_ebizzy_workload(self):
+        ps = process.system_output("ps -e", ignore_status=True).decode().splitlines()
+        pid = 0
+        for w_load in ps:
+            if "ebizzy" in w_load:
+                pid = int(w_load.split(" ")[0])
+                break
+        if pid:
+            os.kill(pid, 9)

--- a/workload/ebizzy_workload.py.data/perf_top_args.yaml
+++ b/workload/ebizzy_workload.py.data/perf_top_args.yaml
@@ -1,0 +1,2 @@
+ebizy_url : 'https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz'
+ebizzy_args : '-S 30'


### PR DESCRIPTION
[root@ workload]# avocado run --max-parallel-tasks=1 ebizzy_workload.py -m ebizzy_workload.py.data/perf_top_args.yaml
Fetching asset from ebizzy_workload.py:ebizzy.test_start_ebizzy_workload
Fetching asset from ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload
JOB ID     : 1f9dce400f42a9799dd68a0f7e8f15984ad6f9be
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2024-03-22T02.49-1f9dce4/job.log
 (1/2) ebizzy_workload.py:ebizzy.test_start_ebizzy_workload;run-2baa: STARTED
 (1/2) ebizzy_workload.py:ebizzy.test_start_ebizzy_workload;run-2baa: PASS (30.62 s)
 (2/2) ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload;run-2baa: STARTED
 (2/2) ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload;run-2baa: PASS (0.63 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2024-03-22T02.49-1f9dce4/results.html
JOB TIME   : 65.32 s