### PR TITLE
perf: Fix false results and add Fedora support

### DIFF
--- a/perf/perf_duplicate_probe.py
+++ b/perf/perf_duplicate_probe.py
@@ -34,7 +34,7 @@ class PerfDuplicateProbe(Test):
         if 'Ubuntu' in distro_name:
             deps.extend(['linux-tools-common', 'linux-tools-%s' %
                          platform.uname()[2]])
-        elif distro_name in ['rhel', 'SuSE']:
+        elif distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
             deps.extend(['perf'])
         else:
             self.cancel("Install the package for perf supported\

--- a/perf/perf_script_bug.py
+++ b/perf/perf_script_bug.py
@@ -37,7 +37,7 @@ class PerfScript(Test):
         parser.read(self.get_data('probe.cfg'))
         self.perf_probe = parser.get(detected_distro.name, 'probepoint')
         deps = ['gcc', 'make']
-        if detected_distro.name in ['rhel', 'SuSE']:
+        if detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos']:
             deps.extend(['perf'])
         elif detected_distro.name in ['Ubuntu']:
             deps.extend(['linux-tools-common', 'linux-tools-%s' %

--- a/perf/perf_script_bug.py.data/probe.cfg
+++ b/perf/perf_script_bug.py.data/probe.cfg
@@ -4,3 +4,5 @@ probepoint = 3
 probepoint = 3
 [Ubuntu]
 probepoint = 3
+[fedora]
+probepoint = 3

--- a/perf/perf_test.py
+++ b/perf/perf_test.py
@@ -65,6 +65,8 @@ class Perftest(Test):
                 deps.extend(['perf', 'gcc-c++'])
                 if 'SuSE' in detected_distro.name:
                     deps.extend(['kernel-default-debuginfo'])
+                elif 'fedora' in detected_distro.name:
+                    deps.extend(['clang', 'kernel-debuginfo'])
                 else:
                     deps.extend(['clang', 'kernel-debuginfo',
                                  'perf-debuginfo'])
@@ -72,7 +74,7 @@ class Perftest(Test):
                 self.cancel("Install the package for perf supported\
                           by %s" % detected_distro.name)
         if run_type == 'upstream':
-            if 'rhel' in detected_distro.name:
+            if detected_distro.name in ['rhel', 'fedora']:
                 deps.extend(['systemtap-sdt-devel', 'slang-devel',
                              'perl-ExtUtils-Embed', 'libcap-devel',
                              'numactl-devel', 'libbabeltrace-devel',


### PR DESCRIPTION
### perf: Fix false results and add Fedora support

Updated perf tests to enable fedora testing

This patch will also enable "perf test" failures
which were earlier cancelled due to missing
"fedora" support in distro.detect()

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)