### PR TITLE
ras/hwinfo: Update testcases and their options

### DIFF
--- a/ras/hwinfo.py
+++ b/ras/hwinfo.py
@@ -43,16 +43,18 @@ class Hwinfo(Test):
                                                "cut -d':' -f2" % self.disk_name,
                                                shell=True).decode("utf-8")
 
-    def test_list(self):
+    def test_list_options(self):
         lists = self.params.get('list', default=['--all', '--cpu', '--disk'])
         for list_item in lists:
             cmd = "hwinfo %s" % list_item
             self.run_cmd(cmd)
 
-    def test_disk(self):
+    def test_only(self):
         self.run_cmd("hwinfo --disk --only %s" % self.disk_name)
 
     def test_unique_id_save(self):
+        if not os.path.isdir("/var/lib/hardware/udi"):
+            self.cancel("/var/lib/hardware/udi path does not exist")
         self.run_cmd("hwinfo --disk --save-config %s" % self.Unique_Id)
         if "failed" in process.system_output("hwinfo --disk --save-config %s"
                                              % self.Unique_Id,
@@ -60,6 +62,8 @@ class Hwinfo(Test):
             self.fail("hwinfo: --save-config UDI option failed")
 
     def test_unique_id_show(self):
+        if not os.path.isdir("/var/lib/hardware/udi"):
+            self.cancel("/var/lib/hardware/udi path does not exist")
         self.run_cmd("hwinfo --disk --show-config %s" % self.Unique_Id)
         if "No config" in process.system_output("hwinfo --disk --show-config %s"
                                                 % self.Unique_Id,
@@ -75,11 +79,10 @@ class Hwinfo(Test):
         if (not os.path.exists('./FILE')) or (os.stat("FILE").st_size == 0):
             self.fail("hwinfo: failed with --log option")
 
-    def test_dump_0(self):
-        self.run_cmd("hwinfo --dump-db 0")
-
-    def test_dump_1(self):
-        self.run_cmd("hwinfo --dump-db 1")
+    def test_dump(self):
+        level = [0, 1]
+        for value in level:
+            self.run_cmd("hwinfo --dump-db %i" % value)
 
     def test_version(self):
         self.run_cmd("hwinfo --version")
@@ -88,12 +91,16 @@ class Hwinfo(Test):
         self.run_cmd("hwinfo --help")
 
     def test_debug(self):
-        self.run_cmd("hwinfo --debug 0 --disk --log=-")
+        level = [0, 1]
+        for value in level:
+            self.run_cmd("hwinfo --debug %i --disk --log=-" % value)
 
     def test_short_block(self):
         self.run_cmd("hwinfo --short --block")
 
     def test_save_config(self):
+        if not os.path.isdir("/var/lib/hardware/udi"):
+            self.cancel("/var/lib/hardware/udi path does not exist")
         self.run_cmd("hwinfo --disk --save-config=all")
         if "failed" in process.system_output("hwinfo --disk --save-config=all",
                                              shell=True).decode("utf-8"):


### PR DESCRIPTION
## ras/hwinfo: Update testcases

1. Updated: test_list as test_list_options to test all list options
2. Updated: test debug N to test hwinfo --debug 1,2 options
3. Updated: test dump N to test hwinfo --debug 1,2 options
4. Updated: test_disk by renaming it to test_only option to make it more suitable corresponding to the command
5. Updated: test_unique_id_save to CANCEL test if directory /var/lib/hardware/udi is not present. In Fedora, Rhel, etc Operating Systems, this directory is not part of the file system. The save config option will look for the presence of the directory to save the file. If it is not present, it will fail.
6. Updated: test_unique_id_show to CANCEL for same reason as test_unique_id_save
7. Updated: test_save_config to CANCEL for same reason as test_unique_id_save

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)