### PR TITLE
perf/perf_24x7_hardware_counters.py: check_valid_chip - Update testcase to avoid failures

### DIFF
--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -214,16 +214,16 @@ class EliminateDomainSuffix(Test):
     def test_check_invalid_chip(self):
         """
         Test invalid out of range chip value
+        chip can take maximum value of 65535 only
         """
-        invalid_chip = [self.chips, 65536]
-        for chip_val in invalid_chip:
-            if self.rev == '004b' or self.rev == '004e':
-                cmd = "hv_24x7/PM_PB_CYC,domain=1,chip=%s/ /bin/true" % chip_val
-            if self.rev == '0080':
-                cmd = "hv_24x7/PM_PHB0_0_CYC,domain=1,chip=%s/ /bin/true" % chip_val
-            res = self.event_stat1(cmd)
-            if res.exit_status == 0:
-                self.fail("perf unable to recognise invalid chip value")
+        invalid_chip = 65536
+        if self.rev == '004b' or self.rev == '004e':
+            cmd = "hv_24x7/PM_PB_CYC,domain=1,chip=%s/ /bin/true" % invalid_chip
+        if self.rev == '0080':
+            cmd = "hv_24x7/PM_PHB0_0_CYC,domain=1,chip=%s/ /bin/true" % invalid_chip
+        res = self.event_stat1(cmd)
+        if res.exit_status == 0:
+            self.fail("perf unable to recognise invalid chip value")
 
     def test_domain_chip_offset(self):
         cmd = "perf stat -r 10 -x ' ' perf stat -r 10 -x ' ' \


### PR DESCRIPTION
## perf/perf_24x7_hardware_counters.py: check_valid_chip - Update testcase to avoid failures

Command: perf stat -v -e hv_24x7/PM_PHB0_0_CYC,domain=1,chip=value
Maximum chip value which can be assigned is 65535
Anything above that range should fail and this test is used to verify that

Hence, setting invalid_chip=65536 can directly test the command In scenarious where multiple chip values are tested, this testcase can fail if the chip values passed before 65536 are in the accepted range.

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)