### PR TITLE
cpu/ppc64_cpu: single core plus smt and upstream as a target

### DIFF
--- a/cpu/ppc64_cpu_test.py
+++ b/cpu/ppc64_cpu_test.py
@@ -165,6 +165,45 @@ class PPC64Test(Test):
                               shell=True):
                 self.fail('SMT loop test failed')
 
+    def test_single_core_smt(self):
+        """
+        Test smt level change when single core is online. This
+        scenario was attempted to catch a regression.
+
+        ppc64_cpu --cores-on=all
+        ppc64_cpu —-smt=on
+        ppc64_cpu --cores-on=1
+        ppc64_cpu --cores-on
+        ppc64_cpu --smt=2
+        ppc64_cpu --smt=4
+        ppc64_cpu --cores-on
+           At this stage the number of online cores should be one.
+           If not fail the test case
+
+        """
+        # online all cores
+        process.system("ppc64_cpu --cores-on=all", shell=True)
+        # Set highest SMT level
+        process.system("ppc64_cpu --smt=on", shell=True)
+        # online single core
+        process.system("ppc64_cpu --cores-on=1", shell=True)
+        # Record the output
+        cores_on = process.system_output("ppc64_cpu --cores-on",
+                                         shell=True).decode("utf-8")
+        op1 = cores_on.strip().split("=")[-1]
+        self.log.debug(op1)
+        # Set 2 threads online
+        process.system("ppc64_cpu --smt=2", shell=True)
+        # Set 4 threads online
+        process.system("ppc64_cpu --smt=4", shell=True)
+        # Record the output
+        cores_on = process.system_output("ppc64_cpu --cores-on",
+                                         shell=True).decode("utf-8")
+        op2 = cores_on.strip().split("=")[-1]
+        self.log.debug(op2)
+        if str(op1) != str(op2):
+            self.fail("SMT with Single core test failed")
+
     def tearDown(self):
         """
         Sets back SMT to original value as was before the test.

--- a/cpu/ppc64_cpu_test.py.data/ppc64_cpu_test.yaml
+++ b/cpu/ppc64_cpu_test.py.data/ppc64_cpu_test.yaml
@@ -1,1 +1,7 @@
 test_loop : 10
+run_type: !mux
+    upstream:
+        ppcutils_url: 'https://github.com/ibm-power-utilities/powerpc-utils/archive/refs/heads/master.zip'
+        type: 'upstream'
+    distro:
+        type: 'distro'


### PR DESCRIPTION
This two patch series add following support:

Add upstream as a target for ppc64_cpu test
    Add capabilities to download and compile upstream source for
    powerpc-utils tools(ppc64_cpu).
Add a test case to validate following scenario:
   A system with single online core along with consecutive smt
   level change to ensure number of online cores do not change

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>