### PR TITLE
fs/xfstest: Fix a regression introduced by 3fc8e18

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -190,7 +190,7 @@ class Xfstests(Test):
                                 'liburcu-devel', 'libinih-devel',
                                  'libopenssl-devel', 'gettext-tools'])
             else:
-                packages.extend(['btrfs-progs-devel', 'userspace-rcu-devel'
+                packages.extend(['btrfs-progs-devel', 'userspace-rcu-devel',
                                  'openssl-devel', 'gettext'])
 
             packages_remove = ['indent', 'btrfs-progs-devel']


### PR DESCRIPTION
Commit 3fc8e18 introduced a regression as it missed a
comma after userspace-rcu-devel.

Update the code accordingly to fix this regression.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>