### PR TITLE
ras/ras_ppcdiag: Update package dependency

### DIFF
--- a/ras/ras_ppcdiag.py
+++ b/ras/ras_ppcdiag.py
@@ -66,7 +66,7 @@ class RASToolsPpcdiag(Test):
             self.detected_distro = distro.detect()
             deps = ['gcc', 'make', 'automake', 'autoconf', 'bison', 'flex',
                     'libtool', 'zlib-devel', 'ncurses-devel', 'librtas-devel',
-                    'libservicelog-devel']
+                    'libservicelog-devel', 'systemd-devel']
             if 'SuSE' in self.detected_distro.name:
                 deps.extend(['libvpd2-devel'])
             elif self.detected_distro.name in ['centos', 'fedora', 'rhel']:


### PR DESCRIPTION
upstream source code for ppc64_diag fails to compile due to
dependency on libudev header
  [stderr] configure: error: libudev header files are required for
  building ppc64-diag

Update the package dependency list to reflect the same

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>