### PR TITLE
perf/perf_genericevents.py: Use AMD Zen for parsing

### DIFF
--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -89,7 +89,7 @@ branch-misses = 0xc3
 stalled-cycles-frontend = 0xd0
 stalled-cycles-backend = 0xd1
 
-[AMD17h]
+[AMDZEN1]
 cpu-cycles = 0x76
 instructions = 0xc0
 cache-references = 0xff60
@@ -98,3 +98,41 @@ branch-instructions = 0xc2
 branch-misses = 0xc3
 stalled-cycles-frontend = 0x0287
 stalled-cycles-backend = 0x0187
+
+[AMDZEN2]
+cpu-cycles = 0x76
+instructions = 0xc0
+cache-references = 0xff60
+cache-misses = 0x0964 0x964
+branch-instructions = 0xc2
+branch-misses = 0xc3
+stalled-cycles-frontend = 0xa9
+
+[AMDZEN3]
+cpu-cycles = 0x76
+instructions = 0xc0
+cache-references = 0xff60
+cache-misses = 0x0964
+branch-instructions = 0xc2
+branch-misses = 0xc3
+stalled-cycles-frontend = 0xa9
+
+[AMDZEN4]
+cpu-cycles = 0x76
+instructions = 0xc0
+cache-references = 0xff60
+cache-misses = 0x0964
+branch-instructions = 0xc2
+branch-misses = 0xc3
+stalled-cycles-frontend = 0xa9
+ref-cycles = 0x120
+
+[AMDZEN5]
+cpu-cycles = 0x76
+instructions = 0xc0
+cache-references = 0xff60
+cache-misses = 0x0964
+branch-instructions = 0xc2
+branch-misses = 0xc3
+stalled-cycles-frontend = 0xa9
+ref-cycles = 0x120


### PR DESCRIPTION
CPU event mappings for AMD Zen processors can vary within the same family. Hence, switch to using the core generation for mapping events. The core generation can be determined by inspecting family and model combinations.

Also update raw_code.cfg with latest event mappings and add an AMD Zen specific formula for computing the raw event code. The formula assumes that the "event" field occupies bits 35:32,7:0 and the "umask" field occupies bits 15:8 as described in the AMD PPRs.

Suggested-by: Sandipan Das <sandipan.das@amd.com>
Signed-off-by: Ayush Jain <ayush.jain3@amd.com>