### PR TITLE
Adapting the new changes made in htx setup/configuration.

### DIFF
--- a/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
+++ b/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
@@ -5,10 +5,6 @@ peer_password: "*******"
 peer_user: "root"
 htx_host_interfaces: ""
 peer_interfaces: ""
-host_ips: ""
-netmask: ""
-peer_ips: ""
-net_ids: ""
 # time limit in minutes
 time_limit: 2
 htx_rpm_link: ""


### PR DESCRIPTION
The build_net multisystem command introduced is for automatic configuration of network interfaces on both host and peer. The command set's the interfaces with some local net id's and pings the interfaces. The command also starts the htx deamon creates/selects and activates net.mdt for the network devices. No need to explicitely start the htx deamon or create/select or activate net.mdt file.

Also removing the code that was supporting the old htx network topology and made compatible to new configuration changes.