### PR TITLE
fs/fsx:Fixing URLError for ltp link

### DIFF
--- a/fs/fsx.py
+++ b/fs/fsx.py
@@ -102,7 +102,7 @@ class Fsx(Test):
 
         if not os.path.exists(self.output):
             os.makedirs(self.output)
-        repo = 'https: // github.com/linux-test-project/ltp/archive/master.zip'
+        repo = 'https://github.com/linux-test-project/ltp/archive/master.zip'
         url = self.params.get('url', default=repo)
         match = next((ext for ext in [".zip", ".tar"] if ext in url), None)
         tarball = ''


### PR DESCRIPTION
Fix issue caused by last commit of extra spaces in link

Before:
```
L0141 DEBUG| PARAMS (key=url, path=*, default=https: // github.com/linux-test-project/ltp/archive/master.zip) => 'https: // github.com/linux-test-project/ltp/archive/master.zip'
[stdlog] 2024-04-05 12:33:22,940 avocado.utils.asset asset            L0398 INFO | Fetching asset ltp-master.zip
[stdlog] 2024-04-05 12:33:22,940 avocado.utils.asset asset            L0402 INFO | Asset not in cache, fetching it.
[stdlog] 2024-04-05 12:33:22,941 avocado.utils.asset asset            L0152 DEBUG| Asset not in cache after lock, fetching it.
[stdlog] 2024-04-05 12:33:22,941 avocado.utils.download download         L0096 INFO | Fetching https:/// // github.com/linux-test-project/ltp/archive/master.zip -> /root/avocado/data/cache/by_location/6ec3298404f928ec28638d7c0e5bfa2ba2aa7771/ltp-master.zip.76ec2324-b94f-48b3-a163-82cec77ec954
[stderr] Process Process-1:1:
[stderr] Traceback (most recent call last):
[stderr]   File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
[stderr]     self.run()
[stderr]   File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
[stderr]     self._target(*self._args, **self._kwargs)
[stderr]   File "/usr/local/lib/python3.10/dist-packages/avocado/utils/download.py", line 69, in _url_download
[stderr]     src_file = url_open(url, data=data)
[stderr]   File "/usr/local/lib/python3.10/dist-packages/avocado/utils/download.py", line 48, in url_open
[stderr]     result = urlopen(url, data=data, timeout=timeout)
[stderr]   File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
[stderr]     return opener.open(url, data, timeout)
[stderr]   File "/usr/lib/python3.10/urllib/request.py", line 516, in open
[stderr]     req = meth(req)
[stderr]   File "/usr/lib/python3.10/urllib/request.py", line 1272, in do_request_
[stderr]     raise URLError('no host given')
[stderr] urllib.error.URLError: <urlopen error no host given>
[stdlog] 2024-04-05 12:33:22,948 avocado.utils.asset asset            L0165 INFO | Temporary asset file unavailable due to failed download attempt.
[stdlog] 2024-04-05 12:33:22,948 avocado.utils.asset asset            L0437 ERROR| FileNotFoundError: [Errno 2] No such file or directory: '/root/avocado/data/cache/by_location/6ec3298404f928ec28638d7c0e5bfa2ba2aa7771/ltp-master.zip.76ec2324-b94f-48b3-a163-82cec77ec954'

```

After:
```
(key=url, path=*, default=https://github.com/linux-test-project/ltp/archive/master.zip) => 'https://github.com/linux-test-project/ltp/archive/master.zip'
[stdlog] 2024-04-05 12:33:49,037 avocado.utils.asset asset            L0398 INFO | Fetching asset ltp-master.zip

```