### PR TITLE
cpu/numatop: Remove POWER10 check

### DIFF
--- a/cpu/numatop.py
+++ b/cpu/numatop.py
@@ -18,11 +18,9 @@
 
 import os
 
-from avocado import Test, skipIf
+from avocado import Test
 from avocado.utils import archive, build, process, distro, cpu
 from avocado.utils.software_manager.manager import SoftwareManager
-
-IS_POWER10 = 'POWER10' in open('/proc/cpuinfo', 'r').read()
 
 
 class Numatop(Test):
@@ -34,8 +32,6 @@ class Numatop(Test):
     :avocado: tags=cpu,privileged
     """
 
-    @skipIf(IS_POWER10,
-            "numatop is not supported on POWER10 Architecture")
     def setUp(self):
         '''
         Build numatop Test


### PR DESCRIPTION
commit 25839aa added POWER10 support in numatop
  numatop/powerpc: Add power10 support

Remove the POWER10 check from the test so that it can run
on POWER10.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>