### PR TITLE
Fix for "Connection activation failed" Error on bridge interface.

### DIFF
--- a/io/net/bridge.py
+++ b/io/net/bridge.py
@@ -96,7 +96,6 @@ class Bridging(Test):
         '''
         try:
             self.networkinterface.add_ipaddr(self.ipaddr, self.netmask)
-            self.networkinterface.save(self.ipaddr, self.netmask)
         except Exception:
             self.networkinterface.save(self.ipaddr, self.netmask)
         self.networkinterface.bring_up()


### PR DESCRIPTION
This patch has updated code to fix the issue "Connection activation failed: No suitable device found for this connection" of a bridge interface.