### PR TITLE
perf/perf_mem: Add support for ubuntu

### DIFF
--- a/perf/perf_mem.py
+++ b/perf/perf_mem.py
@@ -42,6 +42,8 @@ class perf_mem(Test):
         deps = ['gcc', 'make']
         if self.distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
             deps.extend(['perf'])
+        elif self.distro_name in ['Ubuntu', 'debian']:
+            deps.extend(['linux-tools-common'])
         else:
             self.cancel("Install the package for perf supported \
                          by %s" % detected_distro.name)


### PR DESCRIPTION
Add a check to identify Ubuntu OS and install the required package.
Without this check the test fails to run on Ubuntu.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>