### PR TITLE
Correct ref cycles raw codes

### DIFF
--- a/perf/perf_genericevents.py
+++ b/perf/perf_genericevents.py
@@ -96,10 +96,10 @@ class test_generic_events(Test):
             self.log.info('FILE in %s is %s' % (dir, file))
             if raw_code != self.hex_to_int(val):
                 nfail += 1
-                self.log.info('FAIL : Expected value is %s or %s but got '
-                              '%s' % (val, self.hex_to_int(val), raw_code))
+                self.log.info('FAIL : Expected value is %s(hex: %s) but got '
+                              '%s' % (self.hex_to_int(val), val, raw_code))
             else:
-                self.log.info('PASS : Expected value: %s or %s and got '
-                              '%s' % (val, self.hex_to_int(val), raw_code))
+                self.log.info('PASS : Expected value is %s(hex: %s) and got '
+                              '%s' % (self.hex_to_int(val), val, raw_code))
         if nfail != 0:
             self.fail('Failed to verify generic PMU event codes')

--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -124,8 +124,8 @@ cache-references = 0xff60
 cache-misses = 0x0964
 branch-instructions = 0xc2
 branch-misses = 0xc3
-stalled-cycles-frontend = 0xa9
-ref-cycles = 0x120
+stalled-cycles-frontend = 0x00a9
+ref-cycles = 0x100000120
 
 [AMDZEN5]
 cpu-cycles = 0x76
@@ -134,5 +134,5 @@ cache-references = 0xff60
 cache-misses = 0x0964
 branch-instructions = 0xc2
 branch-misses = 0xc3
-stalled-cycles-frontend = 0xa9
-ref-cycles = 0x120
+stalled-cycles-frontend = 0x00a9
+ref-cycles = 0x100000120


### PR DESCRIPTION
Correct ref cycles event rawcode of amd64 respectively in zen4 and later in config file

debug.log ->

        [stdlog] 2024-04-16 13:31:10,450 avocado.test perf_genericeven L0062 INFO | AMD Family: 25 ZEN4
        ...
        [stdlog] 2024-04-16 13:31:10,451 avocado.test perf_genericeven L0096 INFO | FILE in /sys/bus/event_source/devices/cpu/events is ref-cycles
        [stdlog] 2024-04-16 13:31:10,451 avocado.test perf_genericeven L0102 INFO | PASS : Expected value: 0x100000120 or 4294967584 and got 4294967584
        ...

Signed-off-by: Ayush Jain <ayush.jain3@amd.com>