### PR TITLE
perf_cpu_hotplug_enhancements

### DIFF
--- a/perf/perf_cpu_hotplug.py
+++ b/perf/perf_cpu_hotplug.py
@@ -16,6 +16,7 @@
 
 import os
 import platform
+import random
 from avocado import Test
 from avocado.utils import cpu, dmesg, distro, genio
 from avocado.utils.software_manager.manager import SoftwareManager
@@ -87,7 +88,7 @@ class perf_cpu_hotplug(Test):
         hvgpci_present = False
         self.hv24x7_cpumask = False
         self.hvpgci_cpumask = False
-
+        self.events = ["hv_24x7", "hv_gpci"]
         hv24x7_present, self.hv24x7_cpumask = self._check_file("hv_24x7")
         hvgpci_present, self.hvpgci_cpumask = self._check_file("hv_gpci")
 
@@ -110,33 +111,53 @@ class perf_cpu_hotplug(Test):
         cpu_file = "/sys/bus/cpu/devices/cpu%s/online" % cpu_number
         if disable_flag:
             genio.write_one_line(cpu_file, "0")
-            self.log.info("Offline CPU: %s" % cpu_number)
+            self.log.info("Offlined CPU: %s" % cpu_number)
         else:
             genio.write_one_line(cpu_file, "1")
-            self.log.info("Online CPU: %s" % cpu_number)
+            self.log.info("Onlined CPU: %s" % cpu_number)
 
-    def _check_cpumask(self):
-        hv24x7_cpu = self._get_cpumask("hv_24x7")
-        hvgpci_cpu = self._get_cpumask("hv_gpci")
-        self.log.info("hv_24x7 cpumask = %s, hv_gpci cpumask = %s"
-                      % (hv24x7_cpu, hvgpci_cpu))
-        if hv24x7_cpu != hvgpci_cpu:
-            self.fail("cpumask values of hv24x7 and hv_gpci are not same.")
+    def test_cpumask_cpu_off_random(self):
+        """ Checks if the events hv_24X7 and hv_gpci points to any
+        offline cpu while randomly offlining n-1 CPUs """
+        for event in self.events:
+            for i in range(0, len(self.online_cpus)-1):
+                cpuno = random.choice(self.online_cpus)
+                self.log.info("Randomly offlining cpu no : %s" % cpuno)
+                self._cpu_on_off(cpuno)
+                self.cpu_off.append(cpuno)
+                new_event_cpu = self._get_cpumask(event)
+                self.log.info("Current cpumask of the %s event : %s " %
+                              (event, new_event_cpu))
+                self.online_cpus = cpu.online_list()
+                self.log.info("Updated online CPU list: %s" % self.online_cpus)
+                self.log.info("Updated offline CPU list:%s" % self.cpu_off)
+                if new_event_cpu not in self.online_cpus:
+                    self.fail("%s points to an offline cpu" % event)
+            for cpus in self.cpu_off:
+                self._cpu_on_off(cpus, disable_flag=False)
+                self.online_cpus = cpu.online_list()
 
-    def test_cpumask(self):
-        self._check_cpumask()
-
-    def test_cpumask_cpu_off(self):
-        disable_cpu = self._get_cpumask("hv_24x7")
-        self._cpu_on_off(disable_cpu)
-        current_cpu = self._get_cpumask("hv_24x7")
-        self.log.info("Current CPU: %s" % current_cpu)
-        if current_cpu in self.online_cpus and disable_cpu != current_cpu:
-            self.cpu_off.append(disable_cpu)
-        self._check_cpumask()
-
-    def tearDown(self):
-        dmesg.collect_dmesg()
-        if self.cpu_off:
-            for cpu in self.cpu_off:
-                self._cpu_on_off(cpu, disable_flag=False)
+    def test_cpumask_cpu_off_sequence(self):
+        """ Offlines the cpu pointed to by events hv_24X7 and hv_gpci
+        for n-1 times and  checks each time if the new cpu pointed
+        to by the events is an offline cpu """
+        for event in self.events:
+            for i in range(0, len(self.online_cpus)-1):
+                event_cpu = self._get_cpumask(event)
+                self.log.info("Offlining current cpu %s of %s event"
+                              % (event_cpu, event))
+                self._cpu_on_off(event_cpu)
+                self.cpu_off.append(event_cpu)
+                new_event_cpu = self._get_cpumask(event)
+                self.log.info("New cpumask of %s event : %s" %
+                              (event, new_event_cpu))
+                self.online_cpus = cpu.online_list()
+                self.log.info("Updated online CPU list: %s" % self.online_cpus)
+                self.log.info("Updated offline CPU list:%s" % self.cpu_off)
+                if event_cpu in self.online_cpus:
+                    self.fail("CPU offlining failed")
+                elif new_event_cpu == event_cpu | new_event_cpu not in self.online_cpus:
+                    self.fail("%s points to an offline cpu" % event)
+            for cpus in self.cpu_off:
+                self._cpu_on_off(cpus, disable_flag=False)
+                self.online_cpus = cpu.online_list()


### PR DESCRIPTION
Add two new test cases.
The first test case offlines n-1 cpus randomly and checks if hv_24X7 points to any offline cpu.
The second test case checks the cpu pointed to by hv_24X7 event and offlines it. It then checks if the new cpu pointed to by hv_24X7 event is an online cpu, else the test fails. This is repeated n-1 times in a loop

Logs:
avocado run perf_cpu_hotplug.py
JOB ID     : a128bdd0142561e3399d997d05a25f6c70fce192
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2024-04-23T10.20-a128bdd/job.log
 (2/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off: STARTED
 (1/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask: STARTED
 (3/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off_random: STARTED
 (1/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask: PASS (1.22 s)
 (2/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off: PASS (1.81 s)
 (4/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off_sequence: STARTED
 (3/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off_random: PASS (3.97 s)
 (4/4) perf_cpu_hotplug.py:perf_cpu_hotplug.test_cpumask_cpu_off_sequence: PASS (6.10 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2024-04-23T10.20-a128bdd/results.html
JOB TIME   : 44.81 s

[test1.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/15072603/test1.log)
[test2.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/15072604/test2.log)
[test3.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/15072605/test3.log)
[test4.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/15072606/test4.log)
