### PR TITLE
perf/perf_test: add dependent packages

### DIFF
--- a/perf/perf_test.py
+++ b/perf/perf_test.py
@@ -62,9 +62,11 @@ class Perftest(Test):
             elif 'debian' in detected_distro.name:
                 deps.extend(['linux-tools-%s' % platform.uname()[2][3]])
             elif detected_distro.name in ['rhel', 'SuSE', 'fedora', 'centos']:
-                deps.extend(['perf', 'gcc-c++'])
+                deps.extend(['perf', 'gcc-c++', 'bpftool'])
                 if 'SuSE' in detected_distro.name:
                     deps.extend(['kernel-default-debuginfo'])
+                elif 'rhel' in detected_distro.name:
+                    deps.extend(['clang', 'llvm', 'libbpf', 'python3-perf'])
                 elif 'fedora' in detected_distro.name:
                     deps.extend(['clang', 'kernel-debuginfo'])
                 else:


### PR DESCRIPTION
patch adds dependent packages needed to run the perf test

avocado run perf_test.py
JOB ID     : adedac829e04aa8c8feac87ed390f59fb2f8ba09
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-04-24T02.03-adedac8/job.log
 (1/1) perf_test.py:Perftest.test_perf_test: STARTED
 (1/1) perf_test.py:Perftest.test_perf_test: FAIL: 4 Test failed (104.39 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-04-24T02.03-adedac8/results.html
JOB TIME   : 123.77 s