### PR TITLE
perf/perf_24x7: fix domain and core values

### DIFF
--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -87,16 +87,9 @@ class hv_24x7_all_events(Test):
                         " the 24x7 counters info")
 
         # Getting the number of cores and chips available in the machine
-        output = process.run("lscpu")
-        for line in output.stdout.decode("utf-8").split('\n'):
-            if 'Core(s) per socket:' in line:
-                self.cores = int(line.split(':')[1].strip())
-            if 'Physical sockets:' in line:
-                self.physical_sockets = int(line.split(':')[1].strip())
-            if 'Physical chips:' in line:
-                self.physical_chips = int(line.split(':')[1].strip())
-        # chip = physical socket x physical chip
-        self.chip = int(self.physical_sockets*self.physical_chips)
+        self.chips = cpu.lscpu()["chips"]
+        self.phys_cores = cpu.lscpu()["physical_cores"]
+        self.vir_cores = cpu.lscpu()["virtual_cores"]
 
         # Collect all hv_24x7 events
         self.list_of_hv_24x7_events = []
@@ -113,7 +106,11 @@ class hv_24x7_all_events(Test):
             if line.startswith('HP') or line.startswith('CP'):
                 # Running for domain range from 1-6
                 for domain in range(2, 7):
-                    for core in range(0, self.cores + 1):
+                    if domain == 2:
+                        core_range = self.phys_cores
+                    else:
+                        core_range = self.vir_cores
+                    for core in range(0, core_range):
                         events = "hv_24x7/%s,domain=%s,core=%s/" % \
                                  (line, domain, core)
                         cmd = 'perf stat %s %s sleep 1' % (perf_args, events)
@@ -121,8 +118,8 @@ class hv_24x7_all_events(Test):
                         if res.exit_status != 0 or b"not supported" in res.stderr:
                             self.fail_cmd.append(cmd)
             else:
-                for chip_item in range(0, self.chip):
-                    events = "hv_24x7/%s,chip=%s/" % (line, chip_item)
+                for chip_item in range(0, self.chips):
+                    events = "hv_24x7/%s,domain=1,chip=%s/" % (line, chip_item)
                     cmd = "perf stat %s %s sleep 1" % (perf_args, events)
                     res = process.run(cmd, ignore_status=True)
                     if res.exit_status != 0 or b"not supported" in res.stderr:


### PR DESCRIPTION
This patch changes the logic to run domain=2 with physical cores and domain>2 with virtual cores available in the lpar.
Reference for above changes:
1: Physical Chip
2: Physical Core
3: VCPU Home Core
4: VCPU Home Chip
5: VCPU Home Node
6: VCPU Remote Node

Also integrated getting core and chip values directly from cpu.lscpu from avocado utils.
```
avocado run --max-parallel-tasks=1 perf_24x7_hardware_counters.py
JOB ID     : 022e5a78dd28c7deeccde4f8a90e005958883273
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-04-24T07.17-022e5a7/job.log
 (01/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_display_domain_indices_in_sysfs: STARTED
 (01/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_display_domain_indices_in_sysfs: PASS (1.32 s)
 (02/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_phys_core_param: STARTED
 (02/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_phys_core_param: CANCEL: HPM_0THRD_NON_IDLE_CCYC__PHYS_CORE not found (5.73 s)
 (03/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_domain_param: STARTED
 (03/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_domain_param: PASS (1.33 s)
 (04/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_all_domains: STARTED
 (04/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_all_domains: PASS (26.63 s)
 (05/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_invalid_domains: STARTED
 (05/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_invalid_domains: PASS (3.36 s)
 (06/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_invalid_core: STARTED
 (06/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_invalid_core: PASS (1.33 s)
 (07/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_w_chip_param: STARTED
 (07/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_w_chip_param: PASS (1.32 s)
 (08/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_chip_param: STARTED
 (08/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_wo_chip_param: PASS (1.34 s)
 (09/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_valid_chip: STARTED
 (09/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_valid_chip: PASS (1.37 s)
 (10/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_invalid_chip: STARTED
 (10/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_check_invalid_chip: PASS (1.34 s)
 (11/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_domain_chip_offset: STARTED
 (11/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_domain_chip_offset: PASS (101.54 s)
 (12/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_phys_core: STARTED
 (12/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_phys_core: PASS (1.35 s)
 (13/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_vcpu: STARTED
 (13/13) perf_24x7_hardware_counters.py:EliminateDomainSuffix.test_event_helper_vcpu: PASS (1.34 s)
RESULTS    : PASS 12 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-04-24T07.17-022e5a7/results.html
JOB TIME   : 242.99 s
```
```
avocado run perf_24x7_all_events.py
JOB ID     : 5c9e19e40c1b3d5dcabb3ebf664b45dc7499d60f
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-04-24T23.39-5c9e19e/job.log
 (1/1) perf_24x7_all_events.py:hv_24x7_all_events.test_all_events: STARTED
 (1/1) perf_24x7_all_events.py:hv_24x7_all_events.test_all_events: PASS (1184.11 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-04-24T23.39-5c9e19e/results.html
JOB TIME   : 1202.60 s
```