### PR TITLE
annobin-tests.py: Run 'make' before 'make check'

### DIFF
--- a/security/annobin-tests.py
+++ b/security/annobin-tests.py
@@ -66,6 +66,10 @@ class annobin(Test):
         Running tests from annobin
         '''
         count = 0
+        output = build.run_make(self.annobin_dir,
+                                process_kwargs={"ignore_status": True})
+        if output.exit_status:
+            self.cancel("annobin-tests.py: make failed")
         output = build.run_make(self.annobin_dir, extra_args="check",
                                 process_kwargs={"ignore_status": True})
         if output.exit_status:


### PR DESCRIPTION
Run 'make' before running 'make check'.


Reproted-by: Kowshik Jois B S <kowsjois@linux.ibm.com>