### PR TITLE
perf/perf_sdt_probe: refine parsing logic for locating libpthread & libc

### DIFF
--- a/perf/perf_sdt_probe.py
+++ b/perf/perf_sdt_probe.py
@@ -54,10 +54,10 @@ class PerfSDT(Test):
         for line in str(self.libpthread).splitlines():
             if re.search('libpthread.so', line, re.IGNORECASE):
                 if 'lib64' in line:
-                    self.libpthread = line.split(" ")[7]
+                    self.libpthread = line.split("=>")[1]
             if re.search('libc.so', line, re.IGNORECASE):
                 if 'lib64' in line:
-                    self.libc = line.split(" ")[7]
+                    self.libc = line.split("=>")[1]
         if not self.libpthread:
             self.fail("Library %s not found" % self.libpthread)
         if not self.libc:


### PR DESCRIPTION
On recent SLES distro test fails with below error due to issues locating libpthread and libc.
ERROR: Unable to remove 1062 libs found in cache `/etc/ld.so.cache’

On older distros, the path were identified as follows: 
libpthread.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libpthread.so.0 
libc.so.6 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc.so.6

On current distro, the format changed to:
libpthread.so.0 (libc6,64bit) => /lib64/libpthread.so.0 
libc.so.6 (libc6,64bit) => /lib64/libc.so.6

To address this, the parsing logic is updated to correctly identify the paths in both cases.
```
On SLES
avocado run perf_sdt_probe.py
JOB ID     : 234e5315e5ae74fa969e9f9cdbe34b2f9a9dfaf2
JOB LOG    : /home/rohan/avocado-fvt-wrapper/results/job-2024-04-29T21.16-234e531/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: STARTED
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (159.91 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/rohan/avocado-fvt-wrapper/results/job-2024-04-29T21.16-234e531/results.html
JOB TIME   : 209.40 s
```
```
On RHEL
avocado run perf_sdt_probe.py
JOB ID     : 83732b3fa5559da514fcf8d04c4e55e8a5d22caa
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-04-29T09.34-83732b3/job.log
 (1/1) perf_sdt_probe.py:PerfSDT.test: STARTED
 (1/1) perf_sdt_probe.py:PerfSDT.test: PASS (94.40 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-04-29T09.34-83732b3/results.html
JOB TIME   : 144.34 s
```
[debug.log](https://github.com/avocado-framework-tests/avocado-misc-tests/files/15153111/debug.log)