### PR TITLE
enhanced nvmetest.py to convert the total capacity of disk from strig to integer.

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -174,7 +174,7 @@ class NVMeTest(Test):
         """
         output = self.get_id_ctrl_prop('tnvmcap')
         if output:
-            return int(output)
+            return int(output.replace(',', ''))
         return 0
 
     def ns_list(self):


### PR DESCRIPTION


Due to recent changes in nvmecli tool, the total capacity of disk is listed as string as comma (,) separated, but the test need the integer value due to which the tests were failing. fixed the same and now tests are running fine.