### PR TITLE
perf: update c2c/sched/top yaml files

### DIFF
--- a/perf/perf_c2c.py.data/record_report.yaml
+++ b/perf/perf_c2c.py.data/record_report.yaml
@@ -19,6 +19,10 @@ record: !mux
                 record_method: -u
         all_user_full:
                 record_method: --all-user
+        verbose:
+                record_method: -v
+        verbose_full:
+                record_method: --verbose
 
 report: !mux
         coalesce:
@@ -63,3 +67,7 @@ report: !mux
                 report_method: --stats
         stdio:
                 report_method: --stdio
+        verbose:
+              report_method: -v
+        verbose_full:
+              report_method: --verbose

--- a/perf/perf_sched.py.data/perf_sched.yaml
+++ b/perf/perf_sched.py.data/perf_sched.yaml
@@ -4,14 +4,14 @@ subsystem: !mux
     script:
         name: script
     replay:
-        name: replay
+        name: replay -f
     map:
         name: map
         variants: !mux
             compact:
                 option: --compact
             cpus:
-                option: --cpus 0
+                option: --cpus 0 -v
             color-cpus:
                 option: --color-cpus 0
             color-pids:
@@ -20,7 +20,7 @@ subsystem: !mux
         name: timehist
         variants: !mux
             call-graph:
-                option: -g
+                option: -g -D
             call-graph_full:
                 option: --call-graph
             max-stack:
@@ -38,7 +38,7 @@ subsystem: !mux
             tid_full:
                 option: --tid 10
             summary:
-                option: -s
+                option: -s -f
             summary_full:
                 option: --summary
             with-summary:

--- a/perf/perf_top.py.data/perf_top.yaml
+++ b/perf/perf_top.py.data/perf_top.yaml
@@ -50,13 +50,13 @@ variants: !mux
     mmap-pages_full:
         option: --mmap-pages 8
     pid:
-        option: -p 10
+        option: -p 1
     pid_full:
-        option: --pid 10
+        option: --pid 1
     tid:
-        option: -t 10
+        option: -t 1
     tid_full:
-        option: --tid 10
+        option: --tid 1
     uid:
         option: -u 1
     uid_full:
@@ -159,9 +159,9 @@ variants: !mux
         option: --namespaces
     all-cgroups:
         option: --all-cgroups
-    switch-on:
-        option: --switch-on cycles
-    switch-off:
-        option: --switch-off cycles
     show-on-off-events:
         option: --show-on-off-events
+    addr2line:
+        option: --addr2line /usr/bin/addr2line
+    objdump:
+        option: --objdump /usr/bin/objdump


### PR DESCRIPTION
Update perf_c2c, perf_sched and perf_top yaml files with new options available and removing unsupported options from perf_top yaml. commit 57594454ceb92 which adds support for addr2line and objdump

Also perf sched replay fails on some lpar where it reaches the limitation of the maximum open files. This is fixed by using -f option. commit 939cda521a24

Update values for pid and tid in perf_top yaml as with current value it fails with error Unknown option -p 10.
```
avocado run --max-parallel-tasks=1 perf_c2c.py -m perf_c2c.py.data/record_report.yaml
JOB ID     : e6ba5680e1b73cd7961b5a89e308e5447bab6bac
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-08T01.54-e6ba568/job.log
 (1/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose-report-5336: STARTED
 (1/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose-report-5336: PASS (1.55 s)
 (2/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose-report-verbose_full-e552: STARTED
 (2/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose-report-verbose_full-e552: PASS (1.57 s)
 (3/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose_full-report-verbose-1ad8: STARTED
 (3/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose_full-report-verbose-1ad8: PASS (1.53 s)
 (4/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose_full-report-7647: STARTED
 (4/4) perf_c2c.py:perf_c2c.test_c2c;run-record-verbose_full-report-7647: PASS (1.56 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-08T01.54-e6ba568/results.html
JOB TIME   : 35.02 s
```
```
avocado run --max-parallel-tasks=1 perf_sched.py -m perf_sched.py.data/perf_sched.yaml
JOB ID     : c890116f2a84fa6ed99f8d08043aaf90837688b6
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-08T01.57-c890116/job.log
 (1/4) perf_sched.py:perf_sched.test_sched;run-subsystem-replay-8021: STARTED
 (1/4) perf_sched.py:perf_sched.test_sched;run-subsystem-replay-8021: PASS (3.05 s)
 (2/4) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-cpus-8ac4: STARTED
 (2/4) perf_sched.py:perf_sched.test_sched;run-subsystem-map-variants-cpus-8ac4: PASS (2.51 s)
 (3/4) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph-3484: STARTED
 (3/4) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-call-graph-3484: PASS (200.48 s)
 (4/4) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary-f446: STARTED
 (4/4) perf_sched.py:perf_sched.test_sched;run-subsystem-timehist-variants-summary-f446: PASS (2.54 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-08T01.57-c890116/results.html
JOB TIME   : 274.70 s
```
```
avocado run --max-parallel-tasks=1 perf_top.py:test_top -m perf_top.py.data/perf_top.yaml
JOB ID     : fa47ae9115e5abeb869ac3752cad2e062a3b3045
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-08T04.17-fa47ae9/job.log
 (1/6) perf_top.py:perf_top.test_top;run-variants-pid-b5dd: STARTED
 (1/6) perf_top.py:perf_top.test_top;run-variants-pid-b5dd: PASS (40.58 s)
 (2/6) perf_top.py:perf_top.test_top;run-variants-pid_full-2f6f: STARTED
 (2/6) perf_top.py:perf_top.test_top;run-variants-pid_full-2f6f: PASS (40.59 s)
 (3/6) perf_top.py:perf_top.test_top;run-variants-tid-1026: STARTED
 (3/6) perf_top.py:perf_top.test_top;run-variants-tid-1026: PASS (40.57 s)
 (4/6) perf_top.py:perf_top.test_top;run-variants-tid_full-1578: STARTED
 (4/6) perf_top.py:perf_top.test_top;run-variants-tid_full-1578: PASS (40.58 s)
 (5/6) perf_top.py:perf_top.test_top;run-variants-addr2line-9915: STARTED
 (5/6) perf_top.py:perf_top.test_top;run-variants-addr2line-9915: PASS (40.53 s)
 (6/6) perf_top.py:perf_top.test_top;run-variants-objdump-4a13: STARTED
 (6/6) perf_top.py:perf_top.test_top;run-variants-objdump-4a13: PASS (40.53 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-08T04.17-fa47ae9/results.html
JOB TIME   : 271.58 s
```