### PR TITLE
Adding EEH support for non mellanox driver

### DIFF
--- a/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
@@ -24,3 +24,4 @@ host_public_ip: ""
 host_password: ""
 peer_user: ""
 peer_password: ""
+is_mlx_driver: True


### PR DESCRIPTION
Test is extended to run EEH for non-mellanox drivers. A new yaml parameter 'is_mlx'driver' is introduced for this test