### PR TITLE
Added the fix for stop ebizzy workload function

### DIFF
--- a/workload/ebizzy_workload.py
+++ b/workload/ebizzy_workload.py
@@ -53,17 +53,19 @@ class ebizzy(Test):
 
     def test_start_ebizzy_workload(self):
         # Run ebizzy workload for time duration taken from YAML file
-        process.run("./ebizzy {0} &> /tmp/ebizzy_workload.log &".format(
-            self.args), ignore_status=True, sudo=True, shell=True)
+        process.run("./ebizzy {0} &> /tmp/ebizzy_workload.log &".format(self.args), ignore_status=True, sudo=True, shell=True)
         self.log.info("Workload started--!!")
 
     def test_stop_ebizzy_workload(self):
-        ps = process.system_output(
-            "ps -e", ignore_status=True).decode().splitlines()
+        ps = process.system_output("ps -e", ignore_status=True, shell=True).decode().splitlines()
         pid = 0
+        flag = 0
         for w_load in ps:
             if "ebizzy" in w_load:
-                pid = int(w_load.split(" ")[0])
+                pid = int(w_load.strip().split(" ")[0])
+                flag = 1
                 break
         if pid:
             os.kill(pid, 9)
+        if flag == 0:
+            self.cancel("Ebizzy workload is not running or already execution finished")


### PR DESCRIPTION
One extra space was coming in start of output of "ps -e" command, added the fix using python strip() function and pycodestyle fix.

[root@ workload]# avocado run --max-parallel-tasks=1 ebizzy_workload.py:test_stop_ebizzy_workload
Fetching asset from ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload
JOB ID     : eba7f5e70489870232d14b44919b30b21afd48bd
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-15T01.30-eba7f5e/job.log
 (1/1) ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload: STARTED
 (1/1) ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload: CANCEL: Ebizzy workload is not running or already execution finished (0.64 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-15T01.30-eba7f5e/results.html
JOB TIME   : 32.86 s

[root@workload]# avocado run --max-parallel-tasks=1 ebizzy_workload.py:test_stop_ebizzy_workload
Fetching asset from ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload
JOB ID     : 968e8b17abfb5a582450a41732098f5b04992294
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-15T01.32-968e8b1/job.log
 (1/1) ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload: STARTED
 (1/1) ebizzy_workload.py:ebizzy.test_stop_ebizzy_workload: PASS (6.11 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-15T01.32-968e8b1/results.html
JOB TIME   : 335.45 s