### PR TITLE
smtstate.py: fix ERROR: eval() arg 1 must be a string, bytes or code object

### DIFF
--- a/ras/smtstate.py
+++ b/ras/smtstate.py
@@ -37,8 +37,8 @@ class smtstate_tool(Test):
         if "is not SMT capable" in smt_op:
             self.cancel("Machine is not SMT capable, skipping the test")
         distro_name = self.detected_distro.name
-        distro_ver = eval(self.detected_distro.version)
-        distro_rel = eval(self.detected_distro.release)
+        distro_ver = eval(str(self.detected_distro.version))
+        distro_rel = eval(str(self.detected_distro.release))
         if distro_name == "rhel":
             if (distro_ver == 7 or
                     (distro_ver == 8 and distro_rel < 4)):


### PR DESCRIPTION

As eval() is expecting argument as string,bytes or code object but we are getting an integer value so converted that to string.