### PR TITLE
Automated "perf sched benchmark" test.

### DIFF
--- a/cpu/perf_pipe_benchmark.py
+++ b/cpu/perf_pipe_benchmark.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2024 IBM
+# Author: Samir A Mulani <samir@linux.vnet.ibm.com>
+
+from avocado import Test
+from avocado.utils import process
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class perf_sched_pip_workload(Test):
+
+    def setUp(self):
+        """
+        In This test case command runs a scheduler benchmark using
+        perf bench to test pipeline workload performance, repeating
+        it 5 times for accuracy with 10,000,000 iterations.
+        perf stat collects performance statistics during the benchmark.
+        """
+        pkgs = []
+        smm = SoftwareManager()
+        pkgs.extend(["perf"])
+        for pkg in pkgs:
+            if not smm.check_installed(pkg) and not smm.install(pkg):
+                self.cancel(f"Not able to install {pkg}")
+
+        self.stat_loop = self.params.get("stat_loop", default=5)
+        self.load_iteration = self.params.get(
+            "load_iteration", default=10000000)
+
+    def run_workload(self, cmd):
+        perf_stats_data = process.run(cmd)
+        self.log.info(f"successfully run cmd: {cmd}")
+        return perf_stats_data
+
+    def extract_data(self, payload_data):
+        data = (payload_data.stderr)
+        lines = data.decode("utf-8").split("\n")
+        filtered_data = [line.strip() for line in lines if line.strip()]
+        return filtered_data
+
+    def test(self):
+        """
+        In this function we are running the perf benchmark
+        for scheduler pipeline.
+        """
+        cmd = "perf stat -r %s -a perf bench sched pipe \
+                -l %s" % (self.stat_loop, self.load_iteration)
+        payload_data = self.run_workload(cmd)
+        filtered_data = self.extract_data(payload_data)
+        self.log.info(f"Performance matrix : \n {filtered_data[-1]}")
+
+        cmd = "perf stat -n -r %s perf bench sched pipe" % (self.stat_loop)
+        payload_data = self.run_workload(cmd)
+        filtered_data = self.extract_data(payload_data)
+        self.log.info(f"Performance matrix: \n {filtered_data[-1]}")

--- a/cpu/perf_pipe_benchmark.py.data/README.txt
+++ b/cpu/perf_pipe_benchmark.py.data/README.txt
@@ -1,0 +1,36 @@
+Performance Testing with perf
+*****************************
+
+This test case includes performance benchmarks using the perf tool to measure and analyze scheduling performance. Below are the commands used to perform these benchmarks along with their descriptions.
+
+Command 1: perf stat -r 5 -a perf bench sched pipe -l 10000000
+*********
+This command measures the performance of the sched pipe benchmark with a specified loop count.
+
+Prameter details:
+****************
+-> perf stat: Collects and displays performance statistics.
+-> -r 5: Runs the benchmark 5 times and averages the results.
+-> -a: Collects data system-wide.
+-> perf bench sched pipe -l 10000000: Runs the scheduling pipe benchmark with 10,000,000 iterations.
+
+This command provides an average performance measurement over 5 runs, giving a more stable and 
+reliable set of statistics for the scheduling pipe benchmark with a high loop count.
+
+Command 2: perf stat -n -r 5 perf bench sched pipe
+*********
+This command also measures the performance of the sched pipe benchmark but with a default loop count.
+
+Prameter details:
+****************
+-> perf stat: Collects and displays performance statistics.
+-> -n: Ensures that the results include a notation of how many times each event was recorded.
+-> -r 5: Runs the benchmark 5 times and averages the results.
+-> perf bench sched pipe: Runs the scheduling pipe benchmark with the default number of iterations.
+
+This command is useful for obtaining a quick performance snapshot with the default settings, averaged over 5 runs for consistency.
+
+Understanding the Output:
+************************
+The output will include various performance metrics such as the number of context switches, CPU cycles, instructions per cycle, and more.
+By running these benchmarks multiple times, we can ensure that the results are averaged, providing a more accurate representation of the system's performance.

--- a/cpu/perf_pipe_benchmark.py.data/sched_pipe.yaml
+++ b/cpu/perf_pipe_benchmark.py.data/sched_pipe.yaml
@@ -1,0 +1,2 @@
+stat_loop: 5
+load_iteration: 10000000


### PR DESCRIPTION
Here in this test case  the command is running a scheduler benchmark using perf with the perf bench subcommand, specifically testing the scheduler's performance with a pipeline workload. The benchmark is repeated 5 times for accuracy, and the pipeline length is set to 10,000,000 tasks. The perf stat command is used to collect performance statistics during the benchmarking process.