### PR TITLE
cpu/xive.py : fixed 'utf-8' codec error

### DIFF
--- a/cpu/xive.py
+++ b/cpu/xive.py
@@ -42,7 +42,7 @@ class XIVE(Test):
         else:
             self.cancel("Unsupported processor family")
 
-        mode = genio.read_file("/proc/interrupts")
+        mode = genio.read_file("/proc/interrupts").rstrip('\t\r\n\0')
         if 'XIVE' in mode:
             self.intr = 'XIVE'
         elif 'XICS' in mode:


### PR DESCRIPTION
The file contains characters that are not valid UTF-8 encoded. This patch will fix the errors while reading the file.