### PR TITLE
Use correct syntax during drmgr invocation

### DIFF
--- a/cpu/cpustress.py
+++ b/cpu/cpustress.py
@@ -278,13 +278,13 @@ class cpustresstest(Test):
                     self.log.info("DLPAR remove cpu operation")
                     init_count = int(multiprocessing.cpu_count())
                     process.run(
-                        "drmgr -c cpu -d 5 -w 30 -r", shell=True,
+                        "drmgr -c cpu -d 5 -w 30 -r -q 1", shell=True,
                         ignore_status=True, sudo=True)
                     if int(multiprocessing.cpu_count()) >= init_count:
                         self.log.info("no more hotunpluggable cpus")
                     self.log.info("DLPAR add cpu operation")
                     process.run(
-                        "drmgr -c cpu -d 5 -w 30 -a", shell=True,
+                        "drmgr -c cpu -d 5 -w 30 -a -q 1", shell=True,
                         ignore_status=True, sudo=True)
                     if init_count != int(multiprocessing.cpu_count()):
                         self.log.info("no more hotpluggable cpus")

--- a/ras/ras_ppcutils.py
+++ b/ras/ras_ppcutils.py
@@ -154,9 +154,9 @@ class RASToolsPpcutils(Test):
         if lcpu_count:
             lcpu_count = int(lcpu_count)
             if lcpu_count >= 2:
-                self.run_cmd("drmgr -c cpu -r 1")
+                self.run_cmd("drmgr -c cpu -r -q 1")
                 self.run_cmd("lparstat")
-                self.run_cmd("drmgr -c cpu -a 1")
+                self.run_cmd("drmgr -c cpu -a -q 1")
                 self.run_cmd("lparstat")
         self.error_check()
 

--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -314,8 +314,8 @@ class Sosreport(Test):
             if lcpu_count:
                 lcpu_count = int(lcpu_count)
                 if lcpu_count >= 2:
-                    self.run_cmd("drmgr -c cpu -r 1")
-                    self.run_cmd("drmgr -c cpu -a 1")
+                    self.run_cmd("drmgr -c cpu -r -q 1")
+                    self.run_cmd("drmgr -c cpu -a -q 1")
                     self.run_cmd("%s --batch --tmp-dir=%s --all-logs" %
                                  (self.sos_cmd, directory_name))
                 else:
@@ -342,8 +342,8 @@ class Sosreport(Test):
             if mem_count:
                 mem_count = int(mem_count)
                 if mem_count > 512000:
-                    self.run_cmd("drmgr -c mem -r 2")
-                    self.run_cmd("drmgr -c mem -a 2")
+                    self.run_cmd("drmgr -c mem -r -q 2")
+                    self.run_cmd("drmgr -c mem -a -q 2")
                     self.run_cmd("%s --batch --tmp-dir=%s --all-logs" %
                                  (self.sos_cmd, directory_name))
                 else:

--- a/ras/supportconfig.py
+++ b/ras/supportconfig.py
@@ -183,8 +183,8 @@ class Supportconfig(Test):
             if lcpu_count:
                 lcpu_count = int(lcpu_count)
                 if lcpu_count >= 2:
-                    process.run("drmgr -c cpu -r 1")
-                    process.run("drmgr -c cpu -a 1")
+                    process.run("drmgr -c cpu -r -q 1")
+                    process.run("drmgr -c cpu -a -q 1")
                     process.run("supportconfig", sudo=True, ignore_status=True)
                 else:
                     self.is_fail += 1
@@ -210,8 +210,8 @@ class Supportconfig(Test):
             if mem_count:
                 mem_count = int(mem_count)
                 if mem_count > 512000:
-                    process.run("drmgr -c mem -r 2")
-                    process.run("drmgr -c mem -a 2")
+                    process.run("drmgr -c mem -r -q 2")
+                    process.run("drmgr -c mem -a -q 2")
                     process.run("supportconfig", sudo=True, ignore_status=True)
                 else:
                     self.is_fail += 1


### PR DESCRIPTION
Some of the tests sosreport, supportconfig and likes invoke
drmgr to add/remove cpu/memory resources. The commands
used during the execution are syntatically incorrect.
 For example:
    drmgr -c mem -r 2
 Correct command to use:
    drmgr -c mem -r -q 2

Update the relevant tests to use correct syntax

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>