### PR TITLE
Patch to fix Netperf_test "timeout" issues.

### DIFF
--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -91,7 +91,7 @@ class Netperf(Test):
                             % pkg)
         if self.peer_ip == "":
             self.cancel("%s peer machine is not available" % self.peer_ip)
-        self.timeout = self.params.get("TIMEOUT", default="600")
+
         self.mtu = self.params.get("mtu", default=1500)
         self.remotehost = RemoteHost(self.peer_ip, self.peer_user,
                                      password=self.peer_password)
@@ -147,6 +147,10 @@ class Netperf(Test):
         self.duration = self.params.get("duration", default="300")
         self.min = self.params.get("minimum_iterations", default="1")
         self.max = self.params.get("maximum_iterations", default="15")
+
+        # setting netperf timeout values dynamically based on
+        # duration and max values, with additional 60 sec.
+        self.timeout = self.duration * self.max + 60
         self.option = self.params.get("option", default='')
 
     def test(self):

--- a/io/net/netperf_test.py.data/README.txt
+++ b/io/net/netperf_test.py.data/README.txt
@@ -10,7 +10,6 @@ interface		- test interface name eth2 or mac addr 02:5d:c7:xx:xx:03
 PEERIP			- IP of the Peer interface to be tested
 PEERUSER		- Username in Peer system to be used
 Iface			- interface on which test run
-timeout			- Timeout
 NETSERVER_RUN		- Whether to run netserver in peer or not (1 to run, 0 to not run)
 EXPECTED_THROUGHPUT	- Expected Throughput as a percentage (1-100)
 netperf_download	- User has the option to choose download location for netperf tool.

--- a/io/net/netperf_test.py.data/netperf_test.yaml
+++ b/io/net/netperf_test.py.data/netperf_test.yaml
@@ -5,7 +5,6 @@ host_ip: ""
 netmask: ""
 peer_user: "root"
 peer_password: "********"
-TIMEOUT: "720"
 NETSERVER_RUN: 1
 EXPECTED_THROUGHPUT: 90
 duration: 120

--- a/io/net/netperf_test.py.data/netperf_test_virt.yaml
+++ b/io/net/netperf_test.py.data/netperf_test_virt.yaml
@@ -5,7 +5,6 @@ host_ip: ""
 netmask: ""
 peer_user: "root"
 peer_password: "********"
-TIMEOUT: "720"
 NETSERVER_RUN: 1
 EXPECTED_THROUGHPUT: 90
 duration: 120


### PR DESCRIPTION
This patch assigns netperf command timeout values dynamically which helps to avoid "command execution timeouts" errors during the test execution.