### PR TITLE
check_sb

### DIFF
--- a/trace/kprobe.py
+++ b/trace/kprobe.py
@@ -78,12 +78,17 @@ class Kprobe(Test):
         for package in deps:
             if not smg.check_installed(package) and not smg.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
+        cmd = "lsprop  /proc/device-tree/ibm,secure-boot"
+        output = process.system_output(cmd, ignore_status=True).decode()
+        if '00000002' in output:
+            self.cancel("Secure boot is enabled.")
 
     def build_module(self):
         """
         Building of the kprobe kernel module
         """
-        self.log.info("============== Building kprobe Module =================")
+        self.log.info(
+            "============== Building kprobe Module =================")
         self.sourcedir = tempfile.mkdtemp()
         os.chdir(self.sourcedir)
 
@@ -117,7 +122,8 @@ class Kprobe(Test):
             self.fail("insmod kprobe_example.ko failed")
 
         if "Planted kprobe" not in self.run_cmd_out("dmesg |grep -i planted"):
-            self.fail("kprobe couldn't be planted, check dmesg for more information")
+            self.fail(
+                "kprobe couldn't be planted, check dmesg for more information")
 
         """
         Execute date to trigger kernel_clone syscall
@@ -132,12 +138,14 @@ class Kprobe(Test):
             self.fail("rmmod kprobe_example.ko failed")
 
         if "kprobe" not in self.run_cmd_out("dmesg |grep -i unregistered"):
-            self.fail("kprobe unregistering failed, check dmesg for more information")
+            self.fail(
+                "kprobe unregistering failed, check dmesg for more information")
 
     def optprobes_disable_test(self):
         optprobes_file = "/proc/sys/debug/kprobes-optimization"
         if not self.check_kernel_support():
-            self.log.info("No support available for optprobes, skipping optprobes test")
+            self.log.info(
+                "No support available for optprobes, skipping optprobes test")
             return
 
         if not os.path.exists(optprobes_file):
@@ -147,12 +155,14 @@ class Kprobe(Test):
 
         cur_val = genio.read_one_line(optprobes_file)
         genio.write_one_line(optprobes_file, "0")
-        self.log.info("================= Disabling optprobes ==================")
+        self.log.info(
+            "================= Disabling optprobes ==================")
         if "0" not in genio.read_one_line(optprobes_file):
             self.fail("Not able to disable optprobes")
         self.execute_test()
 
-        self.log.info("================= Restoring optprobes ==================")
+        self.log.info(
+            "================= Restoring optprobes ==================")
         genio.write_one_line(optprobes_file, cur_val)
         if cur_val not in genio.read_one_line(optprobes_file):
             self.fail("Not able to restore optprobes to %s", cur_val)

--- a/trace/kretprobe.py
+++ b/trace/kretprobe.py
@@ -71,19 +71,25 @@ class Kretprobe(Test):
         for package in deps:
             if not smg.check_installed(package) and not smg.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
+        cmd = "lsprop  /proc/device-tree/ibm,secure-boot"
+        output = process.system_output(cmd, ignore_status=True).decode()
+        if '00000002' in output:
+            self.cancel("Secure boot is enabled.")
 
     def build_module(self):
         """
         Building of the kretprobe kernel module
         """
-        self.log.info("============== Building kretprobe Module =================")
+        self.log.info(
+            "============== Building kretprobe Module =================")
         self.sourcedir = tempfile.mkdtemp()
         os.chdir(self.sourcedir)
 
         self.location = ('https://raw.githubusercontent.com/torvalds/linux/'
                          'master/samples/kprobes/kretprobe_example.c')
         self.kretprobe_file = self.fetch_asset(self.location, expire='7d')
-        self.kretprobe_dst = os.path.join(self.sourcedir, 'kretprobe_example.c')
+        self.kretprobe_dst = os.path.join(
+            self.sourcedir, 'kretprobe_example.c')
         shutil.copy(self.kretprobe_file, self.kretprobe_dst)
 
         """
@@ -110,7 +116,8 @@ class Kretprobe(Test):
             self.fail("insmod kretprobe_example.ko failed")
 
         if "Planted return probe" not in self.run_cmd_out("dmesg |grep -i planted"):
-            self.fail("kretprobe couldn't be planted, check dmesg for more information")
+            self.fail(
+                "kretprobe couldn't be planted, check dmesg for more information")
 
         """
         Execute date to trigger kernel_clone syscall
@@ -118,14 +125,16 @@ class Kretprobe(Test):
         self.run_cmd("date")
 
         if "return" not in self.run_cmd_out("dmesg |grep -i kernel_clone"):
-            self.fail("kretprobe probing issues, check dmesg for more information")
+            self.fail(
+                "kretprobe probing issues, check dmesg for more information")
 
         self.run_cmd("rmmod kretprobe_example")
         if self.is_fail >= 1:
             self.fail("rmmod kretprobe_example.ko failed")
 
         if "kretprobe" not in self.run_cmd_out("dmesg |grep -i unregistered"):
-            self.fail("kretprobe unregistering failed, check dmesg for more information")
+            self.fail(
+                "kretprobe unregistering failed, check dmesg for more information")
 
     def test(self):
         self.build_module()

--- a/trace/perf_watch_point.py
+++ b/trace/perf_watch_point.py
@@ -51,6 +51,10 @@ class PerfWatchPoint(Test):
         for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
+        cmd = "lsprop  /proc/device-tree/ibm,secure-boot"
+        output = process.system_output(cmd, ignore_status=True).decode()
+        if '00000002' in output:
+            self.cancel("Secure boot is enabled.")
         archive.extract(self.get_data("wptest-master.tar.gz"), self.workdir)
         self.build_dir = os.path.join(self.workdir, 'wptest-master')
         build.make(self.build_dir)


### PR DESCRIPTION
Check if secure boot is enabled. If yes, cancel running krpobe, kretprobe and watchpoint tests

 # dmesg | grep -i secu
[    0.000000] Secure boot mode enabled
[    0.000000] Kernel is locked down from Power secure boot; see man kernel_lockdown.7
[    1.221386] Loaded X.509 cert 'Red Hat Secure Boot CA 7: c442130fde4c50fa1686bbf0692e3ebc64f5db3e'
[    1.226359] Secure boot mode enabled
[    1.237816] Secure boot mode enabled
[    1.237866] evm: security.selinux
[    1.237867] evm: security.SMACK64 (disabled)
[    1.237868] evm: security.SMACK64EXEC (disabled)
[    1.237868] evm: security.SMACK64TRANSMUTE (disabled)
[    1.237869] evm: security.SMACK64MMAP (disabled)
[    1.237869] evm: security.apparmor (disabled)
[    1.237870] evm: security.ima
[    1.237870] evm: security.capability
[    3.114915] SGI XFS with ACLs, security attributes, scrub, quota, no debug enabled

 # avocado run kprobe.py
JOB ID     : cdff2f9b8cf4a981617b867cbe17d36f8be38b84
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-29T01.13-cdff2f9/job.log
 (1/1) kprobe.py:Kprobe.test: STARTED
 (1/1) kprobe.py:Kprobe.test: CANCEL: Secure boot is enabled. (1.27 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-29T01.13-cdff2f9/results.html
JOB TIME   : 17.86 s

 # avocado run kretprobe.py
JOB ID     : 894dbf25cd93ba80a7efbabab1736a204c7e2856
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-29T01.14-894dbf2/job.log
 (1/1) kretprobe.py:Kretprobe.test: STARTED
 (1/1) kretprobe.py:Kretprobe.test: CANCEL: Secure boot is enabled. (1.14 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-29T01.14-894dbf2/results.html
JOB TIME   : 16.47 s

 # avocado run perf_watch_point.py
JOB ID     : f28803729a241bfe3f385d0fd2fc362f4e15bbf7
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-05-29T01.17-f288037/job.log
 (1/1) perf_watch_point.py:PerfWatchPoint.test_watch_point_check: STARTED
 (1/1) perf_watch_point.py:PerfWatchPoint.test_watch_point_check: CANCEL: Secure boot is enabled. (1.18 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-05-29T01.17-f288037/results.html
JOB TIME   : 16.19 s