### PR TITLE
Added changes to distro specific packages

### DIFF
--- a/ras/packages.py
+++ b/ras/packages.py
@@ -27,7 +27,7 @@ class Package_check(Test):
 
         self.sm = SoftwareManager()
         self.packages = self.params.get(
-            'packages', default=['powerpc-utils', 'ppc64-diag', 'lsvpd', 'powerpc-utils-core'])
+            'packages', default=['powerpc-utils', 'ppc64-diag', 'lsvpd'])
         if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
             self.packages.extend(['opal-prd'])
 
@@ -35,7 +35,7 @@ class Package_check(Test):
         dist = distro.detect()
         if dist.name == 'rhel':
             packages_rhel = self.params.get(
-                'packages_rhel', default=['lshw', 'librtas'])
+                'packages_rhel', default=['lshw', 'librtas', 'powerpc-utils-core'])
             self.packages.extend(packages_rhel)
         elif dist.name == 'Ubuntu':
             packages_ubuntu = self.params.get(


### PR DESCRIPTION
Package powerpc-utils-core is specific to RHEL distribution so added distro check to the code.

Before on SLES distro:

localhost:# avocado run --max-parallel-tasks=1 packages.py
JOB ID     : f8e51817fb84fa0e6d5207d4273e1be128a044ad
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-06-04T05.40-f8e5181/job.log
 (1/1) packages.py:Package_check.test: STARTED
 (1/1) packages.py:Package_check.test: FAIL: ['powerpc-utils-core'] packages not installed by default (0.13 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-06-04T05.40-f8e5181/results.html
JOB TIME   : 47.14 s

Test summary:
1-packages.py:Package_check.test: FAIL

After patch on SLES: 

localhost:# avocado run --max-parallel-tasks=1 packages.py
JOB ID     : 8ef29cfe1dc49bb69fb5d74280aa5d303d43a009
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-06-04T05.42-8ef29cf/job.log
 (1/1) packages.py:Package_check.test: STARTED
 (1/1) packages.py:Package_check.test: PASS (0.07 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-06-04T05.42-8ef29cf/results.html
JOB TIME   : 38.99 s

On RHEL system:

[root@]# avocado run --max-parallel-tasks=1 packages.py
JOB ID     : 9f41a457a0fa1a665f4771ea1c72d41af00175e1
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-06-04T01.33-9f41a45/job.log
 (1/1) packages.py:Package_check.test: STARTED
 (1/1) packages.py:Package_check.test: PASS (0.57 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-06-04T01.33-9f41a45/results.html
JOB TIME   : 31.68 s