### PR TITLE
Fixed regression issue in script as core is not a key in lscpu output

### DIFF
--- a/perf/perf_24x7_hardware_counters.py
+++ b/perf/perf_24x7_hardware_counters.py
@@ -93,7 +93,7 @@ class EliminateDomainSuffix(Test):
 
         # Initializing the values of chips and cores using lspcu
         self.chips = cpu.lscpu()["chips"]
-        self.cores = cpu.lscpu()["cores"]
+        self.cores = cpu.lscpu()["physical_cores"]
 
     # Features testing
     def test_display_domain_indices_in_sysfs(self):


### PR DESCRIPTION
LOG:

Python 3.6.15 (default, Sep 23 2021, 15:41:43) [GCC] on linux Type "help", "copyright", "credits" or "license" for more information.
>>> from avocado.utils import cpu
>>> print (cpu.lscpu())
{'virtual_cores': 4, 'physical_sockets': 4, 'physical_chips': 2, 'physical_cores': 15, 'chips': 8}
>>>

this patch address like replace core with physical_core