### PR TITLE
ftrace_log_fix

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -187,10 +187,14 @@ class kselftest(Test):
                     test_comp = self.comp + "/" + self.subtest
                 else:
                     test_comp = self.comp
-                build.make(self.sourcedir,
-                           extra_args='%s -C %s run_tests' %
-                           (kself_args, test_comp))
-        for line in open(os.path.join(self.logdir, 'debug.log')).readlines():
+                make_cmd = 'make -C %s %s -C %s run_tests' % (
+                    self.sourcedir, kself_args, test_comp)
+                result = process.run(make_cmd, shell=True, ignore_status=True)
+        log_output = result.stdout.decode('utf-8')
+        results_path = os.path.join(self.outputdir, 'raw_output')
+        with open(results_path, 'w') as r_file:
+            r_file.write(log_output)
+        for line in open(results_path).readlines():
             if self.run_type == 'upstream':
                 self.find_match(r'not ok (.*) selftests:(.*)', line)
             elif self.run_type == 'distro':


### PR DESCRIPTION
Ftrace tests were ending with a pass even if there were failures in the tests. This was due to the code reading the older snapshot of the log file for matching the 'not ok' string. Therefore, modify logic to paste the log to a different raw file and read the file to match for 'not ok' string.

  # avocado run  kselftest.py -m kselftest.py.data/ftrace.yaml
Fetching asset from kselftest.py:kselftest.test
JOB ID     : 715abe0fa709f9ff99eecd8d1b706825380746b7
JOB LOG    : /root/avocado/avocado-fvt-wrapper/results/job-2024-06-10T10.47-715abe0/job.log
 (1/1) kselftest.py:kselftest.test;run-component-ftrace-run_type-distro-9c69: STARTED
 (1/1) kselftest.py:kselftest.test;run-component-ftrace-run_type-distro-9c69: FAIL: Testcase failed during selftests (246.50 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/avocado-fvt-wrapper/results/job-2024-06-10T10.47-715abe0/results.html
JOB TIME   : 265.89 s

Test summary:
1-kselftest.py:kselftest.test;run-component-ftrace-run_type-distro-9c69: FAIL

[ftrace_debug.log](https://github.com/user-attachments/files/15756819/ftrace_debug.log)
