### PR TITLE
htx: fix htxd start daemon fail

### DIFF
--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -162,6 +162,8 @@ class HtxTest(Test):
         Execute 'HTX' with appropriate parameters.
         """
         self.setup_htx()
+        self.log.info("Stopping existing htx daemon")
+        process.run(" ps -C htxd -o pid=|xargs kill -9")
         self.log.info("Starting the HTX Deamon")
         process.run("/usr/lpp/htx/etc/scripts/htxd_run")
 


### PR DESCRIPTION
Some cases the old htx daemon is still running causing the htxd start command failing and exiting test, with this code we close old daemon before we start new