### PR TITLE
Overwrite already existing "netperf" files while tar file unzip

### DIFF
--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -123,7 +123,7 @@ class Netperf(Test):
             self.cancel("unable to copy the netperf into peer machine")
         self.netperf_dir_peer = "/tmp/%s" % self.version
         self.netperf_dir = os.path.join(self.netperf, self.version)
-        cmd1 = "unzip /tmp/%s -d /tmp;cd %s" % (os.path.basename(tarball), self.netperf_dir_peer)
+        cmd1 = "unzip -o /tmp/%s -d /tmp;cd %s" % (os.path.basename(tarball), self.netperf_dir_peer)
         output = self.session.cmd(cmd1)
         if not output.exit_status == 0:
             self.fail("test failed because command failed in peer machine")


### PR DESCRIPTION
This code support to overwrite on already existing "netperf" files while unzipping from "netperf" tar file, rather than waiting user confirmation for abort, continue or replace for an existing files.