### PR TITLE
limiting "netperf" server to run only with IPv4/AF_INET 

### DIFF
--- a/io/net/netperf_test.py
+++ b/io/net/netperf_test.py
@@ -162,7 +162,7 @@ class Netperf(Test):
             output = self.session.cmd(cmd)
             if not output.exit_status == 0:
                 self.fail("test failed because netserver not available")
-            cmd = "/tmp/%s/src/netserver" % self.version
+            cmd = "/tmp/%s/src/netserver -4" % self.version
             output = self.session.cmd(cmd)
             if not output.exit_status == 0:
                 self.fail("test failed because netserver not available")

--- a/io/net/netperf_test.py.data/README.txt
+++ b/io/net/netperf_test.py.data/README.txt
@@ -26,3 +26,9 @@ Requirements:
 2.install nteifaces using pip.
 command: pip install netifaces
 3.user should have root access to both client machine and peer machine.
+
+Additional Notes:
+-----------------
+Currently "Netserver" supports only for IPv4/AF_INET Ports,
+where Netserver initialize and listens on IPV4 interfaces for both Host and Peer systems.
+


### PR DESCRIPTION
This code supports to run the "netperf" server listening only with IPv4 address on both Host and Peer machines.