### PR TITLE
htx_test.py: Fixed the error where htxd is already running

### DIFF
--- a/io/net/htx_nic_devices.py
+++ b/io/net/htx_nic_devices.py
@@ -286,6 +286,12 @@ class HtxNicTest(Test):
 
     def start_htx_run(self):
         self.log.info("Running the HTX for %s on Host", self.mdt_file)
+        # Kill existing HTXD process if running
+        htxd_pid = process.getoutput("pgrep -f htxd")
+        if htxd_pid:
+            self.log.info("HTXD is already running with PID: %s. Killing it.", htxd_pid)
+            process.run("pkill -f htxd", ignore_status=True)
+            time.sleep(10)
         cmd = "htxcmdline -run -mdt %s" % self.mdt_file
         process.run(cmd, shell=True, sudo=True)
 

--- a/workload/htx_test.py
+++ b/workload/htx_test.py
@@ -161,6 +161,12 @@ class HtxTest(Test):
                 else:
                     self.cancel("RPM link is required for RPM run type")
         self.log.info("Starting the HTX Deamon")
+        # Kill existing HTXD process if running
+        htxd_pid = process.getoutput("pgrep -f htxd")
+        if htxd_pid:
+            self.log.info("HTXD is already running with PID: %s. Killing it.", htxd_pid)
+            process.run("pkill -f htxd", ignore_status=True)
+            time.sleep(10)
         process.run('/usr/lpp/htx/etc/scripts/htxd_run')
 
         self.log.info("Creating the HTX mdt files")


### PR DESCRIPTION
As htxd is already running then testcase is erroring out.So killing the existing pid of htxd and starting it fresh in order to select different mdt's required for testing