### PR TITLE
Added support to run the lockstorm benchmark multiple times

### DIFF
--- a/cpu/lockstorm_benchmark.py.data/lockstorm.yaml
+++ b/cpu/lockstorm_benchmark.py.data/lockstorm.yaml
@@ -1,1 +1,2 @@
 cpu_list:
+test_iter:


### PR DESCRIPTION
Added support to capture and run the lockstorm_benchmark multiple times.
For this introduced new .yaml parameter
test_iter.