### PR TITLE
Add support for Power11

### DIFF
--- a/cpu/pvr.py
+++ b/cpu/pvr.py
@@ -80,6 +80,9 @@ class pvr(Test):
                 self.pvr_value = parser.get('PVR_Values', 'pvr_value_p10_1')
             elif rev[1] == '2.0':
                 self.pvr_value = parser.get('PVR_Values', 'pvr_value_p10_2')
+        elif 'pSeries' in val and 'Power11' in val:
+            if rev[1] == '2.0':
+                self.pvr_value = parser.get('PVR_Values', 'pvr_value_p11')
         else:
             self.fail("Unsupported processor family")
 

--- a/cpu/pvr.py.data/pvr.cfg
+++ b/cpu/pvr.py.data/pvr.cfg
@@ -8,3 +8,4 @@ pvr_value_p9LPAR_2.2 = 4e0202
 pvr_value_p9LPAR_2.3 = 4e0203
 pvr_value_p10_1 = 800100
 pvr_value_p10_2 = 800200
+pvr_value_p11 = 820200

--- a/cpu/xive.py
+++ b/cpu/xive.py
@@ -39,6 +39,8 @@ class XIVE(Test):
             self.hw = "POWER9"
         elif 'POWER10' in cpu_info:
             self.hw = "POWER10"
+        elif 'Power11' in cpu_info:
+            self.hw = "POWER11"
         else:
             self.cancel("Unsupported processor family")
 

--- a/security/grub-extend-pcr.py
+++ b/security/grub-extend-pcr.py
@@ -31,8 +31,10 @@ class GrubExtendPCR(Test):
         Install the basic packages
         '''
         # Check for basic utilities
-        if 'POWER10' not in genio.read_file("/proc/cpuinfo"):
-            self.cancel("Power10 LPAR is required to run this test.")
+        val = genio.read_file("/proc/cpuinfo")
+        power_ver = ['POWER10', 'Power11']
+        if not any(x in val for x in power_ver):
+            self.cancel("LPAR on Power10 and above is required for this test.")
         device_tree_path = "/proc/device-tree/vdevice/"
         vtpm = [i for i, item in enumerate(os.listdir(device_tree_path)) if item.startswith('vtpm@')]
         if not vtpm:

--- a/security/kernel-lockdown-tests.py
+++ b/security/kernel-lockdown-tests.py
@@ -41,8 +41,9 @@ class kernelLockdown(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
         val = genio.read_file("/proc/cpuinfo")
-        if 'POWER10' not in val:
-            self.cancel("Power10 LPAR is required to run this test.")
+        power_ver = ['POWER10', 'Power11']
+        if not any(x in val for x in power_ver):
+            self.cancel("LPAR on Power10 and above is required for this test.")
         # Checking whether lockdown enabled or not.
         self.lockdown_file = "/sys/kernel/security/lockdown"
         if not os.path.exists(self.lockdown_file):

--- a/trace/dawr.py
+++ b/trace/dawr.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import pexpect
 from avocado import Test
-from avocado.utils import build, distro, cpu
+from avocado.utils import build, distro, genio
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -35,8 +35,10 @@ class Dawr(Test):
         '''
         Install the basic packages to support gdb
         '''
-        if "power10" not in cpu.get_family():
-            self.cancel("Test is supported only on IBM POWER10 platform")
+        val = genio.read_file("/proc/cpuinfo")
+        power_ver = ['POWER10', 'Power11']
+        if not any(x in val for x in power_ver):
+            self.cancel("LPAR on Power10 and above is required for this test.")
         # Check for basic utilities
         smm = SoftwareManager()
         self.detected_distro = distro.detect()


### PR DESCRIPTION
Wave 1 of changes to add support for Power11.

- cpu/pvr.py
- security/grub-extend-pcr.py
- security/kernel-lockdown-tests.py
- cpu/xive.py
- trace/dawr.py

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>