### PR TITLE
Fix pmem_dm test failure due to 'Namespace destroy command failed'

### DIFF
--- a/memory/pmem_dm.py
+++ b/memory/pmem_dm.py
@@ -184,8 +184,8 @@ class PmemDeviceMapper(Test):
         if process.system(dm_cmd, shell=True, sudo=True, ignore_status=True):
             self.fail("Creating DM failed")
         self.log.info("Running FIO on device-mapper")
-        dm_disk = "/dev/mapper/linear-pmem"
-        self.part = partition.Partition(dm_disk)
+        self.dm_disk = "/dev/mapper/linear-pmem"
+        self.part = partition.Partition(self.dm_disk)
         self.part.mkfs(fstype='xfs', args='-b size=%s -s size=512 -m reflink=0' %
                        memory.get_page_size())
         mnt_path = self.params.get('mnt_point', default='/pmem')
@@ -202,8 +202,8 @@ class PmemDeviceMapper(Test):
 
     @avocado.fail_on(pmem.PMemException)
     def tearDown(self):
-        if hasattr(self, 'part'):
-            self.part.unmount()
+        if self.dm_disk:
+            process.system('umount %s' % self.dm_disk, ignore_status=True)
         if not self.preserve_dm and hasattr(self, 'plib'):
             process.system('dmsetup remove linear-pmem',
                            sudo=True, ignore_status=True)


### PR DESCRIPTION
unmount function is not unmounting the pmem device because of which namespace destroy is failing so using the umount command.