### PR TITLE
tune queue values for vnic adapter

### DIFF
--- a/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
+++ b/io/net/virt-net/network_virtualization.py.data/network_virtualization.yaml
@@ -25,3 +25,5 @@ host_password: ""
 peer_user: ""
 peer_password: ""
 is_mlx_driver: True
+transmit_tx: 10
+receive_rx: 10


### PR DESCRIPTION
- tune vnic adapter queue to max supported values
- Use dmesg level=4 for vnic related tests