### PR TITLE
nx-gzip/nx-gzip: Rewrite processor version check logic

### DIFF
--- a/nx_gzip/nx_gzip.py
+++ b/nx_gzip/nx_gzip.py
@@ -107,8 +107,7 @@ class NXGZipTests(Test):
         self.branch = self.params.get('git_branch', default='master')
         git.get_repo(self.url, branch=self.branch,
                      destination_dir=self.teststmpdir)
-        if self.branch == 'develop':
-            process.run('./configure', sudo=True, shell=True)
+        process.run('./configure', sudo=True, shell=True)
         os.chdir(self.teststmpdir)
         build.make(self.teststmpdir)
 

--- a/nx_gzip/nx_gzip.py
+++ b/nx_gzip/nx_gzip.py
@@ -16,13 +16,10 @@
 
 import os
 import shutil
-from avocado import Test, skipUnless
+from avocado import Test
 from avocado.utils import build, process, distro, git, archive, memory
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
-
-IS_POWER_NV = 'PowerNV' in open('/proc/cpuinfo', 'r').read()
-IS_POWER10 = 'POWER10' in open('/proc/cpuinfo', 'r').read()
 
 
 class NXGZipTests(Test):
@@ -82,13 +79,14 @@ class NXGZipTests(Test):
         if failed_tests:
             self.fail("%s" % failed_tests)
 
-    @skipUnless(IS_POWER_NV | IS_POWER10,
-                "NX-GZIP tests are supported only on PowerNV(POWER9) or "
-                "POWER10 platform.")
     def setUp(self):
         """
         Install pre-requisite packages
         """
+
+        if not os.path.exists('/dev/crypto/nx-gzip'):
+            self.cancel("NX-GZIP tests are supported only on PowerNV(POWER9)"
+                        ", POWER10 and onwards.")
         smg = SoftwareManager()
         self.dist = distro.detect()
         if self.dist.name not in ['rhel', 'SuSE']:


### PR DESCRIPTION
Running the test on power11 system fails even though it
is supported. To support this and future generations of
IBM Power processors rewrite the processor family check
logic. Instead of checking for processor version, add a
check to detect nx-gzip support.

While at it, also remove the condition to execute configure
command.
    
Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>