### PR TITLE
Fix to avoid returning "False" PID while no process running.

### DIFF
--- a/io/net/irqbalance.py
+++ b/io/net/irqbalance.py
@@ -170,8 +170,7 @@ class irq_balance(Test):
                                             ignore_status=True,
                                             sudo=True).decode("utf-8")
         if not process_pid:
-            self.log.debug(f"No more process PID avaialable")
-            return False
+            self.cancel(f"No process PID of ping command avaialable")
         return process_pid
 
     def compare_range_strings(self, range_str1, range_str2):


### PR DESCRIPTION
This fix supports to avoid caputuring "False" string when no process of ping running,instead of retuning False, the script cancel the test-case.