### PR TITLE
Patch fixes script error out issue in case early cancle

### DIFF
--- a/memory/pmem_dm.py
+++ b/memory/pmem_dm.py
@@ -74,7 +74,7 @@ class PmemDeviceMapper(Test):
         self.dist = distro.detect()
         package = self.params.get('package', default='distro')
         self.preserve_dm = self.params.get('preserve_dm', default=False)
-
+        self.dm_disk = None
         if self.dist.name not in ['SuSE', 'rhel']:
             self.cancel('Unsupported OS %s' % self.dist.name)
 


### PR DESCRIPTION
as Test error out while executing tearDown in case of Test cancles due to some dependencies

Failure log :

[stdlog] 2024-09-04 13:08:26,128 avocado.test stacktrace       L0041 ERROR|
[stdlog] 2024-09-04 13:08:26,128 avocado.test stacktrace       L0043 ERROR| Reproduced traceback from: /usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/t
est.py:604
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR| Traceback (most recent call last):
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/decorators.py", line
 54, in wrapper
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|     raise exc
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/decorators.py", line
 52, in wrapper
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|     return func(*args, **kwargs)
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|   File "/home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/memory/pmem_dm.py", line 140, in test
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|     self.cancel("Cannot run test without split option enabled")
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/test.py", line 754,
in wrapper
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|     return func(actual_message)
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/test.py", line 801,
in cancel
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|     raise exceptions.TestCancel(msg)
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR| avocado.core.exceptions.TestCancel: Cannot run test without split option enabled
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0051 ERROR|
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0041 ERROR|
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0043 ERROR| Reproduced traceback from: /usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/t
est.py:640
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR| Traceback (most recent call last):
[stdlog] 2024-09-04 13:08:26,129 avocado.test stacktrace       L0050 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/decorators.py", line
 52, in wrapper
[stdlog] 2024-09-04 13:08:26,130 avocado.test stacktrace       L0050 ERROR|     return func(*args, **kwargs)
[stdlog] 2024-09-04 13:08:26,130 avocado.test stacktrace       L0050 ERROR|   File "/home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/memory/pmem_dm.py", line 205, in tearDown
[stdlog] 2024-09-04 13:08:26,130 avocado.test stacktrace       L0050 ERROR|     if self.dm_disk:
[stdlog] 2024-09-04 13:08:26,130 avocado.test stacktrace       L0050 ERROR| AttributeError: 'PmemDeviceMapper' object has no attribute 'dm_disk'
[stdlog] 2024-09-04 13:08:26,130 avocado.test stacktrace       L0051 ERROR|