### PR TITLE
Fixed logical issue in kselftest for if/else block.

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -177,7 +177,7 @@ class kselftest(Test):
         kself_args = self.params.get("kself_args", default='')
         if self.comp == "bpf":
             self.bpf()
-        if self.comp == "cpufreq":
+        elif self.comp == "cpufreq":
             self.cpufreq()
         else:
             if self.subtest == "ksm_tests":


### PR DESCRIPTION
Refactor the code logic to execute the kselftest cases based on the selected component correctly. 
`Ex: bpf, cpufrequecy .. etc`