### PR TITLE
Added support in smt workload to validate dmesg logs.

### DIFF
--- a/workload/smt.py
+++ b/workload/smt.py
@@ -16,6 +16,11 @@ from avocado import Test
 from avocado.utils import process, distro
 from avocado.utils.software_manager.manager import SoftwareManager
 import os
+import time
+
+
+def collect_dmesg(object):
+    return process.system_output("dmesg").decode()
 
 
 class smt(Test):
@@ -50,21 +55,39 @@ class smt(Test):
             self.cancel("Test case is supported only on RHEL and SLES")
         self.runtime = self.params.get('runtime', default='')
 
+    def dmesg_validater(self):
+        """
+        This function is responsible to validate the dmesg
+        for any errors after smt workload run.
+        """
+        ERROR = []
+        pattern = ['WARNING: CPU:', 'Oops', 'Segfault', 'soft lockup',
+                   'Unable to handle', 'ard LOCKUP']
+        for fail_pattern in pattern:
+            for log in collect_dmesg(self).splitlines():
+                if fail_pattern in log:
+                    ERROR.append(log)
+        if ERROR:
+            self.fail("Test failed with following errors in dmesg :  %s " %
+                      "\n".join(ERROR))
+        smt = self.logdir + "/smt"
+        os.makedirs(smt, exist_ok=True)
+        cmd = "mv /tmp/smt.log %s " % (smt)
+        process.run(cmd)
+
     def test_smt_start(self):
         """
         Start the SMT Workload
         """
         relative_path = 'smt.py.data/smt.sh'
         absolute_path = os.path.abspath(relative_path)
-        smt_workload = ""
-        if self.runtime == "":
-            smt_workload = "bash " + absolute_path + " &> /tmp/smt.log &"
-        else:
-            smt_workload = "timeout " + str(self.runtime) + "m" + " bash " + \
-                absolute_path + " &> /tmp/smt.log &"
+        smt_workload = "bash " + absolute_path + " &> /tmp/smt.log &"
         process.run(
             smt_workload, ignore_status=True, sudo=True, shell=True)
         self.log.info("SMT Workload started--!!")
+        if self.runtime != "":
+            runtime = self.runtime * 60
+            time.sleep(runtime)
 
     def test_smt_stop(self):
         """
@@ -72,7 +95,10 @@ class smt(Test):
         """
         grep_cmd = "grep -i {}".format("smt.sh")
         awk_cmd = "awk '{print $2}'"
-        process_kill = "ps aux | {} | {} | head -1 | xargs kill".format(grep_cmd, awk_cmd)
+        process_kill = "ps aux | {} | {} | head -1 | xargs kill".format(
+            grep_cmd, awk_cmd)
         process.run(process_kill, ignore_status=True,
                     sudo=True, shell=True)
         self.log.info("SMT Workload killed successfully--!!")
+        # Validate the dmesg for any error
+        self.dmesg_validater()


### PR DESCRIPTION
Added support in the SMT workload to validate dmesg logs and copy the SMT logs from the /tmp/ directory to the current job run directory at intervals equal to the runtime duration specified in the .yaml configuration.