### PR TITLE
Added support for ebizzy benchmark to dump stats data in to speical file.

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -78,10 +78,34 @@ class Ebizzy(Test):
         process.run('[ -x configure ] && ./configure', shell=True)
         build.make(self.sourcedir)
 
-    # Note: default we use always mmap()
-    def test(self):
+    def create_json_dump(self, stdout_output):
+        # Define regex patterns to capture the data
+        patterns = {
+            'cpu_clock': r'([\d.]+)\s+msec cpu-clock',
+            'context_switches': r'([\d.]+)\s+context-switches',
+            'cpu_migrations': r'([\d.]+)\s+cpu-migrations',
+            'page_faults': r'([\d.]+)\s+page-faults',
+            'cycles': r'([\d.]+)\s+cycles',
+            'instructions': r'([\d.]+)\s+instructions',
+            'branches': r'([\d.]+)\s+branches',
+            'branch_misses': r'([\d.]+)\s+branch-misses',
+            'elapsed_time': r'([\d.]+)\s+seconds elapsed'
+        }
 
-        iterations = self.params.get('iterations', default=5)
+        # Extract data using regex
+        extracted_data = {}
+        for key, pattern in patterns.items():
+            match = re.search(pattern, stdout_output)
+            if match:
+                extracted_data[key] = float(match.group(1))
+
+        return extracted_data
+
+    def test(self):
+        ebizzy_payload = []
+        ebizzy_dir = self.logdir + "/ebizzy_workload"
+        os.makedirs(ebizzy_dir, exist_ok=True)
+        iterations = self.params.get('iterations', default=2)
         perfstat = self.params.get('perfstat', default='')
         if perfstat:
             perfstat = 'perf stat ' + perfstat
@@ -99,22 +123,41 @@ class Ebizzy(Test):
 
         os.makedirs(os.path.join(self.logdir, "ebizzy_run"))
         for ite in range(iterations):
-            results = process.system_output('%s %s %s/ebizzy %s'
-                                            % (perfstat, taskset, self.sourcedir, args)).decode("utf-8")
+            results = process.run('%s %s %s/ebizzy %s'
+                                  % (perfstat, taskset, self.sourcedir, args))
+            stderr_output = results.stderr
+            stdout_output = results.stdout
+            ebizzy_payload = ebizzy_dir + "/ebizzy.log"
+            with open(ebizzy_payload, "a") as payload:
+                payload.write("==================Iteration {}============= \
+                        \n".format(str(ite)))
+                lines = stdout_output.splitlines()
+                lines1 = stderr_output.splitlines()
+                ebizzy_payload = lines + lines1
+                for line in ebizzy_payload:
+                    decoded_string = line.decode('utf-8')
+                    cleaned_string = decoded_string.lstrip('\t')
+                    payload.write(cleaned_string + '\n')
+
             pattern = re.compile(r"(.*?) records/s")
-            records = pattern.findall(results)[0]
+            records = pattern.findall(stdout_output.decode("utf-8"))[0]
             pattern = re.compile(r"real (.*?) s")
-            real = pattern.findall(results)[0].strip()
+            real = pattern.findall(stdout_output.decode("utf-8"))[0].strip()
             pattern = re.compile(r"user (.*?) s")
-            usr_time = pattern.findall(results)[0].strip()
+            usr_time = pattern.findall(
+                stdout_output.decode("utf-8"))[0].strip()
             pattern = re.compile(r"sys (.*?) s")
-            sys_time = pattern.findall(results)[0].strip()
+            sys_time = pattern.findall(
+                stdout_output.decode("utf-8"))[0].strip()
+            perf_stat = self.create_json_dump(stderr_output.decode("utf-8"))
             json_object = json.dumps({'records': records,
                                       'real_time': real,
                                       'user': usr_time,
-                                      'sys': sys_time})
+                                      'sys': sys_time,
+                                      'perf_stat': perf_stat})
 
             logfile = os.path.join(
                 self.logdir, "ebizzy_run", "run_%s.json" % (ite + 1))
-            with open(logfile, "w") as outfile:
+            ebizzy_log = ebizzy_dir + "/ebizzy[" + str(ite) + "].json"
+            with open(ebizzy_log, "w") as outfile:
                 outfile.write(json_object)


### PR DESCRIPTION
We have implemented support to store the ebizzy benchmark data in the job directory by creating a dedicated ebizzy_workload folder. Additionally, we are capturing the .json data for each iteration and saving it in the same ebizzy_workload folder for further analysis.

**Run logs:**
` avocado run ebizzy.py -m ebizzy.py.data/ebizzy.yaml  --max-parallel-tasks=1
Fetching asset from ebizzy.py:Ebizzy.test
JOB ID     : 41af3e8d54c5684efcf26b80318bf827ab457053
JOB LOG    : /root/Work/fvt/avocado-fvt-wrapper-1/results/job-2024-09-09T22.51-41af3e8/job.log
 (1/2) ebizzy.py:Ebizzy.test;run-duration-default-perf-pin-size-threads-workers-22d2: STARTED
 (1/2) ebizzy.py:Ebizzy.test;run-duration-default-perf-pin-size-threads-workers-22d2: PASS (201.60 s)
 (2/2) ebizzy.py:Ebizzy.test;run-duration-quick-perf-default-pin-size-threads-workers-2165: STARTED
 (2/2) ebizzy.py:Ebizzy.test;run-duration-quick-perf-default-pin-size-threads-workers-2165: PASS (121.61 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/Work/fvt/avocado-fvt-wrapper-1/results/job-2024-09-09T22.51-41af3e8/results.html
JOB TIME   : 372.47 s`