### PR TITLE
Fix to shutdown all HCL process that initiated by HTX.

### DIFF
--- a/io/disk/htx_block_devices.py
+++ b/io/disk/htx_block_devices.py
@@ -162,11 +162,12 @@ class HtxTest(Test):
         Execute 'HTX' with appropriate parameters.
         """
         self.setup_htx()
-        self.log.info("Stopping existing htx daemon")
-        process.run(" ps -C htxd -o pid=|xargs kill -9")
-        self.log.info("Starting the HTX Deamon")
-        process.run("/usr/lpp/htx/etc/scripts/htxd_run")
-
+        self.log.info("Stopping existing HXE process")
+        hxe_pid = process.getoutput("pgrep -f hxe")
+        if hxe_pid:
+            self.log.info("HXE is already running with PID: %s. Killing it.", hxe_pid)
+            process.run("hcl -shutdown", ignore_status=True)
+            time.sleep(20)
         self.log.info("Creating the HTX mdt files")
         process.run("htxcmdline -createmdt")
 


### PR DESCRIPTION
code fix to kill/shutdown all HTX/HCL processes that was initiated by HTX before initiating HTX for block devices.

Also this code fix re-initiating the HTX process when its already running.

**Actual Issue**
[stdlog] 2024-09-12 00:43:03,092 avocado.utils.process process          L0715 INFO | Command ' ps -C htxd -o pid=|xargs kill -9' finished with 1 after 0.001392055s
[stdlog] 2024-09-12 00:43:03,092 avocado.test stacktrace       L0041 ERROR|
[stdlog] 2024-09-12 00:43:03,092 avocado.test stacktrace       L0043 ERROR| Reproduced traceback from: /usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/test.py:607
[stdlog] 2024-09-12 00:43:03,092 avocado.test stacktrace       L0050 ERROR| Traceback (most recent call last):
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR|   File "/home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/io/disk/htx_block_devices.py", line 166, in test_start
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR|     process.run(" ps -C htxd -o pid=|xargs kill -9")
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/utils/process.py", line 1013, in run
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR|     raise CmdError(cmd, sp.result)
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR| avocado.utils.process.CmdError: Command ' ps -C htxd -o pid=|xargs kill -9' failed.
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR| stdout: b''
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR| stderr: b"error: unknown sort specifier\n\nUsage:\n ps [options]\n\n Try 'ps --help <simple|list|output|threads|misc|all>'\n  or 'ps --help <s|l|o|t|m|a>'\n for additional help text.\n\nFor more details see ps(1).\n"
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0050 ERROR| additional_info: None
[stdlog] 2024-09-12 00:43:03,093 avocado.test stacktrace       L0051 ERROR|
[stdlog] 2024-09-12 00:43:03,093 avocado.test test             L0611 DEBUG| Local variables:
[stdlog] 2024-09-12 00:43:03,113 avocado.test test             L0614 DEBUG|  -> self <class 'htx_block_devices.HtxTest'>: 1-/home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_start;run-6197
[stdlog] 2024-09-12 00:43:03,113 avocado.test test             L0688 ERROR| Traceback (most recent call last):
[stdlog] 2024-09-12 00:43:03,113 avocado.test test             L0688 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/test.py", line 615, in _run_test
[stdlog]     raise details
[stdlog] 2024-09-12 00:43:03,114 avocado.test test             L0688 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/core/test.py", line 602, in _run_test
[stdlog]     testMethod()
[stdlog] 2024-09-12 00:43:03,114 avocado.test test             L0688 ERROR|   File "/home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/io/disk/htx_block_devices.py", line 166, in test_start
[stdlog]     process.run(" ps -C htxd -o pid=|xargs kill -9")
[stdlog] 2024-09-12 00:43:03,114 avocado.test test             L0688 ERROR|   File "/usr/local/lib/python3.9/site-packages/avocado_framework-106.0-py3.9.egg/avocado/utils/process.py", line 1013, in run
[stdlog]     raise CmdError(cmd, sp.result)
[stdlog] 2024-09-12 00:43:03,114 avocado.test test             L0688 ERROR| avocado.utils.process.CmdError: Command ' ps -C htxd -o pid=|xargs kill -9' failed.

Test results after the fix
-------------------------------

[root@ltcever60-lp5 disk]# avocado run htx_block_devices.py -m htx_block_devices.py.data/htx_block_devices.yaml --max-parallel-tasks=1
JOB ID     : e4faab510a4e6085fb036b387e6d6eebaa0a10e8
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2024-09-12T10.42-e4faab5/job.log
 (1/3) htx_block_devices.py:HtxTest.test_start;run-8dbf: STARTED
 (1/3) htx_block_devices.py:HtxTest.test_start;run-8dbf: PASS (106.31 s)
 (2/3) htx_block_devices.py:HtxTest.test_check;run-8dbf: STARTED
 (2/3) htx_block_devices.py:HtxTest.test_check;run-8dbf: PASS (60.08 s)
 (3/3) htx_block_devices.py:HtxTest.test_stop;run-8dbf: STARTED
 (3/3) htx_block_devices.py:HtxTest.test_stop;run-8dbf: PASS (11.12 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2024-09-12T10.42-e4faab5/results.html
JOB TIME   : 210.28 s






