### PR TITLE
Fixing the issue of getting "Unknown" value with platform.processor

### DIFF
--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -22,8 +22,8 @@ This test verifies that for supported slots.
 
 import os
 import time
-import platform
 from avocado import Test
+from avocado.utils import cpu
 from avocado.utils import nvme
 from avocado.utils import wait, multipath
 from avocado.utils import linux_modules, genio, pci
@@ -46,7 +46,7 @@ class PCIHotPlugTest(Test):
         """
         Setup the device.
         """
-        if 'ppc' not in platform.processor():
+        if 'ppc' not in cpu.get_arch():
             self.cancel("Processor is not ppc64")
         if os.path.exists('/proc/device-tree/bmc'):
             self.cancel("Test Unsupported! on this platform")

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -16,8 +16,8 @@
 import os
 import glob
 import re
-import platform
 import multiprocessing
+from avocado.utils import cpu
 from avocado import Test
 from avocado.utils import process, memory, build, archive
 from avocado.utils.software_manager.manager import SoftwareManager
@@ -81,7 +81,7 @@ def collect_dmesg(object):
 class MemStress(Test):
 
     '''
-    Stress test to exercise memory component
+    Stress test to exercize memory component
 
     This test performs memory hotunplug/hotplug tests with below scenarios:
        1. hotunplug one by one in a loop for all
@@ -195,7 +195,7 @@ class MemStress(Test):
         self.__error_check()
 
     def test_dlpar_mem_hotplug(self):
-        if 'ppc' in platform.processor() and 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
+        if 'ppc' in cpu.get_arch() and 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
             if b"mem_dlpar=yes" in process.system_output("drmgr -C", ignore_status=True, shell=True):
                 self.log.info("\nDLPAR remove memory operation\n")
                 for _ in range(len(self.blocks_hotpluggable) // 2):


### PR DESCRIPTION
platform.processor is returning the unknown value and hence tests were failing. So changed this checking with other util functions like cpu.get_arch()