### PR TITLE
perf_hv_gpci.py & perf_24x7_all_events.py: Fix

### DIFF
--- a/perf/perf_24x7_all_events.py
+++ b/perf/perf_24x7_all_events.py
@@ -93,7 +93,7 @@ class hv_24x7_all_events(Test):
 
         # Collect all hv_24x7 events
         self.list_of_hv_24x7_events = []
-        for lne in process.get_command_output_matching('perf list', 'hv_24x7'):
+        for lne in process.get_command_output_matching("perf list | grep 'hv_24x7' | grep -v 'descriptor'", 'hv_24x7'):
             lne = lne.split(',')[0].split('/')[1]
             self.list_of_hv_24x7_events.append(lne)
 

--- a/perf/perf_hv_gpci.py
+++ b/perf/perf_hv_gpci.py
@@ -68,7 +68,7 @@ class perf_hv_gpci(Test):
         self.list_partition = []
         self.list_hw = []
         self.list_noid = []
-        for line in process.get_command_output_matching('perf list', 'hv_gpci'):
+        for line in process.get_command_output_matching("perf list | grep 'hv_gpci' | grep -v 'descriptor'", 'hv_gpci'):
             line = "%s/%s" % (line.split('/')[0], line.split('/')[1])
             if 'phys_processor_idx' in line:
                 self.list_phys.append(line)


### PR DESCRIPTION
Fix to accomodate event descripter in perf list.
On the current RHEL Distro, we have event descriptor along with events and while testing it is taking an event descriptor to test and is throwing an error. Change in the perf list command to remove event descriptors from the list.