### PR TITLE
Package ppc64-diag is now a part of Appstream not baseOS.

### DIFF
--- a/ras/packages.py
+++ b/ras/packages.py
@@ -27,7 +27,7 @@ class Package_check(Test):
 
         self.sm = SoftwareManager()
         self.packages = self.params.get(
-            'packages', default=['powerpc-utils', 'ppc64-diag', 'lsvpd'])
+            'packages', default=['powerpc-utils', 'ppc64-diag-rtas', 'lsvpd'])
         if 'PowerNV' in open('/proc/cpuinfo', 'r').read():
             self.packages.extend(['opal-prd'])
 

--- a/ras/packages.py.data/list.yaml
+++ b/ras/packages.py.data/list.yaml
@@ -1,3 +1,3 @@
-packages: ['powerpc-utils', 'ppc64-diag', 'lsvpd', 'powerpc-utils-core']
-packages_rhel: ['lshw', 'librtas']
-packages_ubuntu: ['librtas2']
+packages: ["powerpc-utils", "ppc64-diag-rtas", "lsvpd", "powerpc-utils-core"]
+packages_rhel: ["lshw", "librtas"]
+packages_ubuntu: ["librtas2"]


### PR DESCRIPTION
ppc64-diag is now splitted in two parts, ppc64-diag-rtas as part of baseOS and ppc-64-diag as part of Appstream.

[root@ltcrain8oj-lp7 ras]# avocado run --max-parallel-tasks=1 packages.py
JOB ID     : 774721c03c73d98867248051824a9d57d28197a1
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2024-10-03T23.38-774721c/job.log
 (1/1) packages.py:Package_check.test: STARTED
 (1/1) packages.py:Package_check.test: PASS (0.27 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2024-10-03T23.38-774721c/results.html
JOB TIME   : 15.67 s

[root@ltcrain8oj-lp7 ras]# rpm -qa ppc64-diag*
ppc64-diag-rtas-2.7.9-7.el10.ppc64le