### PR TITLE
stress-ng: fix teardown

### DIFF
--- a/generic/stress-ng.py
+++ b/generic/stress-ng.py
@@ -198,11 +198,12 @@ class Stressng(Test):
                       "\n".join(ERROR))
 
     def tearDown(self):
-        if 'filesystem' in self.class_type:
+        if hasattr(self, 'loop_dev') and os.path.exists(self.loop_dev):
             process.run("umount %s" % self.loop_dev, ignore_status=True,
                         sudo=True)
             process.run("losetup -d %s" % self.loop_dev, ignore_status=True,
                         sudo=True)
+        if os.path.exists('/tmp/blockfile'):
             process.run("rm -rf /tmp/blockfile", ignore_status=True, sudo=True)
-            if (os.path.exists(self.stressmnt)):
-                process.run(f"rm -rf {self.stressmnt}")
+        if hasattr(self, 'stressmnt') and os.path.exists(self.stressmnt):
+            process.run(f"rm -rf {self.stressmnt}", ignore_status=True)


### PR DESCRIPTION
Fix the teardown function to prevent AttributeError by adding checks to see if the attribute and path exists before trying to remove it.

Before fix:
ERROR: 'Stressng' object has no attribute 'loop_dev' 
ERROR: 'Stressng' object has no attribute 'stressmnt'

After fix:
CANCEL: Build Failed, Please check the build logs for details !!
```
avocado run stress-ng.py -m stress-ng.py.data/stress-ng-fs.yaml
Fetching asset from stress-ng.py:Stressng.test
JOB ID     : 6fc94c4cdaeba93499384ac1ca4b3790620f005a
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2024-10-23T13.59-6fc94c4/job.log
 (1/1) stress-ng.py:Stressng.test;run-exclude-fs_type-ext4-stressors-workers-f640: STARTED
 (1/1) stress-ng.py:Stressng.test;run-exclude-fs_type-ext4-stressors-workers-f640: CANCEL: Build Failed, Please check the build logs for details !! (10.28 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2024-10-23T13.59-6fc94c4/results.html
JOB TIME   : 27.14 s
```