### PR TITLE
print CANCEL message instead of FAIL for sriov

### DIFF
--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -213,6 +213,8 @@ class DlparPci(Test):
         '''
         drmgr remove, add and replace operations
         '''
+        if self.sriov == "yes":
+            self.cancel("drmgr -c pci test is not supported for this device")
         for pci in self.pci_device:
             self.set_adapter_details(pci)
             for _ in range(self.num_of_dlpar):


### PR DESCRIPTION
drmgr pci test is showing FAIL for test_drmgr_pci
this needs to be test CANCEL as sriov interface does not support drmgr -c pci option.

ls -l /sys/bus/pci/slots/<SLOT> is not available for sriov interface and the hence the -c pci option is failing.