### PR TITLE
perf: fix perf tests to support generic compat pmu

### DIFF
--- a/perf/perf_c2c.py
+++ b/perf/perf_c2c.py
@@ -56,7 +56,7 @@ class perf_c2c(Test):
                 self.cancel('%s is needed for the test to be run' % package)
 
         # Check for c2c is available in the system.
-        output = process.run('perf mem record -e list').stderr.decode("utf-8")
+        output = process.run('perf mem record -e list', ignore_status=True).stderr.decode("utf-8")
         if 'ldlat-stores' in output or 'ldlat-loads' in output:
             self.log.info("perf c2c is available")
         else:

--- a/perf/perf_genericevents.py.data/raw_code.cfg
+++ b/perf/perf_genericevents.py.data/raw_code.cfg
@@ -1,3 +1,17 @@
+[GENERIC_COMPAT_PMU]
+cpu-cycles = 0x600f4
+instructions = 0x500fa
+stalled-cycles-frontend = 0x100f8
+branch-misses = 0x400f6
+cache-misses = 0x400f0
+L1-dcache-load-misses = 0x400f0
+L1-dcache-store-misses = 0x300f0
+L1-icache-load-misses = 0x200fc
+LLC-load-misses = 0x300fe
+branch-load-misses = 0x400f6
+dTLB-load-misses = 0x300fc
+iTLB-load-misses = 0x400fc
+
 [POWER8]
 cpu-cycles = 0x1e
 stalled-cycles-frontend = 0x100f8

--- a/perf/perf_json.py
+++ b/perf/perf_json.py
@@ -72,6 +72,18 @@ class perf_json(Test):
         if 'ppc64' not in detected_distro.arch:
             self.cancel("Processor is not PowerPC")
 
+        # Collect all pmu events from perf list and json files
+        self.perf_list_pmu_events = set()
+        self.json_pmu_events = set()
+        self.json_event_info = {}
+
+        output = process.system_output("perf list --raw-dump pmu", shell=True)
+        for ln in output.decode().split():
+            if ln.startswith('pm_') and ln not in ("hv_24x7" or "hv_gpci"):
+                self.perf_list_pmu_events.add(ln)
+        if not self.perf_list_pmu_events:
+            self.cancel("No PMU events found. Skipping the test.")
+
         deps = ['gcc', 'make', 'perf']
         if 'Ubuntu' in detected_distro.name:
             deps.extend(['linux-tools-common', 'linux-tools-%s'
@@ -100,16 +112,6 @@ class perf_json(Test):
         if self.rev in rev_to_power:
             self.testdir += '%s/' % rev_to_power[self.rev]
         self.sourcedir = os.path.join(self.buldir, self.testdir)
-
-        # Collect all pmu events from perf list and json files
-        self.perf_list_pmu_events = set()
-        self.json_pmu_events = set()
-        self.json_event_info = {}
-
-        output = process.system_output("perf list --raw-dump pmu", shell=True)
-        for ln in output.decode().split():
-            if ln.startswith('pm_') and ln not in ("hv_24x7" or "hv_gpci"):
-                self.perf_list_pmu_events.add(ln)
 
         # Clear the dmesg to capture the delta at the end of the test.
         dmesg.clear_dmesg()

--- a/perf/perf_mem.py
+++ b/perf/perf_mem.py
@@ -52,7 +52,7 @@ class perf_mem(Test):
                 self.cancel('%s is needed for the test to be run' % package)
 
         # Check for mem is available in the system.
-        output = process.run('perf mem record -e list').stderr.decode("utf-8")
+        output = process.run('perf mem record -e list', ignore_status=True).stderr.decode("utf-8")
         if 'ldlat-stores' in output or 'ldlat-loads' in output:
             self.log.info("perf mem is available")
         else:

--- a/perf/perf_pmu.py
+++ b/perf/perf_pmu.py
@@ -202,9 +202,8 @@ class PerfBasic(Test):
 
         sys_fs_events = os.listdir(
             os.path.join(base_dir, event_type, 'events'))
-        if len(sys_fs_events) < 21:
-            self.fail("%s events folder contains less than 21 entries"
-                      % event_type)
+        if not sys_fs_events:
+            self.fail("no events found in %s events folder" % event_type)
         self.log.info("%s events count = %s" %
                       (event_type, len(sys_fs_events)))
 
@@ -235,13 +234,13 @@ class PerfBasic(Test):
         self._remove_temp_user()
 
     def test_caps_feat(self):
-        modes = ['power10', 'power11']
-        if self.model in modes:
-            cmd = "cat /sys/bus/event_source/devices/cpu/caps/pmu_name"
-            sysfs_value = process.system_output(cmd, shell=True).decode()
-            self.log.info(" Sysfs caps version : %s " % sysfs_value)
+        caps_filepath = "/sys/bus/event_source/devices/cpu/caps/pmu_name"
+        if os.path.isfile(caps_filepath):
+            pmu_name = process.system_output(f'cat {caps_filepath}',
+                                             shell=True).decode()
+            self.log.info("Sysfs pmu registered: %s" % pmu_name)
         else:
-            self.cancel("This test is supported only for Power10 and above")
+            self.cancel("Caps file not found, skipping test")
 
     @skipIf(IS_POWER_NV or IS_KVM_GUEST, "This test is for PowerVM")
     def test_hv_24x7_event_count(self):

--- a/perf/perf_rawevents.py
+++ b/perf/perf_rawevents.py
@@ -67,6 +67,11 @@ class PerfRawevents(Test):
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
 
+        output = process.system_output("perf list --raw-dump pmu|grep pm_*",
+                                       shell=True, ignore_status=True)
+        if not output:
+            self.cancel("No PMU events found. Skipping the test")
+
         revisions_to_test = ['004b', '004e', '0080', '0082']
         for rev in revisions_to_test:
             for filename in [f'name_events_{rev}', f'raw_codes_{rev}']:


### PR DESCRIPTION
perf_c2c, perf_mem tests give error incase perf mem command fails when events are not available. Fix it by adding ignore_status check so test cancels.
```
Before fix:
ERROR: Command 'perf mem record -e list' failed.\nstdout: b''\nstderr: b'failed: memory events not supported\n'\nadditional_info: None
After fix:
CANCEL: perf c2c is not available
CANCEL: perf mem is not available
```
Added event raw codes for generic compat pmu for perf_genericevents test.
```
Before fix:
FAIL: Failed to verify generic PMU event codes
After fix:
JOB ID     : a2cf174c0134ef38b143831c6bdddbfd85946ee2
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2024-11-04T21.23-a2cf174/job.log
 (1/1) perf_genericevents.py:test_generic_events.test: STARTED
 (1/1) perf_genericevents.py:test_generic_events.test: PASS (0.05 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2024-11-04T21.23-a2cf174/results.html
JOB TIME   : 6.65 s
```
perf_json test results in false positive when pmu events are not present in case of generic compat pmu. Modify the code to cancel when events are not present. Also moved kernel building part after perf list check to avoid kernel build when not required.
```
Before fix:
JOB ID     : 0e1be5a1d5184c1504c80e99ff091a3cf97ae054
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2024-10-11T21.53-0e1be5a/job.log
 (1/2) /home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_json.py:perf_json.test_pmu_events: STARTED
 (1/2) /home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_json.py:perf_json.test_pmu_events:  PASS (913.64 s)
 (2/2) /home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_json.py:perf_json.test_compare: STARTED
 (2/2) /home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/perf/perf_json.py:perf_json.test_compare:  FAIL: mismatch in event list between perf list and json files (916.98 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2024-10-11T21.53-0e1be5a/results.html
JOB TIME   : 1886.96 s
After fix:
JOB ID     : 80f213407807e482d07b04d99317beadfa7b2c1b
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2024-11-05T00.50-80f2134/job.log
 (1/2) perf_json.py:perf_json.test_pmu_events: STARTED
 (1/2) perf_json.py:perf_json.test_pmu_events: CANCEL: No PMU events found. Skipping the test. (0.05 s)
 (2/2) perf_json.py:perf_json.test_compare: STARTED
 (2/2) perf_json.py:perf_json.test_compare: CANCEL: No PMU events found. Skipping the test. (0.04 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 2
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2024-11-05T00.50-80f2134/results.html
JOB TIME   : 63.69 s
```
Modified perf_pmu:test_cpu_event_count by removing hardcoded number, instead just check for presence of events.
```
Before fix:
FAIL: cpu events folder contains less than 21 entries (0.04 s)
After fix:
 (03/10) perf_pmu.py:PerfBasic.test_cpu_event_count: STARTED
 (03/10) perf_pmu.py:PerfBasic.test_cpu_event_count: PASS (0.22 s)
```
perf_pmu:test_caps_feat fails on older distros where caps file is not present. Modified the code to check for caps file presence instead of checking for P10/P11.
```
Before fix:
ERROR: Command 'cat /sys/bus/event_source/devices/cpu/caps/pmu_name' failed
After fix:
CANCEL: Caps file not found, skipping test
```
Add a check to find pmu events presence before running perf_rawevents test.
```
Before fix:
FAIL: perf_raw_events: refer log file for failed events
After fix:
JOB ID     : d9169c7dfde5aae4c756a372839687a071a97031
JOB LOG    : /home/OpTest/avocado-fvt-wrapper/results/job-2024-11-04T19.28-d9169c7/job.log
 (1/2) perf_rawevents.py:PerfRawevents.test_raw_code: STARTED
 (1/2) perf_rawevents.py:PerfRawevents.test_raw_code: CANCEL: No PMU events found. Skipping the test. (1.42 s)
 (2/2) perf_rawevents.py:PerfRawevents.test_name_event: STARTED
 (2/2) perf_rawevents.py:PerfRawevents.test_name_event: CANCEL: No PMU events found. Skipping the test. (1.42 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 2
JOB HTML   : /home/OpTest/avocado-fvt-wrapper/results/job-2024-11-04T19.28-d9169c7/results.html
JOB TIME   : 10.05 s
```