### PR TITLE
fs/flail.py: correct flail command usage

### DIFF
--- a/fs/flail.py
+++ b/fs/flail.py
@@ -36,18 +36,11 @@ class Flail(Test):
         for package in ['gcc', 'make']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel(package + ' is needed for the test to be run')
-        self.fs_type = self.params.get('fstype', default='xfs')
+        self.args = self.params.get('args', default='')
 
         archive.extract(self.get_data("flail-0.2.0.tar.gz"), self.workdir)
         self.build_dir = os.path.join(self.workdir, 'flail-0.2.0')
         os.chdir(self.build_dir)
-        fin = open("Makefile", "rt")
-        data = fin.read()
-        data = data.replace('-lm -o $@ flail.c', '-o $@ flail.c -lm')
-        fin.close()
-        fin = open("Makefile", "wt")
-        fin.write(data)
-        fin.close()
         build.make(self.build_dir)
 
     def test(self):
@@ -58,7 +51,7 @@ class Flail(Test):
         '''
         self.clear_dmesg()
         os.chdir(self.build_dir)
-        process.system('./flail %s 1' % self.fs_type, ignore_status=True)
+        process.system('./flail %s' % self.args, ignore_status=True)
         dmesg = process.system_output('dmesg')
         match = re.search(br'Call Trace:', dmesg, re.M | re.I)
         if match:

--- a/fs/flail.py.data/flail.yaml
+++ b/fs/flail.py.data/flail.yaml
@@ -1,5 +1,5 @@
+# flail takes 3 parameters namely name, seed and duration.
+# you can pass these parameters as -n, -s and -d as per requirement.
 run : !mux
- xfs:
-  fstype :  'xfs'
- ext4:
-  fstype :  'ext4'
+  params:
+    args: '-n read -s 2 -d 1000'


### PR DESCRIPTION
The previous command './flail <ext4/xfs> 1' was invalid and ignored by flail. 
flail takes only 3 args, updated yaml file with same. 
Also removed the makefile modification step since no longer required.