### PR TITLE
Patch to fix test failure on lpar with 1GB hugepages - v2

### DIFF
--- a/memory/transparent_hugepages.py
+++ b/memory/transparent_hugepages.py
@@ -91,6 +91,8 @@ class Thp(Test):
         # Start Stresssing the  System
         self.log.info('Stress testing using dd command')
 
+        if not self.count:
+            self.cancel("Please pass valid value for mem_size in yaml file")
         for iterator in range(self.count):
             stress_cmd = 'dd if=/dev/zero of=%s/%d bs=%dM count=1'\
                          % (self.mem_path, iterator, self.block_size)


### PR DESCRIPTION
Adding check to verify count value is non-zero.

[Bug 209952] RHEL10 [ P10 ] [ 6.11.0-0.rc5.22.el10.ppc64le ] [ FW1110.00 ]: transparent_hugepages.py test is failing on RHEL10