### PR TITLE
Fix patch apply issue

### DIFF
--- a/cpu/dwh.py
+++ b/cpu/dwh.py
@@ -64,12 +64,13 @@ class Dwh(Test):
 
         for file_name in ['dwh.cpp', 'Makefile']:
             self.copyutil(file_name)
-        os.chdir(self.teststmpdir)
         if dist.name in ['fedora', 'rhel']:
-            process.system('patch -p0 < %s' %
-                           os.path.abspath(self.get_data('fofd.patch')), shell=True)
+            cmd = 'patch -p0 < %s' % os.path.abspath(self.get_data('fofd.patch'))
         elif dist.name in ['Ubuntu', 'debian']:
-            process.system("sed -i 's/g++.*/& -lrt/' Makefile", shell=True)
+            cmd = "sed -i 's/g++.*/& -lrt/' Makefile"
+        os.chdir(self.teststmpdir)
+        process.run(cmd, shell=True)
+
         build.make(self.teststmpdir)
 
     def test(self):

--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -72,8 +72,8 @@ class Ebizzy(Test):
 
         patch = self.params.get(
             'patch', default='Fix-build-issues-with-ebizzy.patch')
-        os.chdir(self.sourcedir)
         patch_cmd = 'patch -p0 < %s' % os.path.abspath((self.get_data(patch)))
+        os.chdir(self.sourcedir)
         process.run(patch_cmd, shell=True)
         process.run('[ -x configure ] && ./configure', shell=True)
         build.make(self.sourcedir)

--- a/cpu/linsched.py
+++ b/cpu/linsched.py
@@ -52,8 +52,8 @@ class Linsched(Test):
         self.sourcedir = os.path.join(
             self.workdir, 'linux-scheduler-testing-master')
 
-        os.chdir(self.sourcedir)
         fix_patch = 'patch -p1 < %s' % os.path.abspath(self.get_data('fix.patch'))
+        os.chdir(self.sourcedir)
         process.run(fix_patch, shell=True, ignore_status=True)
 
         build.make(self.sourcedir)


### PR DESCRIPTION
Fix patch application issue caused by incorrect current directory Fixes 8c1cc5b52a06: ("fix patch apply issue")

--Before--
ERROR| Traceback (most recent call last):
ERROR|   File "ebizzy.py", line 76, in setUp
ERROR|   File "/usr/lib64/python3.9/posixpath.py", line 375, in abspath
ERROR|     path = os.fspath(path)
ERROR| TypeError: expected str, bytes or os.PathLike object, not NoneType
ERROR|
ERROR| ERROR 1-ebizzy.py:Ebizzy.test;run-duration-default-perf-pin-size-threads-workers-e56a ->
TestSetupFail: expected str, bytes or os.PathLike object, not NoneType

And similar issue in dwh and linsched tests

This change fixes that

--After--
DEBUG| DATA (filename=dwh.cpp) => /root/avocado-misc-tests/cpu/dwh.py.data/dwh.cpp (found at file source dir) DATA (filename=Makefile) => /root/avocado-misc-tests/cpu/dwh.py.data/Makefile (found at file source dir) DATA (filename=fofd.patch) => /root/avocado-misc-tests/cpu/dwh.py.data/fofd.patch (found at file source dir) INFO | Running 'patch -p0 < /root/avocado-misc-tests/cpu/dwh.py.data/fofd.patch' DEBUG| [stdout] patching file dwh.cpp
INFO | Command 'patch -p0 < /root/avocado-misc-tests/cpu/dwh.py.data/fofd.patch' finished with 0 after 0.003100977s INFO | Running 'make'