### PR TITLE
Skip malloc1 and malloc2 due to indefinite runtime

### DIFF
--- a/kernel/will-it-scale.py.data/README
+++ b/kernel/will-it-scale.py.data/README
@@ -22,8 +22,6 @@ Following is a list of testcase currently supported.
  - lock2
  - lseek1
  - lseek2
- - malloc1
- - malloc2
  - mmap1
  - mmap2
  - open1

--- a/kernel/will-it-scale.py.data/will-it-scale.yaml
+++ b/kernel/will-it-scale.py.data/will-it-scale.yaml
@@ -32,10 +32,6 @@ testcase: !mux
         name: lseek1
     lseek2:
         name: lseek2
-    malloc1:
-        name: malloc1
-    malloc2:
-        name: malloc2
     mmap1:
         name: mmap1
     mmap2:


### PR DESCRIPTION
While running the will-it-scale test suite, it was observed that certain tests are getting stuck indefinitely, causing the entire test suite to be blocked. To avoid this, we are temporarily removing the following tests from the will-it-scale test bucket
1. malloc1
2. malloc2