### PR TITLE
Fixes testcases failure due to previously created namespace.

### DIFF
--- a/memory/ndctl.py.data/ndctl.yaml
+++ b/memory/ndctl.py.data/ndctl.yaml
@@ -3,7 +3,7 @@ size: "null"
 map:
 git_branch: 'pending'
 ndctl_project_version: '73'
-preserve_change: True
+preserve_change: False
 mnt_point: '/mnt/pmem'
 fio_job:
 version: !mux


### PR DESCRIPTION
test_fsdax_write, test_map_sync and test_devdax_write tests are failing with error 'Namespace create command failed' because of previously created namespace so changing preserve_change to false.