### PR TITLE
Added support to run pmem_dt_check.py on P11 FW.

### DIFF
--- a/memory/pmem_dt_check.py
+++ b/memory/pmem_dt_check.py
@@ -77,7 +77,7 @@ class NdctlDeviceTreeCheck(Test):
         """
         Build 'ndctl' and setup the binary.
         """
-        if "powerpc" not in cpu.get_cpu_arch():
+        if cpu.get_cpu_arch() not in ["powerpc", "ppc64le"]:
             self.cancel("Test supported only on POWER arch")
 
         deps = []


### PR DESCRIPTION
On P11 FW pmem_dt_check.py test is skipped as cpu.get_cpu_arch() returns ppc64le.