### PR TITLE
Ubuntu version number handling in tests.

### DIFF
--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -86,7 +86,7 @@ class Dbench(Test):
                 self.error('%s is needed for the test to be run' % pkg)
 
         if fstype == 'btrfs':
-            ver = int(distro.detect().version)
+            ver = int(distro.detect().version.split('.')[0])
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -82,7 +82,7 @@ class FioTest(Test):
             self.cancel("Please Provide valid disk")
 
         if fstype == 'btrfs':
-            ver = int(distro.detect().version)
+            ver = int(distro.detect().version.split('.')[0])
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -79,7 +79,7 @@ class FSMark(Test):
         smm = SoftwareManager()
 
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
+            ver = int(distro.detect().version.split('.')[0])
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -79,7 +79,7 @@ class LtpFs(Test):
                 self.cancel("%s is needed for the test to be run" % package)
 
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
+            ver = int(distro.detect().version.split('.')[0])
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -63,7 +63,7 @@ class Lvsetup(Test):
         if self.fs_name == 'xfs':
             pkgs = ['xfsprogs']
         if self.fs_name == 'btrfs':
-            ver = int(distro.detect().version)
+            ver = int(distro.detect().version.split('.')[0])
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -78,7 +78,7 @@ class Tiobench(Test):
         smm = SoftwareManager()
         packages = ['gcc', 'mdadm']
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
+            ver = int(distro.detect().version.split('.')[0])
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -65,7 +65,7 @@ class Lshwrun(Test):
         if dist.name == "SuSE" and int(dist.version) < 15:
             self.cancel("lshw not supported on SLES-%s. Please run "
                         "on SLES15 or higher versions only " % dist.version)
-        if ((dist.name == 'Ubuntu' and int(dist.version) >= 18) or
+        if ((dist.name == 'Ubuntu' and int(dist.version.split('.')[0]) >= 18) or
                 (dist.name in ["SuSE", 'debian'])):
             packages.extend(['iproute2'])
         else:


### PR DESCRIPTION
Recently, avocado distro utils had a fix to return the full version number in ubuntu and debian distros, instead of just the major number earlier. This patch handles change that in tests.

Mentioned commit: https://github.com/avocado-framework/avocado/commit/55d1cd3a143d3a9a5667458da1e3014a7bc46939