### PR TITLE
Fixed htx ssl issue while accessing the HTX RPM

### DIFF
--- a/workload/htx_test.py
+++ b/workload/htx_test.py
@@ -58,12 +58,21 @@ class HtxTest(Test):
             htx_rpm for htx_rpm in matching_htx_versions
             if distro_pattern in htx_rpm]
         distro_specific_htx_versions.sort(reverse=True)
-        self.latest_htx_rpm = distro_specific_htx_versions[0]
-
-        if process.system('rpm -ivh --nodeps %s%s '
-                          '--force' % (self.rpm_link, self.latest_htx_rpm),
+        htx_latest_rpm = distro_specific_htx_versions[0]
+        self.latest_htx_rpm = htx_latest_rpm
+        tmp_dir = "/tmp/" + htx_latest_rpm
+        cmd = "curl -k %s/%s -o %s" % (self.rpm_link, self.latest_htx_rpm,
+                                       tmp_dir)
+        if process.system(cmd,
                           shell=True, ignore_status=True):
-            self.cancel("Installation of rpm failed")
+            self.cancel("rpm download failed")
+        cmd = "rpm -ivh %s" % (tmp_dir)
+        if process.system(cmd,
+                          shell=True, ignore_status=True):
+            self.cancel("rpm installation failed")
+        cmd = "rm -rf %s" % (tmp_dir)
+        # Remove the downloaded HTX rpm from /tmp directory
+        process.run(cmd)
 
     def setUp(self):
         """
@@ -164,7 +173,8 @@ class HtxTest(Test):
         # Kill existing HTXD process if running
         htxd_pid = process.getoutput("pgrep -f htxd")
         if htxd_pid:
-            self.log.info("HTXD is already running with PID: %s. Killing it.", htxd_pid)
+            self.log.info(
+                "HTXD is already running with PID: %s. Killing it.", htxd_pid)
             process.run("pkill -f htxd", ignore_status=True)
             time.sleep(10)
         process.run('/usr/lpp/htx/etc/scripts/htxd_run')


### PR DESCRIPTION
Due to an SSL issue on the LPAR, the installation of the HTX RPM using rpm -ivh is failing.
To resolve this, we have implemented a curl-based
approach to download and install the HTX RPM packages