### PR TITLE
Enhanced blktest

### DIFF
--- a/fs/blktests.py
+++ b/fs/blktests.py
@@ -33,8 +33,10 @@ class Blktests(Test):
         '''
         Setup Blktests
         '''
+        self.disk = []
         self.disk = self.params.get('disk', default='')
         self.dev_type = self.params.get('type', default='')
+        self.disk = self.disk.split(',')
         smm = SoftwareManager()
         dist = distro.detect()
         if dist.name in ['Ubuntu', 'debian']:
@@ -57,14 +59,15 @@ class Blktests(Test):
 
         build.make(self.sourcedir)
 
+            
     def test(self):
 
         self.clear_dmesg()
         os.chdir(self.sourcedir)
 
         genio.write_one_line("/proc/sys/kernel/hung_task_timeout_secs", "0")
-        if self.disk:
-            os.environ['TEST_DEVS'] = self.disk
+        for disk in self.disk:
+            os.environ['TEST_DEVS'] = ' '.join(self.disk)
         cmd = './check %s' % self.dev_type
         result = process.run(cmd, ignore_status=True, verbose=True)
         if result.exit_status != 0:

--- a/fs/blktests.py
+++ b/fs/blktests.py
@@ -59,7 +59,6 @@ class Blktests(Test):
 
         build.make(self.sourcedir)
 
-            
     def test(self):
 
         self.clear_dmesg()

--- a/fs/blktests.py.data/blktests.yaml
+++ b/fs/blktests.py.data/blktests.yaml
@@ -1,2 +1,12 @@
-disk: "null"
-type: "null"
+disk: "/dev/mapper/mpathi,/dev/mapper/mpathh"
+component: !mux
+    block:
+        type: "block"
+    scsi:
+        type" "scsi"
+    nvme:
+        type: "nvme"
+    loop:
+        type: "loop"
+    dm:
+        type: "dm"


### PR DESCRIPTION
Current blktest could only accept one test and one disk. Enchanced the test to accept multiple disks and modified the yaml file, to run multiple types of test cases.