### PR TITLE
kernel/kselftest.py: fix cancellation check for pmu event_code_tests

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -129,8 +129,6 @@ class kselftest(Test):
                 process.system("make install -C %s" % self.sourcedir,
                                shell=True, sudo=True)
         else:
-            if self.subtest == 'pmu/event_code_tests':
-                self.cancel("selftest not supported on distro")
             # Make sure kernel source repo is configured
             if detected_distro.name in ['centos', 'fedora', 'rhel']:
                 src_name = 'kernel'
@@ -155,6 +153,11 @@ class kselftest(Test):
                 self.buldir = "/usr/src/linux"
 
         self.sourcedir = os.path.join(self.buldir, self.testdir)
+        if self.subtest == 'pmu/event_code_tests':
+            pmu_test_dir = os.path.join(
+                self.sourcedir, 'powerpc/pmu/event_code_tests')
+            if not os.path.exists(pmu_test_dir):
+                self.cancel("selftest not supported on distro")
         # cmsg_* tests from net/ subdirectory takes a lot of time to complete.
         # Until they have been root caused skip them.
         if self.comp == 'net':


### PR DESCRIPTION
Move the cancellation check for pmu/event_code_tests to the test execution block to ensure it correctly verifies the existence of the required directory and avoids early cancellation.
```
Fetching asset from kselftest.py:kselftest.test
JOB ID     : 4f1f1f0d6bee4ef33117ad5ff1cd8b3b5fe8825f
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2025-02-26T14.03-4f1f1f0/job.log
 (1/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-distro-77ee: STARTED
 (1/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-distro-77ee:  PASS (128.73 s)
 (2/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-distro-109d: STARTED
 (2/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-distro-109d:  PASS (0.97 s)
 (3/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-distro-92f3: STARTED
 (3/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-distro-92f3:  PASS (1.01 s)
 (4/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-upstream-8ab9: STARTED
 (4/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-upstream-8ab9:  PASS (391.88 s)
 (5/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-upstream-01a1: STARTED
 (5/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-upstream-01a1:  PASS (265.35 s)
 (6/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-upstream-3a10: STARTED
 (6/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-upstream-3a10:  PASS (266.35 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2025-02-26T14.03-4f1f1f0/results.html
JOB TIME   : 1078.61 s
```
```
Fetching asset from kselftest.py:kselftest.test
JOB ID     : fa97da965e004bedc8b0f38a2904074330a9cef2
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2025-02-27T00.50-fa97da9/job.log
 (1/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-distro-77ee: STARTED
 (1/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-distro-77ee:  PASS (173.13 s)
 (2/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-distro-109d: STARTED
 (2/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-distro-109d:  CANCEL: selftest not supported on distro (36.77 s)
 (3/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-distro-92f3: STARTED
 (3/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-distro-92f3:  PASS (35.96 s)
 (4/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-upstream-8ab9: STARTED
 (4/6) kselftest.py:kselftest.test;run-component-pmu/ebb-run_type-upstream-8ab9:  PASS (370.31 s)
 (5/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-upstream-01a1: STARTED
 (5/6) kselftest.py:kselftest.test;run-component-pmu/event_code-run_type-upstream-01a1:  PASS (227.16 s)
 (6/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-upstream-3a10: STARTED
 (6/6) kselftest.py:kselftest.test;run-component-pmu/sampling_tests-run_type-upstream-3a10:  PASS (227.30 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2025-02-27T00.50-fa97da9/results.html
JOB TIME   : 1138.79 s
```