### PR TITLE
Changing the plotform validation to power for IBM power servers

### DIFF
--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -54,7 +54,7 @@ class DiskInfo(Test):
         pkg = ""
         device = self.params.get('disk', default=None)
         self.disk = disk.get_absolute_disk_path(device)
-        if 'ppc' not in cpu.get_arch():
+        if 'power' not in cpu.get_arch():
             self.cancel("Processor is not ppc64")
         self.dirs = self.params.get('dir', default=self.workdir)
         self.fstype = self.params.get('fs', default='ext4')

--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -47,7 +47,7 @@ class PCIHotPlugTest(Test):
         """
         Setup the device.
         """
-        if 'ppc' not in cpu.get_arch():
+        if 'power' not in cpu.get_arch():
             self.cancel("Processor is not ppc64")
         if os.path.exists('/proc/device-tree/bmc'):
             self.cancel("Test Unsupported! on this platform")

--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -195,7 +195,7 @@ class MemStress(Test):
         self.__error_check()
 
     def test_dlpar_mem_hotplug(self):
-        if 'ppc' in cpu.get_arch() and 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
+        if 'power' in cpu.get_arch() and 'PowerNV' not in open('/proc/cpuinfo', 'r').read():
             if b"mem_dlpar=yes" in process.system_output("drmgr -C", ignore_status=True, shell=True):
                 self.log.info("\nDLPAR remove memory operation\n")
                 for _ in range(len(self.blocks_hotpluggable) // 2):


### PR DESCRIPTION
earlier we were validating "ppc" for power server, Now it has changed to power as from RH10 onwards this has been changed and the utility is also now returning powerpc