### PR TITLE
kernel/will-it-scale: Add support to download libhwloc

### DIFF
--- a/kernel/will-it-scale.py
+++ b/kernel/will-it-scale.py
@@ -18,11 +18,12 @@
 
 import os
 import shutil
+import pathlib
 from sys import version_info
 
 from avocado import Test
 from avocado import skipIf
-from avocado.utils import process, build, memory, archive
+from avocado.utils import process, build, memory, archive, distro
 from avocado.utils.software_manager.manager import SoftwareManager
 
 SINGLE_NODE = len(memory.numa_nodes_with_memory()) < 2
@@ -37,6 +38,41 @@ class WillItScaleTest(Test):
 
     :avocado: tags=kernel,ppc64le
     """
+    fail_cmd = list()
+
+    def run_cmd(self, cmd):
+        if process.system(cmd, ignore_status=True, sudo=True, shell=True):
+            self.fail_cmd.append(cmd)
+        return
+
+    def get_libhw(self):
+        """
+        SLES does not contain hwloc-devel package, get the source and
+        compile it to be linked to will-it-scale binaries.
+
+        Source - https://github.com/open-mpi/hwloc/
+        """
+        hwloc_url = ('https://github.com/open-mpi/hwloc/archive/refs/'
+                     'heads/master.zip')
+        tarball = self.fetch_asset('hwloc.zip', locations=hwloc_url,
+                                   expire='7d')
+        archive.extract(tarball, self.workdir)
+        self.sourcedir = os.path.join(self.workdir, 'hwloc-master')
+        os.chdir(self.sourcedir)
+        self.run_cmd('./autogen.sh')
+        self.run_cmd('./configure --prefix=/usr')
+        if self.fail_cmd:
+            self.fail('Configure failed, please check debug logs')
+        if build.make(self.sourcedir):
+            self.fail('make failed, please check debug logs')
+        if build.make(self.sourcedir, extra_args='install'):
+            self.fail('make install failed, please check debug logs')
+        # Create a symlink with name libhwloc.so.0
+        if not pathlib.Path("/usr/lib/libhwloc.so.0").is_symlink():
+            self.run_cmd('ln -s /usr/lib/libhwloc.so.0.0.0 '
+                         '/usr/lib/libhwloc.so.0')
+            if self.fail_cmd:
+                self.warn('libhwloc softlink failed, program may not run')
 
     @skipIf(SINGLE_NODE, "Test requires at least two numa nodes")
     @skipIf(VERSION_CHK, "Test requires Python 3.7+")
@@ -49,10 +85,17 @@ class WillItScaleTest(Test):
         To generate graphical results
           ./postprocess.py
         """
+        self.distro_rel = distro.detect()
         smm = SoftwareManager()
-        for package in ['gcc', 'make', 'hwloc-devel']:
+        deps = ['gcc', 'make']
+        if self.distro_rel.name.lower() in ['fedora', 'redhat']:
+            deps.extend(['hwloc-devel'])
+        for package in deps:
             if not smm.check_installed(package) and not smm.install(package):
-                self.cancel('%s is needed for the test to be run' % package)
+                self.cancel('%s is required for this test' % package)
+        # Compile and install libhwloc library
+        if 'suse' in self.distro_rel.name.lower():
+            self.get_libhw()
 
         self.postprocess = self.params.get('postprocess', default=True)
         self.testcase = self.params.get('name', default='brk1')
@@ -64,6 +107,10 @@ class WillItScaleTest(Test):
         archive.extract(tarball, self.workdir)
         self.sourcedir = os.path.join(self.workdir, 'will-it-scale-master')
         os.chdir(self.sourcedir)
+        # Modify the makefile to point to installed libhwloc
+        if 'suse' in self.distro_rel.name.lower():
+            makefile_patch = 'patch -p1 < %s' % self.get_data('makefile.patch')
+            process.run(makefile_patch, shell=True)
         if build.make(self.sourcedir):
             self.fail('make failed, please check debug logs')
 

--- a/kernel/will-it-scale.py.data/makefile.patch
+++ b/kernel/will-it-scale.py.data/makefile.patch
@@ -1,0 +1,10 @@
+diff -Naurp a/Makefile b/Makefile
+--- a/Makefile	2025-03-04 07:50:31.400000000 +0100
++++ b/Makefile	2025-03-04 07:51:58.560000000 +0100
+@@ -1,5 +1,5 @@
+ CFLAGS+=-Wall -O2 -g
+-LDFLAGS+=-lhwloc
++LDFLAGS+=-Wl,-rpath=/usr/lib -lhwloc
+ 
+ processes := $(patsubst tests/%.c,%_processes,$(wildcard tests/*.c))
+ threads := $(patsubst tests/%.c,%_threads,$(wildcard tests/*.c))


### PR DESCRIPTION
On certain Linux distributions libhwloc may not be available. This blocks the
execution of will-it-scale. Add support to compile and install libhwloc library
using the hwloc source code.

Update the will-it-scale source code to use the installed libhwloc library. 
Restrict this check to the distribution releases that do not ship hwloc-devel
package.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>