### PR TITLE
io/iommu/amd: Update kernel config and dmesg check methods

### DIFF
--- a/io/iommu/amd/iommu_v2pgmode_test.py
+++ b/io/iommu/amd/iommu_v2pgmode_test.py
@@ -50,7 +50,12 @@ def check_dmesg(string):
     """
     cmd = f'dmesg | grep -i "{string}"'
     output = process.run(cmd, ignore_status=True, shell=True).stdout_text
-    if output != "":
+    if output == "":
+        cmd = f'journalctl -k -b | grep -i "{string}"'
+        output = process.run(cmd, ignore_status=True, shell=True).stdout_text
+        if output != "":
+            return True
+    else:
         return True
     return False
 

--- a/io/iommu/amd/iommu_v2pgmode_test.py
+++ b/io/iommu/amd/iommu_v2pgmode_test.py
@@ -18,20 +18,30 @@
 Validate 5 level page table support in v2 iommu page table mode
 """
 
+import os
+import platform
 from avocado import Test
 from avocado import skipUnless
-from avocado.utils import cpu, process, linux_modules
+from avocado.utils import cpu, process
 
 
-def check_kernelconf_5lvl():
-    '''
-    Check 5-Level page table support at kernel.
-    '''
-    cfg_param = "CONFIG_X86_5LEVEL"
-    result = linux_modules.check_kernel_config(cfg_param)
-    if result == linux_modules.ModuleConfig.NOT_SET:
-        return False
-    return True
+def check_kernelconf(config_file, config):
+    """
+    check if kernel config 'config' is enable on not in 'config_file'
+
+    :config_file: kernel config file path to check
+    :config: kernel config to check if builtin or not
+    return: bool
+    """
+    with open(config_file, "r") as kernel_config:
+        for line in kernel_config:
+            line = line.split("=")
+            if len(line) != 2:
+                continue
+            if line[0].strip() == f"{config}":
+                if line[1].strip() == 'y':
+                    return True
+    return False
 
 
 def check_dmesg(string):
@@ -74,12 +84,30 @@ class IommuPageTable(Test):
         else:
             self.cancel("IOMMU is not enabled")
 
+    def check_kernelconf_5lvl(self):
+        """
+        Check if kernel config 'CONFIG_X86_5LEVEL' enabled or not
+        return: bool
+        """
+
+        kernel_version = platform.uname()[2]
+        config_file = "/boot/config-" + kernel_version
+        if os.path.exists(config_file):
+            return check_kernelconf(config_file, "CONFIG_X86_5LEVEL")
+
+        config_file = "/lib/modules/" + kernel_version + "/build/.config"
+        if os.path.exists(config_file):
+            return check_kernelconf(config_file, "CONFIG_X86_5LEVEL")
+
+        self.cancel("Kernel config not found in '/boot/' and '/lib/modules/<uname -r>/build/'")
+        return False
+
     def test(self):
         '''
         Test if host page table mode matches with iommu v2 page table mode
         '''
         if check_dmesg('V2 page table enabled'):
-            if (cpu.cpu_has_flags(["la57"]) and check_kernelconf_5lvl()):
+            if (cpu.cpu_has_flags(["la57"]) and self.check_kernelconf_5lvl()):
                 if check_v2pgtbl_mode("5"):
                     self.log.info("Host page table mode (5lvl) match with IOMMU V2 Page mode")
                 else:


### PR DESCRIPTION
**This patch series**
1. [Patch 1] Update check_kernelconf_5lvl() to usem "/lib/modules/<kernel_version>/build/.config" to check for kernel config
   file making test work for both ubuntu and rhel.
2. [Patch 2] Add addtional journalctl check for kernel logs in addition to dmesg.

**Run**
avocado-misc-tests# avocado run io/iommu/amd/iommu_v2pgmode_test.py
JOB ID     : 3cc7db3ef40f8195a00951bf6c7f6556d79beefc
JOB LOG    : /root/tests/results/job-2025-03-04T08.04-3cc7db3/job.log
 (1/1) io/iommu/amd/iommu_v2pgmode_test.py:IommuPageTable.test: STARTED
 (1/1) io/iommu/amd/iommu_v2pgmode_test.py:IommuPageTable.test: PASS (0.21 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/tests/results/job-2025-03-04T08.04-3cc7db3/results.html
JOB TIME   : 1.91 s