### PR TITLE
io/iommu: Validate pci_addr input and update check_dmesg()

### DIFF
--- a/io/iommu/iommu_tests.py
+++ b/io/iommu/iommu_tests.py
@@ -91,6 +91,7 @@ class IommuTest(Test):
         self.pci_devices = self.params.get('pci_devices', default=None)
         self.count = int(self.params.get('count', default=1))
         self.domains = ["DMA", "DMA-FQ", "identity", "auto"]
+        self.dmesg_grep = self.params.get('dmesg_grep', default='')
         if not self.pci_devices:
             self.cancel("No pci device given")
         smm = SoftwareManager()
@@ -397,6 +398,8 @@ class IommuTest(Test):
         process.run(cmd, ignore_status=True, shell=True, sudo=True)
 
         cmd = "diff dmesg_final.txt dmesg_initial.txt"
+        if self.dmesg_grep != '':
+            cmd = f"{cmd} | grep -i -e '{self.dmesg_grep}'"
         dmesg_diff = process.run(cmd, ignore_status=True, shell=True, sudo=True).stdout_text
         if dmesg_diff != '':
             self.whiteboard = f"{dmesg_diff}"


### PR DESCRIPTION
**This patch series**
1. [Patch 0/2] Add check to validate pci address (pci_addr) user input.
2. [Patch 1/2 and 2/2] Update the process of checking and validating dmesg for each subtest. Current process clears the dmesg 
affecting subsequent tests that depends on dmesg.

**Run**
```
avocado-misc-tests# avocado run io/iommu/iommu_tests.py -p pci_devices="0000:01:00.0" -p dmesg_grep="iommu|AMD-Vi" -p count='1' --max-parallel-tasks=
1
JOB ID     : 132c8969e459f615389a975bced0ded359a49735
JOB LOG    : /root/tests/results/job-2025-03-04T08.09-132c896/job.log
 (1/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_bind: STARTED
 (1/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_bind: PASS (6.55 s)
 (2/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind: STARTED
 (2/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind: PASS (64.15 s)
 (3/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind: STARTED
 (3/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind: PASS (64.32 s)
 (4/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan: STARTED
 (4/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan: PASS (5.58 s)
 (5/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan: STARTED
 (5/6) io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan: PASS (66.99 s)
 (6/6) io/iommu/iommu_tests.py:IommuTest.test_reset_rescan: STARTED
 (6/6) io/iommu/iommu_tests.py:IommuTest.test_reset_rescan: PASS (1.39 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/tests/results/job-2025-03-04T08.09-132c896/results.html
JOB TIME   : 216.69 s
```