### PR TITLE
io/iommu/amd: Derive cpu page table level from va bits of /proc/cpuinfo

### DIFF
--- a/io/iommu/amd/iommu_v2pgmode_test.py
+++ b/io/iommu/amd/iommu_v2pgmode_test.py
@@ -104,7 +104,8 @@ class IommuPageTable(Test):
         if os.path.exists(config_file):
             return check_kernelconf(config_file, "CONFIG_X86_5LEVEL")
 
-        self.cancel("Kernel config not found in '/boot/' and '/lib/modules/<uname -r>/build/'")
+        self.log.info("Kernel config not found in '/boot/' and '/lib/modules/<uname -r>/build/'."
+                      "Using VA bits in /proc/cpuinfo to derive cpu page table level")
         return False
 
     def test(self):


### PR DESCRIPTION
Instead of canceling the test if kernel config file is not found, rely and derive cpu page table level from /proc/cpuinfo.

**Run**
```
avocado-misc-tests# avocado run io/iommu/amd/iommu_v2pgmode_test.py
JOB ID     : d36a3fa532950d598b273529a8854e1fe7be3944
JOB LOG    : /root/tests/results/job-2025-03-04T12.40-d36a3fa/job.log
 (1/1) io/iommu/amd/iommu_v2pgmode_test.py:IommuPageTable.test: STARTED
 (1/1) io/iommu/amd/iommu_v2pgmode_test.py:IommuPageTable.test: PASS (0.22 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/tests/results/job-2025-03-04T12.40-d36a3fa/results.html
JOB TIME   : 1.93 s
```