### PR TITLE
Fixed split error occured while getting distro version

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -82,7 +82,7 @@ class FioTest(Test):
             self.cancel("Please Provide valid disk")
 
         if fstype == 'btrfs':
-            ver = int(distro.detect().version.split('.')[0])
+            ver = int(distro.detect().version)
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -79,7 +79,7 @@ class LtpFs(Test):
                 self.cancel("%s is needed for the test to be run" % package)
 
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version.split('.')[0])
+            ver = int(distro.detect().version)
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -63,7 +63,7 @@ class Lvsetup(Test):
         if self.fs_name == 'xfs':
             pkgs = ['xfsprogs']
         if self.fs_name == 'btrfs':
-            ver = int(distro.detect().version.split('.')[0])
+            ver = int(distro.detect().version)
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -78,7 +78,7 @@ class Tiobench(Test):
         smm = SoftwareManager()
         packages = ['gcc', 'mdadm']
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version.split('.')[0])
+            ver = int(distro.detect().version)
             rel = int(distro.detect().release)
             if distro.detect().name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:


### PR DESCRIPTION
The current utility returns the exact version and not required to further maniculate. hence changing the those .py files which has this further maniculations.