### PR TITLE
trace/dawr: Handle debuginfod check

### DIFF
--- a/trace/dawr.py
+++ b/trace/dawr.py
@@ -61,6 +61,9 @@ class Dawr(Test):
         time.sleep(0.3)
         child.logfile = sys.stdout
         child.expect('(gdb)')
+        if self.distro_name in ['fedora', 'SuSE']:
+            child.sendline('set debuginfod enabled on')
+            child.expect_exact([pexpect.TIMEOUT, ''])
         return_value = []
         return child, return_value
 
@@ -71,9 +74,6 @@ class Dawr(Test):
         """
         child, return_value = self.run_cmd('dawr_v1')
         i = 0
-        if self.distro_name == "fedora":
-            child.sendline('set debuginfod enabled on')
-            child.expect_exact([pexpect.TIMEOUT, ''])
         child.sendline('awatch a')
         return_value.append(child.expect_exact(['watchpoint 1: a',
                                                 pexpect.TIMEOUT]))
@@ -94,9 +94,6 @@ class Dawr(Test):
         """
         child, return_value = self.run_cmd('dawr_v2')
         i = 0
-        if self.distro_name == "fedora":
-            child.sendline('set debuginfod enabled on')
-            child.expect_exact([pexpect.TIMEOUT, ''])
         for value in ['a', 'b']:
             i = i+1
             child.sendline('awatch %s' % value)


### PR DESCRIPTION
On recent Linux distribution releases running gdb debug session
with dawr binary fails. While running the program with gdb, 
following interactive debuginfod related question is introduced

Enable debuginfod for this session? (y or [n])

Handle this additional ask by extending the fedora only check to
SUSE release. While at it avoid duplication of this code by moving
the logic to run_cmd

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>