### PR TITLE
generic/ipistorm: Update arch detection logic

### DIFF
--- a/generic/ipistorm.py
+++ b/generic/ipistorm.py
@@ -41,8 +41,8 @@ class DBLIPIStrom(Test):
         """
         Install necessary packages to build the linux module
         """
-        if 'power' not in cpu.get_family():
-            self.cancel('Test Only supported on Power')
+        if 'ppc64' not in cpu.get_arch:
+            self.cancel("Test is supported only on ppc64le architecture")
 
         pkgs = ['gcc', 'make']
         smm = SoftwareManager()


### PR DESCRIPTION
ipistorm test error's out with following message:

 (1/1) generic/ipistorm.py:DBLIPIStrom.test: STARTED
 (1/1) generic/ipistorm.py:DBLIPIStrom.test: ERROR (0.01 s)

Switch to get_arch() instead of get_family()

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>