### PR TITLE
memory/libhugetlbfs.py: Handle make failures

### DIFF
--- a/memory/libhugetlbfs.py
+++ b/memory/libhugetlbfs.py
@@ -129,7 +129,8 @@ class LibHugetlbfs(Test):
         os.chdir(self.workdir)
         patch = self.params.get('patch', default='elflink.patch')
         process.run('patch -p1 < %s' % self.get_data(patch), shell=True)
-
+        process.run('./autogen.sh', shell=True)
+        process.run('./configure', shell=True)
         build.make(self.workdir, extra_args='BUILDTYPE=NATIVEONLY')
 
     @staticmethod


### PR DESCRIPTION
Fix make failures in test
Link 3a9d51c107e1 ("build: automake support")

--Before--
JOB ID     : 7a795476fc2f2ebb762692593821d6d30c1b81f2
JOB LOG    : /root/avocado-misc-tests/results/job-2025-03-13T18.34-7a79547/job.log
 (1/1) libhugetlbfs.py:LibHugetlbfs.test;run-hugepages_requested-default-mount_dir-f2fd: STARTED
 (1/1) libhugetlbfs.py:LibHugetlbfs.test;run-hugepages_requested-default-mount_dir-f2fd: ERROR:
 Command 'make BUILDTYPE=NATIVEONLY' failed.\nstdout: b''\nstderr: b'make: *** No targets specified
and no makefile found.  Stop.\n'\nadditional_info: None (0.92 s)

RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-misc-tests/results/job-2025-03-13T18.34-7a79547/results.html
JOB TIME   : 13.14 s

--After--
JOB ID     : b8a9130d68296b939e48ee374ed7fbaa8641a2d0
JOB LOG    : /root/avocado-misc-tests/results/job-2025-03-13T18.36-b8a9130/job.log
 (1/1) libhugetlbfs.py:LibHugetlbfs.test;run-hugepages_requested-default-mount_dir-f2fd: STARTED
 (1/1) libhugetlbfs.py:LibHugetlbfs.test;run-hugepages_requested-default-mount_dir-f2fd: PASS (32.12 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado-misc-tests/results/job-2025-03-13T18.36-b8a9130/results.html
JOB TIME   : 36.55 s