### PR TITLE
Update btrfs package name in ubuntu

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -92,7 +92,7 @@ class Bonnie(Test):
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs not supported with RHEL 7.4 onwards")
             elif distro.detect().name == 'Ubuntu':
-                deps.extend(['btrfs-tools'])
+                deps.extend(['btrfs-progs'])
         if raid_needed:
             deps.append('mdadm')
 

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -93,9 +93,9 @@ class Dbench(Test):
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
-                if not sm.check_installed("btrfs-tools") and not \
-                        sm.install("btrfs-tools"):
-                    self.cancel('btrfs-tools is needed for the test to be run')
+                if not sm.check_installed("btrfs-progs") and not \
+                        sm.install("btrfs-progs"):
+                    self.cancel('btrfs-progs is needed for the test to be run')
 
         self.results = []
         tarball = self.fetch_asset(

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -83,7 +83,7 @@ class DiskInfo(Test):
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
             if self.distro == 'Ubuntu':
-                pkg_list.append("btrfs-tools")
+                pkg_list.append("btrfs-progs")
         for pkg in pkg_list:
             if pkg and not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel("Package %s is missing and could not be installed"

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -86,9 +86,9 @@ class FSMark(Test):
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
             if distro.detect().name == 'Ubuntu':
-                if not smm.check_installed("btrfs-tools") and not \
-                        smm.install("btrfs-tools"):
-                    self.cancel('btrfs-tools is needed for the test to be run')
+                if not smm.check_installed("btrfs-progs") and not \
+                        smm.install("btrfs-progs"):
+                    self.cancel('btrfs-progs is needed for the test to be run')
 
         if raid_needed:
             if not smm.check_installed('mdadm') and not smm.install('mdadm'):

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -443,10 +443,10 @@ class IOZone(Test):
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
                 if distro.detect().name == 'Ubuntu':
-                    if not smm.check_installed("btrfs-tools") and not \
-                            smm.install("btrfs-tools"):
+                    if not smm.check_installed("btrfs-progs") and not \
+                            smm.install("btrfs-progs"):
                         self.cancel(
-                            'btrfs-tools is needed for the test to be run')
+                            'btrfs-progs is needed for the test to be run')
 
         tarball = self.fetch_asset(self.source_url)
         archive.extract(tarball, self.teststmpdir)

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -90,9 +90,9 @@ class LtpFs(Test):
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
             if distro_name == 'Ubuntu':
-                if not smm.check_installed("btrfs-tools") and not \
-                        smm.install("btrfs-tools"):
-                    self.cancel('btrfs-tools is needed for the test to be run')
+                if not smm.check_installed("btrfs-progs") and not \
+                        smm.install("btrfs-progs"):
+                    self.cancel('btrfs-progs is needed for the test to be run')
 
         self.raid_name = '/dev/md/sraid'
         self.vgname = 'avocado_vg'

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -88,7 +88,7 @@ class Tiobench(Test):
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
             if distro_name == 'Ubuntu':
-                packages.extend(['btrfs-tools'])
+                packages.extend(['btrfs-progs'])
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel("%s package required for this test." % package)


### PR DESCRIPTION
The btrfs-tools package has been deprecated and
replaced by btrfs-progs