### PR TITLE
Update gcc package name

### DIFF
--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -93,15 +93,16 @@ class FioTest(Test):
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
 
-        pkg_list = ['cmake', 'gcc-c++']
-        if distro_name in ['Ubuntu', 'debian']:
-            pkg_list.append('libaio-dev')
+        pkg_list = ['cmake']
+        if distro_name in ['Ubuntu', 'debian', 'uos']:
+            pkg_list.extend(['libaio-dev', 'g++'])
             if fstype == 'btrfs':
                 pkg_list.append('btrfs-progs')
         elif distro_name is 'SuSE':
-            pkg_list.append('libaio1')
+            pkg_list.extend(['libaio1', 'gcc-c++'])
         else:
-            pkg_list.append('libaio')
+            pkg_list.extend(['libaio', 'gcc-c++'])
+
         if self.disk_type == 'nvdimm':
             pkg_list.extend(['autoconf', 'pkg-config'])
             if distro.detect().name == 'SuSE':


### PR DESCRIPTION
Fix gcc package name in ubuntu, rhel distros respectively

==BEFORE==

==UBUNTU==
avocado run --max-parallel-tasks 1 fiotest.py -m fiotest.py.data/fio.yaml 
JOB ID     : e5608dddca61bb1a112fb273b46faf7158eccd87
JOB LOG    : /root/Avocadotests_tmp/results/job-2025-03-18T12.58-e5608dd/job.log
 (1/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-raid-8e42: STARTED
 (1/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-raid-8e42: CANCEL: Package gcc-c++ is missing and could not be installed (0.72 s)
 (2/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-no_raid-bc4a: STARTED
 (2/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-no_raid-bc4a: CANCEL: Package gcc-c++ is missing and could not be installed (0.75 s)
 (3/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-raid-2f9f: STARTED
 (3/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-raid-2f9f: CANCEL: Package gcc-c++ is missing and could not be installed (0.72 s)
 (4/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-no_raid-45f9: STARTED
 (4/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-no_raid-45f9: CANCEL: Package gcc-c++ is missing and could not be installed (0.69 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 4
JOB HTML   : /root/Avocadotests_tmp/results/job-2025-03-18T12.58-e5608dd/results.html
JOB TIME   : 14.29 s

==AFTER==

==UBUNTU==
avocado run --max-parallel-tasks 1 fiotest.py -m fiotest.py.data/fio.yaml 
JOB ID     : db19e65c4daef928d340354e71e5e45851d57c3e
JOB LOG    : /root/Avocadotests_tmp/results/job-2025-03-18T12.51-db19e65/job.log
 (1/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-raid-8e42: STARTED
 (1/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-raid-8e42: WARN: Test passed but there were warnings during execution. Check the log for details. (81.22 s)
 (2/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-no_raid-bc4a: STARTED
 (2/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-no_raid-bc4a: WARN: Test passed but there were warnings during execution. Check the log for details. (71.64 s)
 (3/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-raid-2f9f: STARTED
 (3/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-raid-2f9f: WARN: Test passed but there were warnings during execution. Check the log for details. (66.63 s)
 (4/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-no_raid-45f9: STARTED
 (4/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-no_raid-45f9: WARN: Test passed but there were warnings during execution. Check the log for details. (64.11 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 4 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/Avocadotests_tmp/results/job-2025-03-18T12.51-db19e65/results.html
JOB TIME   : 298.13 s


==RHEL==
avocado run --max-parallel-tasks 1 fiotest.py -m fiotest.py.data/fio.yaml 
JOB ID     : 77a77727c6f5fc327886fc0536508e77e9fe169e
JOB LOG    : /root/Avocadotests_tmp/results/job-2025-03-18T18.20-77a7772/job.log
 (1/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-raid-3280: STARTED
 (1/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-raid-3280: WARN: Test passed but there were warnings during execution. Check the log for details. (46.26 s)
 (2/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-no_raid-de86: STARTED
 (2/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-lv-raid-no_raid-de86: WARN: Test passed but there were warnings during execution. Check the log for details. (41.24 s)
 (3/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-raid-28f5: STARTED
 (3/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-raid-28f5: WARN: Test passed but there were warnings during execution. Check the log for details. (31.13 s)
 (4/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-no_raid-e513: STARTED
 (4/4) fiotest.py:FioTest.test;run-fs-no_fs-lv-no_lv-raid-no_raid-e513: WARN: Test passed but there were warnings during execution. Check the log for details. (30.03 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 4 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/Avocadotests_tmp/results/job-2025-03-18T18.20-77a7772/results.html
JOB TIME   : 162.60 s