### PR TITLE
Refactor distro and its version detection

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -79,19 +79,20 @@ class Bonnie(Test):
         self.number_to_stat = self.params.get('number-to-stat', default=2048)
         self.data_size = self.params.get('data_size_to_pass', default=0)
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         # Install the package from web
         deps = ['gcc', 'make']
-        if distro.detect().name == 'Ubuntu':
+        if detected_distro.name == 'Ubuntu':
             deps.extend(['g++'])
         else:
             deps.extend(['gcc-c++'])
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs not supported with RHEL 7.4 onwards")
-            elif distro.detect().name == 'Ubuntu':
+            elif detected_distro.name == 'Ubuntu':
                 deps.extend(['btrfs-progs'])
         if raid_needed:
             deps.append('mdadm')

--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -87,7 +87,10 @@ class Bonnie(Test):
         else:
             deps.extend(['gcc-c++'])
         if self.fstype == 'btrfs':
-            ver = int(detected_distro.version)
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -87,7 +87,10 @@ class Dbench(Test):
                 self.error('%s is needed for the test to be run' % pkg)
 
         if fstype == 'btrfs':
-            ver = int(detected_distro.version.split('.')[0])
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -78,6 +78,7 @@ class Dbench(Test):
         if not os.path.exists(self.mountpoint):
             os.mkdir(self.mountpoint)
         sm = SoftwareManager()
+        detected_distro = distro.detect()
         pkgs = ["gcc", "patch"]
         if raid_needed:
             pkgs.append('mdadm')
@@ -86,13 +87,13 @@ class Dbench(Test):
                 self.error('%s is needed for the test to be run' % pkg)
 
         if fstype == 'btrfs':
-            ver = int(distro.detect().version.split('.')[0])
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version.split('.')[0])
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
-            if distro.detect().name == 'Ubuntu':
+            if detected_distro.name == 'Ubuntu':
                 if not sm.check_installed("btrfs-progs") and not \
                         sm.install("btrfs-progs"):
                     self.cancel('btrfs-progs is needed for the test to be run')

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -51,6 +51,7 @@ class DiskInfo(Test):
         :param dir: path of the directory to mount the disk device
         """
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         pkg = ""
         device = self.params.get('disk', default=None)
         self.disk = disk.get_absolute_disk_path(device)
@@ -68,7 +69,7 @@ class DiskInfo(Test):
             self.cancel("Given disk is os boot disk,"
                         "it will be harmful to run this test")
         pkg_list = ["lshw"]
-        self.distro = distro.detect().name
+        self.distro = detected_distro.name
         if self.distro == 'Ubuntu':
             pkg_list.append("hwinfo")
         if self.fstype == 'ext4':
@@ -76,9 +77,9 @@ class DiskInfo(Test):
         if self.fstype == 'xfs':
             pkg_list.append('xfsprogs')
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -77,7 +77,10 @@ class DiskInfo(Test):
         if self.fstype == 'xfs':
             pkg_list.append('xfsprogs')
         if self.fstype == 'btrfs':
-            ver = int(detected_distro.version)
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -81,7 +81,10 @@ class Disktest(Test):
         self.raid_name = '/dev/md/sraid'
 
         if self.fstype == 'btrfs':
-            ver = int(detected_distro.version)
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -64,6 +64,7 @@ class Disktest(Test):
         """
         self.err_mesg = []
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         if not smm.check_installed("gcc") and not smm.install("gcc"):
             self.cancel('Gcc is needed for the test to be run')
         # Log of all the disktest processes
@@ -80,9 +81,9 @@ class Disktest(Test):
         self.raid_name = '/dev/md/sraid'
 
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -72,7 +72,7 @@ class FioTest(Test):
         self.devdax_file = None
         self.disk_type = self.params.get('disk_type', default='')
         device = self.params.get('disk', default=None)
-        distro_name = distro.detect().name
+        detected_distro = distro.detect()
         if device and not self.disk_type:
             self.disk = disk.get_absolute_disk_path(device)
             if self.disk not in disk.get_all_disk_paths():
@@ -83,29 +83,29 @@ class FioTest(Test):
             self.cancel("Please Provide valid disk")
 
         if fstype == 'btrfs':
-            if distro_name == 'Ubuntu':
-                ver = int(distro.detect().version.split('.')[0])
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
             else:
-                ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro_name == 'rhel':
+                ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
 
         pkg_list = ['cmake']
-        if distro_name in ['Ubuntu', 'debian', 'uos']:
+        if detected_distro.name in ['Ubuntu', 'debian', 'uos']:
             pkg_list.extend(['libaio-dev', 'g++'])
             if fstype == 'btrfs':
                 pkg_list.append('btrfs-progs')
-        elif distro_name is 'SuSE':
+        elif detected_distro.name is 'SuSE':
             pkg_list.extend(['libaio1', 'gcc-c++'])
         else:
             pkg_list.extend(['libaio', 'gcc-c++'])
 
         if self.disk_type == 'nvdimm':
             pkg_list.extend(['autoconf', 'pkg-config'])
-            if distro.detect().name == 'SuSE':
+            if detected_distro.name == 'SuSE':
                 pkg_list.extend(['ndctl', 'libnuma-devel',
                                  'libndctl-devel'])
             else:

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -79,7 +79,10 @@ class FSMark(Test):
         smm = SoftwareManager()
         detected_distro = distro.detect()
         if self.fstype == 'btrfs':
-            ver = int(detected_distro.version.split('.')[0])
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -77,15 +77,15 @@ class FSMark(Test):
         self.vgname = 'avocado_vg'
         self.lvname = 'avocado_lv'
         smm = SoftwareManager()
-
+        detected_distro = distro.detect()
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version.split('.')[0])
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version.split('.')[0])
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
-            if distro.detect().name == 'Ubuntu':
+            if detected_distro.name == 'Ubuntu':
                 if not smm.check_installed("btrfs-progs") and not \
                         smm.install("btrfs-progs"):
                     self.cancel('btrfs-progs is needed for the test to be run')

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -428,6 +428,7 @@ class IOZone(Test):
 
         self.base_dir = os.path.abspath(self.basedir)
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         packages = ['gcc', 'make', 'patch']
         if raid_needed:
             packages.append('mdadm')
@@ -436,13 +437,13 @@ class IOZone(Test):
                 self.cancel("%s is needed for the test to be run" % package)
 
         if fstype == 'btrfs':
-            ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
-                if distro.detect().name == 'Ubuntu':
+                if detected_distro.name == 'Ubuntu':
                     if not smm.check_installed("btrfs-progs") and not \
                             smm.install("btrfs-progs"):
                         self.cancel(
@@ -459,13 +460,11 @@ class IOZone(Test):
         patch = self.get_data(patch)
         process.run('patch -p3 < %s' % patch, shell=True)
 
-        d_distro = distro.detect()
-        arch = d_distro.arch
-        if arch == 'ppc':
+        if detected_distro.arch == 'ppc':
             build.make(make_dir, extra_args='linux-powerpc')
-        elif arch == 'ppc64' or arch == 'ppc64le':
+        elif detected_distro.arch == 'ppc64' or detected_distro.arch == 'ppc64le':
             build.make(make_dir, extra_args='linux-powerpc64')
-        elif arch == 'x86_64':
+        elif detected_distro.arch == 'x86_64':
             build.make(make_dir, extra_args='linux-AMD64')
         else:
             build.make(make_dir, extra_args='linux')

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -437,7 +437,10 @@ class IOZone(Test):
                 self.cancel("%s is needed for the test to be run" % package)
 
         if fstype == 'btrfs':
-            ver = int(detected_distro.version)
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -70,6 +70,7 @@ class LtpFs(Test):
         self.fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         packages = ['gcc', 'make', 'automake', 'autoconf']
         if raid_needed:
             packages.append('mdadm')
@@ -78,9 +79,9 @@ class LtpFs(Test):
                 self.cancel("%s is needed for the test to be run" % package)
 
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -79,7 +79,10 @@ class LtpFs(Test):
                 self.cancel("%s is needed for the test to be run" % package)
 
         if self.fstype == 'btrfs':
-            ver = int(detected_distro.version)
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -59,7 +59,6 @@ class LtpFs(Test):
         self.fsstress_count = self.params.get('fsstress_loop', default='1')
         self.n_val = self.params.get('n_val', default='100')
         self.p_val = self.params.get('p_val', default='100')
-        distro_name = distro.detect().name
 
         if device is not None:
             self.disk = disk.get_absolute_disk_path(device)
@@ -72,6 +71,7 @@ class LtpFs(Test):
             self.dir = self.workdir
 
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         packages = ['gcc', 'make', 'automake', 'autoconf']
         if raid_needed:
             packages.append('mdadm')
@@ -80,16 +80,16 @@ class LtpFs(Test):
                 self.cancel("%s is needed for the test to be run" % package)
 
         if self.fstype == 'btrfs':
-            if distro_name == 'Ubuntu':
-                ver = int(distro.detect().version.split('.')[0])
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
             else:
-                ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro_name == 'rhel':
+                ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with \
                                 RHEL 7.4 onwards")
-            if distro_name == 'Ubuntu':
+            if detected_distro.name == 'Ubuntu':
                 if not smm.check_installed("btrfs-progs") and not \
                         smm.install("btrfs-progs"):
                     self.cancel('btrfs-progs is needed for the test to be run')

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -52,6 +52,7 @@ class Lvsetup(Test):
         pkgs = []
         self.disks = []
         smm = SoftwareManager()
+        detected_distro = distro.detect()
         devices = self.params.get('lv_disks', default=None).split()
         if devices:
             for dev in devices:
@@ -60,23 +61,22 @@ class Lvsetup(Test):
         self.lv_name = self.params.get('lv_name', default='avocado_lv')
         self.fs_name = self.params.get('fs', default='ext4').lower()
         self.lv_size = self.params.get('lv_size', default='0')
-        distro_name = distro.detect().name
         if self.fs_name == 'xfs':
             pkgs = ['xfsprogs']
         if self.fs_name == 'btrfs':
-            if distro_name == 'Ubuntu':
-                ver = int(distro.detect().version.split('.')[0])
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
             else:
-                ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro_name == 'rhel':
+                ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
-            if distro_name == 'SuSE':
+            if detected_distro.name == 'SuSE':
                 pkgs = ['btrfsprogs']
             else:
                 pkgs = ['btrfs-progs']
-        if distro_name in ['Ubuntu', 'debian']:
+        if detected_distro.name in ['Ubuntu', 'debian']:
             pkgs.extend(['lvm2'])
 
         for pkg in pkgs:

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -70,10 +70,11 @@ class ParallelDd(Test):
         self.dd_roptions = self.params.get('dd_roptions', default='')
         self.fs_dd_woptions = self.params.get('fs_dd_woptions', default='')
         self.fs_dd_roptions = self.params.get('fs_dd_roptions', default='')
+        detected_distro = distro.detect()
         if self.fstype == 'btrfs':
-            ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro.detect().name == 'rhel':
+            ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
 

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -72,7 +72,10 @@ class ParallelDd(Test):
         self.fs_dd_roptions = self.params.get('fs_dd_roptions', default='')
         detected_distro = distro.detect()
         if self.fstype == 'btrfs':
-            ver = int(detected_distro.version)
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
+            else:
+                ver = int(detected_distro.version)
             rel = int(detected_distro.release)
             if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -60,8 +60,7 @@ class Tiobench(Test):
         self.raid_create = False
         device = self.params.get('disk', default=None)
         self.dir = self.params.get('dir', default=None)
-        distro_name = distro.detect().name
-
+        detected_distro = distro.detect()
         if device is not None:
             self.disk = disk.get_absolute_disk_path(device)
             if self.disk not in disk.get_all_disk_paths():
@@ -79,15 +78,15 @@ class Tiobench(Test):
         smm = SoftwareManager()
         packages = ['gcc', 'mdadm']
         if self.fstype == 'btrfs':
-            if distro_name == 'Ubuntu':
-                ver = int(distro.detect().version.split('.')[0])
+            if detected_distro.name == 'Ubuntu':
+                ver = int(detected_distro.version.split('.')[0])
             else:
-                ver = int(distro.detect().version)
-            rel = int(distro.detect().release)
-            if distro_name == 'rhel':
+                ver = int(detected_distro.version)
+            rel = int(detected_distro.release)
+            if detected_distro.name == 'rhel':
                 if (ver == 7 and rel >= 4) or ver > 7:
                     self.cancel("btrfs is not supported with RHEL 7.4 onwards")
-            if distro_name == 'Ubuntu':
+            if detected_distro.name == 'Ubuntu':
                 packages.extend(['btrfs-progs'])
         for package in packages:
             if not smm.check_installed(package) and not smm.install(package):

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -66,6 +66,10 @@ class kselftest(Test):
         self.build_option = self.params.get('build_option', default='-bp')
         self.run_type = self.params.get('type', default='upstream')
         self.detected_distro = distro.detect()
+        if self.detected_distro.name == 'Ubuntu':
+            self.distro_ver = int(self.detected_distro.version.split('.')[0])
+        else:
+            self.distro_ver = int(self.detected_distro.version)
         deps = ['gcc', 'make', 'automake', 'autoconf', 'rsync']
         if (self.comp == "powerpc"):
             if 'ppc' not in self.detected_distro.arch:
@@ -81,7 +85,7 @@ class kselftest(Test):
                          'fuse', 'fuse-devel', 'glibc-devel-static',
                          'traceroute', 'iproute2', 'socat', 'clang7',
                          'libnuma-devel'])
-            if self.detected_distro.version >= 15:
+            if self.distro_ver >= 15:
                 deps.extend(['libhugetlbfs-devel'])
             else:
                 deps.extend(['libhugetlbfs-libhugetlb-devel'])
@@ -91,8 +95,7 @@ class kselftest(Test):
                          'libcap-ng-devel', 'popt-devel',
                          'libhugetlbfs-devel', 'clang', 'traceroute',
                          'iproute-tc', 'socat', 'numactl-devel'])
-            dis_ver = int(self.detected_distro.version)
-            if self.detected_distro.name == 'rhel' and dis_ver >= 9:
+            if self.detected_distro.name == 'rhel' and self.distro_ver >= 9:
                 packages_remove = ['libhugetlbfs-devel']
                 deps = list(set(deps)-set(packages_remove))
                 deps.extend(['fuse3-devel'])
@@ -205,7 +208,7 @@ class kselftest(Test):
                 self.find_match(r'not ok (.*) selftests:(.*)', line)
             elif self.run_type == 'distro':
                 if self.detected_distro.name == 'SuSE' and\
-                        self.detected_distro.version == 12:
+                        self.distro_ver == 12:
                     self.find_match(r'selftests:(.*)\[FAIL\]', line)
                 else:
                     self.find_match(r'not ok (.*) selftests:(.*)', line)

--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -65,34 +65,34 @@ class kselftest(Test):
 
         self.build_option = self.params.get('build_option', default='-bp')
         self.run_type = self.params.get('type', default='upstream')
-        detected_distro = distro.detect()
+        self.detected_distro = distro.detect()
         deps = ['gcc', 'make', 'automake', 'autoconf', 'rsync']
         if (self.comp == "powerpc"):
-            if 'ppc' not in detected_distro.arch:
+            if 'ppc' not in self.detected_distro.arch:
                 self.cancel("Testing on a non powerpc platform")
-        if detected_distro.name in ['Ubuntu', 'debian']:
+        if self.detected_distro.name in ['Ubuntu', 'debian']:
             deps.extend(['libpopt0', 'libc6', 'libc6-dev', 'libcap-dev',
                          'libpopt-dev', 'libcap-ng0', 'libcap-ng-dev',
                          'libnuma-dev', 'libfuse-dev', 'elfutils', 'libelf-dev',
                          'libhugetlbfs-dev'])
-        elif 'SuSE' in detected_distro.name:
+        elif 'SuSE' in self.detected_distro.name:
             deps.extend(['glibc', 'glibc-devel', 'popt-devel', 'sudo',
                          'libcap2', 'libcap-devel', 'libcap-ng-devel',
                          'fuse', 'fuse-devel', 'glibc-devel-static',
                          'traceroute', 'iproute2', 'socat', 'clang7',
                          'libnuma-devel'])
-            if detected_distro.version >= 15:
+            if self.detected_distro.version >= 15:
                 deps.extend(['libhugetlbfs-devel'])
             else:
                 deps.extend(['libhugetlbfs-libhugetlb-devel'])
-        elif detected_distro.name in ['centos', 'fedora', 'rhel']:
+        elif self.detected_distro.name in ['centos', 'fedora', 'rhel']:
             deps.extend(['popt', 'glibc', 'glibc-devel', 'glibc-static',
                          'libcap-ng', 'libcap', 'libcap-devel',
                          'libcap-ng-devel', 'popt-devel',
                          'libhugetlbfs-devel', 'clang', 'traceroute',
                          'iproute-tc', 'socat', 'numactl-devel'])
-            dis_ver = int(detected_distro.version)
-            if detected_distro.name == 'rhel' and dis_ver >= 9:
+            dis_ver = int(self.detected_distro.version)
+            if self.detected_distro.name == 'rhel' and dis_ver >= 9:
                 packages_remove = ['libhugetlbfs-devel']
                 deps = list(set(deps)-set(packages_remove))
                 deps.extend(['fuse3-devel'])
@@ -138,9 +138,9 @@ class kselftest(Test):
             if self.subtest == 'pmu/event_code_tests':
                 self.cancel("selftest not supported on distro")
             # Make sure kernel source repo is configured
-            if detected_distro.name in ['centos', 'fedora', 'rhel']:
+            if self.detected_distro.name in ['centos', 'fedora', 'rhel']:
                 src_name = 'kernel'
-                if detected_distro.name == 'rhel':
+                if self.detected_distro.name == 'rhel':
                     # Check for "el*a" where ALT always ends with 'a'
                     if platform.uname()[2].split(".")[-2].endswith('a'):
                         self.log.info('Using ALT as kernel source')
@@ -149,9 +149,9 @@ class kselftest(Test):
                     src_name, self.workdir, self.build_option)
                 self.buldir = os.path.join(
                     self.buldir, os.listdir(self.buldir)[0])
-            elif detected_distro.name in ['Ubuntu', 'debian']:
+            elif self.detected_distro.name in ['Ubuntu', 'debian']:
                 self.buldir = smg.get_source('linux', self.workdir)
-            elif 'SuSE' in detected_distro.name:
+            elif 'SuSE' in self.detected_distro.name:
                 if not smg.check_installed("kernel-source") and not\
                         smg.install("kernel-source"):
                     self.cancel(
@@ -204,8 +204,8 @@ class kselftest(Test):
             if self.run_type == 'upstream':
                 self.find_match(r'not ok (.*) selftests:(.*)', line)
             elif self.run_type == 'distro':
-                if distro.detect().name == 'SuSE' and\
-                        distro.detect().version == 12:
+                if self.detected_distro.name == 'SuSE' and\
+                        self.detected_distro.version == 12:
                     self.find_match(r'selftests:(.*)\[FAIL\]', line)
                 else:
                     self.find_match(r'not ok (.*) selftests:(.*)', line)


### PR DESCRIPTION
Refactor distro detection to avoid redundant calls
Store distro detection result in detected_distro
instead of calling distro.detect() multiple times

Fix distro version detection
Update distro version detection as per update in
avocado utils change
https://github.com/avocado-framework/avocado/commit/55d1cd3a143d3a9a5667458da1e3014a7bc46939

Signed-off-by: Ayush Jain [Ayush.jain3@amd.com](mailto:Ayush.jain3@amd.com)