### PR TITLE
Add dmesg_grep key to iommu_tests.yaml

### DIFF
--- a/io/iommu/iommu_tests.py.data/README.txt
+++ b/io/iommu/iommu_tests.py.data/README.txt
@@ -17,3 +17,4 @@ Inputs Needed (in multiplexer file):
 ------------------------------------
 pci_devices -      can be fetched from <lspci -nnD>  output. Use space for multiple devices "001b:62:00.0 001b:62:00.1"
 count -      This is an integer value given for number of time tests to run.
+dmesg_grep -	can be used to filter the dmesg log by passing patterns separated by a pipe. For example: dmesg_grep: "IOMMU|NVME|..."

--- a/io/iommu/iommu_tests.py.data/iommu_tests.yaml
+++ b/io/iommu/iommu_tests.py.data/iommu_tests.yaml
@@ -1,2 +1,3 @@
 pci_devices: ""
 count: 10
+dmesg_grep: "IOMMU"


### PR DESCRIPTION
Add the dmesg_grep key to iommu_tests.yaml to filter logs specific to IOMMU. The test will fail if any warnings or error messages related to IOMMU are found.

Test Run logs:

==Before==
Without 'dmesg_grep' key in the YAML file:

   JOB ID     : 861808368cf52c4c4e7bd143f4960fd1bc28423f
    JOB LOG    : /home/amd/iommu_test/tests/results/job-2025-03-25T08.25-8618083/job.log
     (1/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind;run-81a2: STARTED
     (1/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind;run-81a2: FAIL: Running test logged warn,err,alert,crit logs in dmesg. Please refer whiteboard of the test result (5.54 s)
     (2/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind;run-81a2: STARTED
     (2/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind;run-81a2: FAIL: Running test logged warn,err,alert,crit logs in dmesg. Please refer whiteboard of the test result (64.43 s)
     (3/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind;run-81a2: STARTED
     (3/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind;run-81a2: FAIL: Running test logged warn,err,alert,crit logs in dmesg. Please refer whiteboard of the test result (323.21 s)
     (4/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan;run-81a2: STARTED
     (4/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan;run-81a2: FAIL: Running test logged warn,err,alert,crit logs in dmesg. Please refer whiteboard of the test result (5.64 s)
     (5/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan;run-81a2: STARTED
     (5/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan;run-81a2: FAIL: Running test logged warn,err,alert,crit logs in dmesg. Please refer whiteboard of the test result (65.16 s)
     (6/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_reset_rescan;run-81a2: STARTED
     (6/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_reset_rescan;run-81a2: FAIL: Running test logged warn,err,alert,crit logs in dmesg. Please refer whiteboard of the test result (0.73 s)
    RESULTS    : PASS 0 | ERROR 0 | FAIL 6 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

==After==
With 'dmesg_grep: "IOMMU"' key-value pair in the YAML file:

   JOB ID     : 7b765347521752128d21b8e54e22e57b2dc12afe
    JOB LOG    : /home/amd/iommu_test/tests/results/job-2025-03-25T09.17-7b76534/job.log
     (1/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind;run-6f78: STARTED
     (1/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind;run-6f78: PASS (5.53 s)
     (2/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind;run-6f78: STARTED
     (2/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind;run-6f78: PASS (64.41 s)
     (3/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind;run-6f78: STARTED
     (3/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind;run-6f78: PASS (323.59 s)
     (4/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan;run-6f78: STARTED
     (4/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan;run-6f78: PASS (5.61 s)
     (5/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan;run-6f78: STARTED
     (5/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan;run-6f78: PASS (65.13 s)
     (6/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_reset_rescan;run-6f78: STARTED
     (6/6) avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_reset_rescan;run-6f78: PASS (0.68 s)
    RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0