### PR TITLE
Adding "lshw" to package list that needs to be installed before test …

### DIFF
--- a/io/common/distro_tools.py
+++ b/io/common/distro_tools.py
@@ -65,7 +65,7 @@ class DisrtoTool(Test):
                                               device_path_name)
 
         smm = SoftwareManager()
-        for pkg in ['pciutils', 'net-tools']:
+        for pkg in ['pciutils', 'net-tools', 'lshw']:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel("%s package is need to test" % pkg)
 


### PR DESCRIPTION
…runs

In few latest distros, lshw package is not getting installed by default during installation and hence the test cases are failing. So added the package name to the list that needs to be installed before test start and test are running fine now.