### PR TITLE
remove restore_slave_cfg_file for hbond tests

### DIFF
--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -270,5 +270,3 @@ class Ethtool(Test):
         except Exception:
             self.networkinterface.remove_cfg_file()
             self.log.info("backup file not availbale, could not restore file.")
-        if self.hbond:
-            self.networkinterface.restore_slave_cfg_file()

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -145,6 +145,4 @@ class ReceiveMulticastTest(Test):
             except Exception:
                 self.networkinterface.remove_cfg_file()
                 self.log.info("backup file not available, could not restore file.")
-            if self.hbond:
-                self.networkinterface.restore_slave_cfg_file()
             self.session.quit()

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -345,8 +345,6 @@ class NetworkTest(Test):
                 self.networkinterface.remove_cfg_file()
                 self.log.info(
                     "backup file not available, could not restore file.")
-            if self.hbond:
-                self.networkinterface.restore_slave_cfg_file()
         self.remotehost.remote_session.quit()
         self.remotehost_public.remote_session.quit()
         if 'scp' or 'ssh' in str(self.name.name):

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -184,7 +184,5 @@ class TcpdumpTest(Test):
                 self.networkinterface.remove_cfg_file()
                 self.log.info(
                     "backup file not available, could not restore file.")
-            if self.hbond:
-                self.networkinterface.restore_slave_cfg_file()
             self.remotehost.remote_session.quit()
             self.remotehost_public.remote_session.quit()


### PR DESCRIPTION
restore_slave_cfg_file is failing incase of hbond
as slave_cfg_file is not being created and saved for hbond tests. Only the bond interface file is saved during the setUp