### PR TITLE
ima-modsig-tests.py: Add new testcases

### DIFF
--- a/security/ima-modsig-tests.py
+++ b/security/ima-modsig-tests.py
@@ -14,7 +14,7 @@
 # Author: Nageswara R Sastry <rnsastry@linux.ibm.com>
 
 from avocado import Test
-from avocado.utils import linux_modules, process, distro
+from avocado.utils import linux_modules, process, distro, genio
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -43,6 +43,8 @@ class IMAmodsig(Test):
         self._check_kernel_config('CONFIG_MODULE_SIG')
         if self.no_config:
             self.cancel("Config options not set are: %s" % self.no_config)
+        self.ima_cmd = "keyctl list %:.ima"
+        self.builtin_cmd = "keyctl list %:.builtin_trusted_keys"
 
     def _run_cmd(self, cmd):
         key_list = []
@@ -53,13 +55,62 @@ class IMAmodsig(Test):
                 key_list.append(line.split(':')[3])
         return key_list
 
-    def test(self):
-        output1_list = self._run_cmd("keyctl list %:.ima")
-        output2_list = self._run_cmd("keyctl list %:.builtin_trusted_keys")
+    def test_ima_signing_key(self):
+        """
+        Check if ima signing key is available in the keyring
+        """
+        output_list = self._run_cmd(self.ima_cmd)
+        if not output_list:
+            self.fail("No keys found in 'ima' keyring.")
+        self.log.info("Keys found in 'ima' keyring.")
+
+    def test_builtin_trusted_keys(self):
+        """
+        Check if builtin trusted keys are available in the keyring
+        """
+        output_list = self._run_cmd(self.builtin_cmd)
+        if not output_list:
+            self.fail("No keys found in 'builtin_trusted_keys' keyring.")
+        self.log.info("Keys found in 'builtin_trusted_keys' keyring.")
+
+    def test_ima_builtin_trusted_keys(self):
+        """
+        Check if ima signing key is available in builtin trusted keys
+        """
+        output1_list = self._run_cmd(self.ima_cmd)
+        output2_list = self._run_cmd(self.builtin_cmd)
         found = 0
         for key in output1_list:
             if key in output2_list:
                 found += 1
         if not found:
-            self.fail("Signing key not available in"
-                      "'ima' and 'builtin_trusted_keys'.")
+            self.fail("'ima' Signing key not available in"
+                      "'builtin_trusted_keys'.")
+        self.log.info("'ima' Signing key available in"
+                      "'builtin_trusted_keys' keyring.")
+
+    def test_ima_policy_with_secure_boot_enabled(self):
+        """
+        Check if IMA policy is loaded with secure boot enabled
+        """
+        # Checking the Guest Secure Boot enabled or not.
+        cmd = "lsprop  /proc/device-tree/ibm,secure-boot"
+        output = process.system_output(cmd, ignore_status=True).decode()
+        if '00000002' not in output:
+            self.cancel("Secure boot is not enabled.")
+        output = genio.read_file("/sys/kernel/security/ima/policy")
+        if not output:
+            self.fail("IMA policy not loaded with secure boot enabled.")
+        self.log.info("IMA policy loaded with secure boot enabled.")
+        if 'appraise' not in output or 'modsig' not in output:
+            self.fail("IMA policy not loaded 'appraise' or 'modsig' with secure boot enabled.")
+        self.log.info("IMA policy loaded 'appraise' or 'modsig' with secure boot enabled.")
+
+    def test_ima_keyring_integrity(self):
+        """
+        Check if IMA keyring integrity is compromised
+        """
+        output = process.system_output(self.ima_cmd, ignore_status=True, shell=True).decode("utf-8")
+        if "tampered" in output:
+            self.fail("IMA keyring integrity is compromised.")
+        self.log.info("IMA keyring integrity is not compromised.")


### PR DESCRIPTION
Modify testcase:
test_ima_keyring_integrity

Add new testcases:
test_ima_signing_key
test_builtin_trusted_keys
test_ima_policy_with_secure_boot_enabled
test_ima_keyring_integrity