### PR TITLE
pvr.py: Remove un-necessary test

### DIFF
--- a/cpu/pvr.py
+++ b/cpu/pvr.py
@@ -20,7 +20,6 @@ import re
 
 import configparser
 from avocado import Test
-from avocado.utils import process
 from avocado.utils import genio
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import distro
@@ -97,10 +96,3 @@ class pvr(Test):
             self.log.info("PVR from /proc/cpuinfo for the system is correct")
         else:
             self.fail("PVR from /proc/cpuinfo for the system is not correct")
-        pvr_dtc = process.run("dtc -I fs /proc/device-tree -O dts |grep %s | "
-                              "head -1" % self.pvr_value, shell=True,
-                              ignore_status=True)
-        if not pvr_dtc.exit_status:
-            self.log.info("PVR from device tree for the system is correct")
-        else:
-            self.fail("PVR from device tree for the system is not correct")


### PR DESCRIPTION
pvr value is never part of device tree (verified with Power8/9/10/11). Removing the un-necessary test