### PR TITLE
Checking if the pci slot obtained is present or not

### DIFF
--- a/io/pci/pci_hotplug.py
+++ b/io/pci/pci_hotplug.py
@@ -88,6 +88,9 @@ class PCIHotPlugTest(Test):
             self.contr_name = nvme.get_controller_name(self.device[0])
             self.ns_list = nvme.get_current_ns_ids(self.contr_name)
 
+        if not os.path.isdir('/sys/bus/pci/slots/%s' % slot):
+            self.cancel("%s is not present in sysfs path" % slot)
+
     def test(self):
         """
         Removes and adds back a PCI adapter based on pci_adress.


### PR DESCRIPTION
Introducing the generic check to see if the slot directory is present to perform add and remove operation

Since for SRIOV VF Ethernet and ROCE ports there will be no slot directory available and hence pci hotplug cannot be done