### PR TITLE
xfstest.py.data: add upstream yaml files to test auto group

### DIFF
--- a/fs/xfstests.py.data/btrfs/4k_auto_upstream.yaml
+++ b/fs/xfstests.py.data/btrfs/4k_auto_upstream.yaml
@@ -1,0 +1,22 @@
+scratch_mnt: '/mnt/scratch'
+test_mnt: '/mnt/test'
+disk_mnt: '/mnt/loop-device'
+
+loop_type: !mux
+    type: 'loop'
+    loop_size: '5GiB'
+    # Option to provide disk for loop device creation,
+    # Uses '/' by default for file creation
+    disk: "null"
+
+fs_type: !mux
+    fs_btrfs_4k_auto:
+        fs: 'btrfs'
+        args: '-R xunit -L 10 -g auto'
+        mkfs_opt: '-f -s 4096'
+        mount_opt: ''
+
+run_type: !mux
+    upstream:
+        run_type: 'upstream'
+        btrfsprogs_url: 'https://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git'

--- a/fs/xfstests.py.data/btrfs/64k_auto_upstream.yaml
+++ b/fs/xfstests.py.data/btrfs/64k_auto_upstream.yaml
@@ -1,0 +1,22 @@
+scratch_mnt: '/mnt/scratch'
+test_mnt: '/mnt/test'
+disk_mnt: '/mnt/loop-device'
+
+loop_type: !mux
+    type: 'loop'
+    loop_size: '5GiB'
+    # Option to provide disk for loop device creation,
+    # Uses '/' by default for file creation
+    disk: "null"
+
+fs_type: !mux
+    fs_btrfs_64k_auto:
+        fs: 'btrfs'
+        args: '-R xunit -L 10 -g auto'
+        mkfs_opt: '-f -s 65536 -n 65536'
+        mount_opt: ''
+
+run_type: !mux
+    upstream:
+        run_type: 'upstream'
+        btrfsprogs_url: 'https://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git'

--- a/fs/xfstests.py.data/ext4/4k_auto_upstream.yaml
+++ b/fs/xfstests.py.data/ext4/4k_auto_upstream.yaml
@@ -1,0 +1,22 @@
+scratch_mnt: '/mnt/scratch'
+test_mnt: '/mnt/test'
+disk_mnt: '/mnt/loop-device'
+
+loop_type: !mux
+    type: 'loop'
+    loop_size: '12GiB'
+    # Option to provide disk for loop device creation,
+    # Uses '/' by default for file creation
+    disk: "null"
+
+fs_type: !mux
+    fs_ext4_4k_auto:
+        fs: 'ext4'
+        args: '-R xunit -L 10 -g auto'
+        mkfs_opt: '-b 4096'
+        mount_opt: '-o block_validity'
+
+run_type: !mux
+    upstream:
+        run_type: 'upstream'
+        e2fsprogs_url: 'https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git'

--- a/fs/xfstests.py.data/ext4/64k_auto_upstream.yaml
+++ b/fs/xfstests.py.data/ext4/64k_auto_upstream.yaml
@@ -1,0 +1,22 @@
+scratch_mnt: '/mnt/scratch'
+test_mnt: '/mnt/test'
+disk_mnt: '/mnt/loop-device'
+
+loop_type: !mux
+    type: 'loop'
+    loop_size: '12GiB'
+    # Option to provide disk for loop device creation,
+    # Uses '/' by default for file creation
+    disk: "null"
+
+fs_type: !mux
+    fs_ext4_64k_auto:
+        fs: 'ext4'
+        args: '-R xunit -e ext4/048 -L 10 -g auto'
+        mkfs_opt: '-b 65536'
+        mount_opt: '-o block_validity'
+
+run_type: !mux
+    upstream:
+        run_type: 'upstream'
+        e2fsprogs_url: 'https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git'

--- a/fs/xfstests.py.data/xfs/4k_auto_upstream.yaml
+++ b/fs/xfstests.py.data/xfs/4k_auto_upstream.yaml
@@ -1,0 +1,22 @@
+scratch_mnt: '/mnt/scratch'
+test_mnt: '/mnt/test'
+disk_mnt: '/mnt/loop-device'
+
+loop_type: !mux
+    type: 'loop'
+    loop_size: '12GiB'
+    # Option to provide disk for loop device creation,
+    # Uses '/' by default for file creation
+    disk: "null"
+
+fs_type: !mux
+    fs_xfs_4k_auto:
+        fs: 'xfs'
+        args: '-R xunit -L 10 -g auto'
+        mkfs_opt: '-f -b size=4096'
+        mount_opt: ''
+
+run_type: !mux
+    upstream:
+        run_type: 'upstream'
+        xfsprogs_url: 'https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git'

--- a/fs/xfstests.py.data/xfs/64k_auto_upstream.yaml
+++ b/fs/xfstests.py.data/xfs/64k_auto_upstream.yaml
@@ -1,0 +1,22 @@
+scratch_mnt: '/mnt/scratch'
+test_mnt: '/mnt/test'
+disk_mnt: '/mnt/loop-device'
+
+loop_type: !mux
+    type: 'loop'
+    loop_size: '12GiB'
+    # Option to provide disk for loop device creation,
+    # Uses '/' by default for file creation
+    disk: "null"
+
+fs_type: !mux
+    fs_xfs_64k_auto:
+        fs: 'xfs'
+        args: '-R xunit -L 10 -g auto'
+        mkfs_opt: '-f -b size=65536'
+        mount_opt: ''
+
+run_type: !mux
+    upstream:
+        run_type: 'upstream'
+        xfsprogs_url: 'https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git'


### PR DESCRIPTION
Added new upstream yaml files to run with auto group for 4k and 64k block size. 
Also modified btrfs 4k yaml file to take default supported node size.