### PR TITLE
start network traffic before EEH test

### DIFF
--- a/io/pci/EEH.py.data/EEH.yaml
+++ b/io/pci/EEH.py.data/EEH.yaml
@@ -2,3 +2,6 @@ max_freeze: 1
 function: 4
 err: 
 pci_device:
+host_ip:
+peer_ip:
+netmask:


### PR DESCRIPTION
The patch addresses
1) check if the test is on network device
2) if network device , then yaml is populated with the interface details 3) start network traffic (flood ping) which is important for EEH test to succeed 4) stop the network traffic after error injection