### PR TITLE
Added tests for 1GB alignment.

### DIFF
--- a/memory/ndctl.py
+++ b/memory/ndctl.py
@@ -645,7 +645,7 @@ class NdctlTest(Test):
                     self.fail('Numa mismatch between ndctl and sys interface')
 
     @avocado.fail_on(pmem.PMemException)
-    def test_label_read_write(self):
+    def test_label_read_write(self, align='2M'):
         region = self.get_default_region()
         if (self.plib.is_region_legacy(region)):
             self.cancel("Legacy config skipping the test")
@@ -659,7 +659,7 @@ class NdctlTest(Test):
             self.fail("Label zero-fill failed")
 
         self.plib.enable_region(name=region)
-        self.plib.create_namespace(region=region)
+        self.plib.create_namespace(region=region, align=align)
         self.log.info("Storing labels with a namespace")
         old_op = process.system_output(
             '%s check-labels %s' % (self.ndctl, nmem), shell=True)
@@ -747,7 +747,7 @@ class NdctlTest(Test):
                 self.plib.destroy_namespace(region=reg_name, force=True)
 
     @avocado.fail_on(pmem.PMemException)
-    def test_daxctl_memhotplug_unplug(self):
+    def test_daxctl_memhotplug_unplug(self, align='2M'):
         """
         Test devdax memory hotplug/unplug
         """
@@ -757,7 +757,7 @@ class NdctlTest(Test):
         region = self.get_default_region()
         self.plib.disable_namespace(region=region)
         self.plib.destroy_namespace(region=region)
-        self.plib.create_namespace(region=region, mode='devdax')
+        self.plib.create_namespace(region=region, mode='devdax', align=align)
         daxdev = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'chardev')
         old_mem = memory.meminfo.MemTotal.b
@@ -796,7 +796,7 @@ class NdctlTest(Test):
         return read_out[0]
 
     @avocado.fail_on(pmem.PMemException)
-    def test_write_infoblock_supported_align(self):
+    def test_write_infoblock_supported_align(self, align='2M'):
         """
         Test write_infoblock with align size
         """
@@ -805,7 +805,7 @@ class NdctlTest(Test):
         region = self.get_default_region()
         self.plib.disable_namespace(region=region)
         self.plib.destroy_namespace(region=region)
-        self.plib.create_namespace(region=region, mode='devdax')
+        self.plib.create_namespace(region=region, mode='devdax', align=align)
         ns_name = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
         self.plib.disable_namespace(namespace=ns_name)
@@ -814,7 +814,7 @@ class NdctlTest(Test):
         self.plib.enable_namespace(namespace=ns_name)
 
     @avocado.fail_on(pmem.PMemException)
-    def test_write_infoblock_unalign(self):
+    def test_write_infoblock_unalign(self, align='2M'):
         """
         Test write_infoblock with unsupported align size
         """
@@ -823,7 +823,7 @@ class NdctlTest(Test):
         region = self.get_default_region()
         self.plib.disable_namespace(region=region)
         self.plib.destroy_namespace(region=region)
-        self.plib.create_namespace(region=region, mode='devdax')
+        self.plib.create_namespace(region=region, mode='devdax', align=align)
         ns_name = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
         self.plib.disable_namespace(namespace=ns_name)
@@ -853,7 +853,7 @@ class NdctlTest(Test):
         self.plib.destroy_namespace(namespace=ns_name, force=True)
 
     @avocado.fail_on(pmem.PMemException)
-    def test_write_infoblock_align_default(self):
+    def test_write_infoblock_align_default(self, align='2M'):
         """
         Test write_infoblock with align size
         """
@@ -862,7 +862,7 @@ class NdctlTest(Test):
         region = self.get_default_region()
         self.plib.disable_namespace(region=region)
         self.plib.destroy_namespace(region=region)
-        self.plib.create_namespace(region=region, mode='devdax')
+        self.plib.create_namespace(region=region, mode='devdax', align=align)
         ns_name = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
         align = self.plib.run_ndctl_list_val(
@@ -873,7 +873,7 @@ class NdctlTest(Test):
             self.fail("Alignment is not same as default alignment")
 
     @avocado.fail_on(pmem.PMemException)
-    def test_write_infoblock_size(self):
+    def test_write_infoblock_size(self, align='2M'):
         """
         Test write_infoblock with align size
         """
@@ -882,7 +882,7 @@ class NdctlTest(Test):
         region = self.get_default_region()
         self.plib.disable_namespace(region=region)
         self.plib.destroy_namespace(region=region)
-        self.plib.create_namespace(region=region, mode='devdax')
+        self.plib.create_namespace(region=region, mode='devdax', align=align)
         ns_name = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
         size = self.plib.run_ndctl_list_val(
@@ -894,7 +894,7 @@ class NdctlTest(Test):
         self.plib.enable_namespace(namespace=ns_name)
 
     @avocado.fail_on(pmem.PMemException)
-    def test_write_infoblock_size_unaligned(self):
+    def test_write_infoblock_size_unaligned(self, align='2M'):
         """
         Test write_infoblock with align size
         """
@@ -903,7 +903,7 @@ class NdctlTest(Test):
         region = self.get_default_region()
         self.plib.disable_namespace(region=region)
         self.plib.destroy_namespace(region=region)
-        self.plib.create_namespace(region=region, mode='devdax')
+        self.plib.create_namespace(region=region, mode='devdax', align=align)
         ns_name = self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
         size = self.plib.run_ndctl_list_val(
@@ -949,12 +949,12 @@ class NdctlTest(Test):
             self.fail("FIO mmap workload on fsdax failed")
 
     @avocado.fail_on(pmem.PMemException)
-    def test_fsdax_write(self):
+    def test_fsdax_write(self, align='2M'):
         """
         Test filesystem DAX with a FIO workload
         """
         region = self.get_default_region()
-        self.plib.create_namespace(region=region, mode='fsdax')
+        self.plib.create_namespace(region=region, mode='fsdax', align=align)
         self.disk = '/dev/%s' % self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'blockdev')
         size = self.plib.run_ndctl_list_val(self.plib.run_ndctl_list(
@@ -1001,18 +1001,122 @@ class NdctlTest(Test):
             self.fail('Write with MAP_SYNC flag failed')
 
     @avocado.fail_on(pmem.PMemException)
-    def test_devdax_write(self):
+    def test_devdax_write(self, align='2M'):
         """
         Test device DAX with a daxio binary
         """
         region = self.get_default_region()
-        self.plib.create_namespace(region=region, mode='devdax')
+        self.plib.create_namespace(region=region, mode='devdax', align=align)
         daxdev = "/dev/%s" % self.plib.run_ndctl_list_val(
             self.plib.run_ndctl_list("-N -r %s" % region)[0], 'chardev')
         if process.system(
                 "%s -b no -i /dev/urandom -o %s"
                 % (self.get_data("daxio.static"), daxdev), ignore_status=True):
             self.fail("DAXIO write on devdax failed")
+
+    @avocado.fail_on(pmem.PMemException)
+    def test_namespace_1gb_alignment(self):
+        """
+        Test namespace with 1GB alignment
+        """
+        region = self.get_default_region()
+        self.plib.disable_namespace(region=region)
+        self.plib.destroy_namespace(region=region)
+        size = 2 * 1024 * 1024 * 1024  # 2GB
+        align = 1 * 1024 * 1024 * 1024  # 1GB
+        try:
+            self.plib.create_namespace(region=region, size=size, align=align)
+            self.check_namespace_align(region)
+            ns_json = self.plib.run_ndctl_list('-r %s -N' % region)[0]
+            created_align = self.plib.run_ndctl_list_val(ns_json, 'align')
+            if created_align != align:
+                self.fail("Expected alignment %s, Got %s" % (align, created_align))
+            else:
+                self.log.info("Namespace with 1GB alignment: %s", ns_json)
+        except pmem.PMemException:
+            self.fail("Namespace creation with 1GB alignment must have failed!")
+        ns_name = self.plib.run_ndctl_list_val(
+            self.plib.run_ndctl_list("-N -r %s" % region)[0], 'dev')
+        self.plib.disable_namespace(namespace=ns_name)
+        self.plib.destroy_namespace(region=region)
+
+
+    def test_namespace_1gb_alignment_enable_disable(self):
+        """
+        Test enabling and disabling a 1GB alignment namespace
+        """
+        region = self.get_default_region()
+        self.plib.disable_namespace(region=region)
+        self.plib.destroy_namespace(region=region)
+        size = 2 * 1024 * 1024 * 1024  # 2GB
+        align = 1 * 1024 * 1024 * 1024  # 1GB
+        try:
+            self.plib.create_namespace(region=region, size=size, align=align)
+            ns_name = self.plib.run_ndctl_list_val(self.plib.run_ndctl_list(
+                '-r %s -N' % region)[0], 'dev')
+            self.plib.disable_namespace(namespace=ns_name, region=region)
+            self.plib.enable_namespace(namespace=ns_name, region=region)
+            self.check_namespace_align(region)
+        except pmem.PMemException:
+            self.fail("Namespace creation or enable/disable with 1GB alignment must have failed!")
+
+    def test_modes_1gb_alignment_namespaces(self):
+        """
+        Test creating and destroying 1GB alignment namespaces in 2 modes
+        """
+        region = self.get_default_region()
+        self.plib.disable_namespace(region=region)
+        self.plib.destroy_namespace(region=region)
+        modes = ['fsdax', 'devdax']
+        size = 2 * 1024 * 1024 * 1024  # 2GB
+        align = 1 * 1024 * 1024 * 1024  # 1GB
+        for mode in modes:
+            try:
+                self.plib.create_namespace(region=region, size=size, align=align, mode=mode)
+                ns_name = self.plib.run_ndctl_list_val(self.plib.run_ndctl_list(
+                    '-r %s -N' % region)[0], 'dev')
+                self.log.info("Created namespace with mode %s and 1GB alignment: %s", mode, ns_name)
+            except pmem.PMemException:
+                self.fail("Namespace creation with mode %s and 1GB alignment must have failed!" % mode)
+        process.system('ndctl destroy-namespace all -f')
+
+    @avocado.fail_on(pmem.PMemException)
+    def test_daxctl_1gb_alignment_memhotplug_unplug(self):
+        """
+        Test devdax memory hotplug/unplug with 1GB alignment
+        """
+        self.test_daxctl_memhotplug_unplug(align='1073741824')
+
+    @avocado.fail_on(pmem.PMemException)
+    def test_fsdax_write_1gb_alignment(self):
+        """
+        Test filesystem DAX with a FIO workload
+        """
+        self.test_fsdax_write(align='1073741824')
+
+    @avocado.fail_on(pmem.PMemException)
+    def test_devdax_write_1gb_alignment(self):
+        """
+        Test device DAX with a daxio binary
+        """
+        self.test_devdax_write(align='1073741824')
+
+    @avocado.fail_on(pmem.PMemException)
+    def test_label_read_write_1gb_alignment(self):
+        """
+        Test devdax memory hotplug/unplug
+        """
+        self.test_label_read_write(align='1073741824')
+
+    @avocado.fail_on(pmem.PMemException)
+    def test_write_infoblock_1gb_alignment(self):
+        """
+        Test write_infoblock with different alignment
+        """
+        self.test_write_infoblock_supported_align(align='1073741824')
+        self.test_write_infoblock_unalign(align='1073741824')
+        self.test_write_infoblock_size(align='1073741824')
+        self.test_write_infoblock_size_unaligned(align='1073741824')
 
     @avocado.fail_on(pmem.PMemException)
     def tearDown(self):


### PR DESCRIPTION
Support for 1GB alignemnt is newly added feature, have added the testcases for same.


[root@ltcblue8vb-lp12 memory]# avocado run --max-parallel-tasks=1 ndctl.py:NdctlTest.*1gb_alignment* -m ndctl.py.data/ndctl.yaml
JOB ID     : c8e6b387dbd11f19b603e3b47fe9835b1a081326
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2025-06-16T09.33-c8e6b38/job.log
 (01/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (01/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (1.41 s)
 (02/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (02/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (1.44 s)
 (03/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (03/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (0.99 s)
 (04/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (04/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (0.89 s)
 (05/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (05/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (1.42 s)
 (06/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (06/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (0.89 s)
 (07/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (07/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (1.07 s)
 (08/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (08/32) ndctl.py:NdctlTest.test_namespace_1gb_alignment_enable_disable;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (0.99 s)
 (09/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (09/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (0.89 s)
 (10/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (10/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (0.90 s)
 (11/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (11/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (1.02 s)
 (12/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (12/32) ndctl.py:NdctlTest.test_modes_1gb_alignment_namespaces;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (1.10 s)
 (13/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (13/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (0.89 s)
 (14/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (14/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (0.88 s)
 (15/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (15/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (1.16 s)
 (16/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (16/32) ndctl.py:NdctlTest.test_daxctl_1gb_alignment_memhotplug_unplug;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (1.12 s)
 (17/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (17/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (0.89 s)
 (18/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (18/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (0.88 s)
 (19/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (19/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (52.97 s)
 (20/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (20/32) ndctl.py:NdctlTest.test_fsdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (52.97 s)
 (21/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (21/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (0.88 s)
 (22/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (22/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (0.86 s)
 (23/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (23/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (28.52 s)
 (24/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (24/32) ndctl.py:NdctlTest.test_devdax_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (28.56 s)
 (25/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (25/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (0.89 s)
 (26/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (26/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (0.89 s)
 (27/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (27/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (0.98 s)
 (28/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (28/32) ndctl.py:NdctlTest.test_label_read_write_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (0.96 s)
 (29/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: STARTED
 (29/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-upstream-66ae: CANCEL: iniparser is needed for the test to be run (0.89 s)
 (30/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: STARTED
 (30/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-sector-version-upstream-aef5: CANCEL: iniparser is needed for the test to be run (0.88 s)
 (31/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: STARTED
 (31/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-fsdax-version-distro-fa47: PASS (3.18 s)
 (32/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: STARTED
 (32/32) ndctl.py:NdctlTest.test_write_infoblock_1gb_alignment;run-fio_job-map-mode_types-sector-version-distro-243f: PASS (3.29 s)
RESULTS    : PASS 16 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 16
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2025-06-16T09.33-c8e6b38/results.html
JOB TIME   : 276.33 s
[root@ltcblue8vb-lp12 memory]# 
