### PR TITLE
fixing script in SLES as cmd variable not defined

### DIFF
--- a/cpu/dwh.py
+++ b/cpu/dwh.py
@@ -65,11 +65,13 @@ class Dwh(Test):
         for file_name in ['dwh.cpp', 'Makefile']:
             self.copyutil(file_name)
         if dist.name in ['fedora', 'rhel']:
-            cmd = 'patch -p0 < %s' % os.path.abspath(self.get_data('fofd.patch'))
+            cmd = 'patch -p0 < %s' % os.path.abspath(
+                self.get_data('fofd.patch'))
         elif dist.name in ['Ubuntu', 'debian']:
             cmd = "sed -i 's/g++.*/& -lrt/' Makefile"
         os.chdir(self.teststmpdir)
-        process.run(cmd, shell=True)
+        if dist.name != 'SuSE':
+            process.run(cmd, shell=True)
 
         build.make(self.teststmpdir)
 


### PR DESCRIPTION
LOG:

` (1/1) /home/OpTest/avocado-fvt-wrapper/tests/avocado-misc-tests/cpu/dwh.py:Dwh.test:  ERROR: cannot access local variable 'cmd' where it is not associated with a value (0.07 s)