### PR TITLE
perf_fuzzer: Fix false pass by properly checking command exit status

### DIFF
--- a/perf/perf_fuzzer.py
+++ b/perf/perf_fuzzer.py
@@ -35,8 +35,7 @@ class Perffuzzer(Test):
 
     @staticmethod
     def run_cmd_out(cmd):
-        return process.system_output(cmd, shell=True, ignore_status=True,
-                                     sudo=True)
+        return process.run(cmd, shell=True, ignore_status=True, sudo=True)
 
     def setUp(self):
         '''
@@ -72,8 +71,8 @@ class Perffuzzer(Test):
         Building the perf event test suite
         """
         self.sourcedir = os.path.join(self.workdir, 'perf_event_tests-master')
-        if build.make(self.sourcedir, extra_args="-s -S") > 0:
-            self.cancel("Building perf event test suite failed")
+        if build.make(self.sourcedir, extra_args="-s -S") != 0:
+            self.fail("Building perf event test suite failed")
 
     def execute_perf_fuzzer(self):
         os.chdir(self.sourcedir)
@@ -84,7 +83,9 @@ class Perffuzzer(Test):
         self.perf_fuzzer = os.path.join(self.sourcedir, "fuzzer/perf_fuzzer")
         if not os.path.exists(self.perf_fuzzer):
             self.cancel("fuzzer not found at %s" % self.perf_fuzzer)
-        self.output = self.run_cmd_out(self.perf_fuzzer).decode("utf-8")
+        output = self.run_cmd_out(self.perf_fuzzer)
+        if output.exit_status != 0:
+            self.fail(f'perf fuzzer failed with exit code {output.exit_status}')
 
     def test(self):
         '''


### PR DESCRIPTION
Fix perf fuzzer test false pass by checking the command exit status.
```
avocado run perf_fuzzer.py
Fetching asset from perf_fuzzer.py:Perffuzzer.test
JOB ID     : 7360348089cbc0d4a1b69c8152307392bf09e99c
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2025-06-18T13.12-7360348/job.log
 (1/1) perf_fuzzer.py:Perffuzzer.test: STARTED
 (1/1) perf_fuzzer.py:Perffuzzer.test: FAIL: perf fuzzer failed with exit code 1 (33.36 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2025-06-18T13.12-7360348/results.html
JOB TIME   : 59.73 s
```
[debug.log](https://github.com/user-attachments/files/20791273/debug.log)