### PR TITLE
Improve xfstest

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -159,8 +159,8 @@ class Xfstests(Test):
                  'libattr1-dev', 'libacl1-dev', 'libgdbm-dev',
                  'uuid-runtime', 'libaio-dev', 'fio', 'dbench',
                  'gettext', 'libinih-dev', 'liburcu-dev', 'libblkid-dev',
-                 'liblzo2-dev', 'zlib1g-dev', 'e2fslibs-dev', 'asciidoc',
-                 'xmlto', 'libzstd-dev', 'libudev-dev', 'bc', 'dump', 'acl',
+                 'liblzo2-dev', 'zlib1g-dev', 'e2fslibs-dev',
+                 'libzstd-dev', 'libudev-dev', 'bc', 'dump', 'acl',
                  'lvm2', 'sed'])
             if self.detected_distro.version in ['14']:
                 packages.extend(['libtool'])
@@ -178,8 +178,8 @@ class Xfstests(Test):
                              'xfsdump', 'psmisc', 'sed', 'libacl-devel',
                              'libattr-devel', 'libaio-devel', 'libuuid-devel',
                              'libblkid-devel', 'lzo-devel', 'zlib-devel',
-                             'e2fsprogs-devel', 'asciidoc', 'xmlto',
-                             'libzstd-devel', 'systemd-devel', 'meson',
+                             'e2fsprogs-devel', 'libzstd-devel',
+                             'systemd-devel', 'meson',
                              'xfsprogs-devel', 'gcc-c++'])
             if self.detected_distro.name == 'rhel' and (
                     self.detected_distro.version.startswith('9')):

--- a/fs/xfstests.py.data/btrfs/4k.yaml
+++ b/fs/xfstests.py.data/btrfs/4k.yaml
@@ -13,5 +13,5 @@ fs_type: !mux
     fs_btrfs_4k:
         fs: 'btrfs'
         args: '-R xunit -L 10 -g quick'
-        mkfs_opt: '-f -s 4096 -n 4096'
+        mkfs_opt: '-f -s 4096'
         mount_opt: ''

--- a/fs/xfstests.py.data/btrfs/4k_adv.yaml
+++ b/fs/xfstests.py.data/btrfs/4k_adv.yaml
@@ -13,5 +13,5 @@ fs_type: !mux
     fs_btrfs_4k_adv:
         fs: 'btrfs'
         args: '-R xunit -L 10 -g quick'
-        mkfs_opt: '-f -s 4096 -n 4096 -O quota,mixed-bg,block-group-tree'
+        mkfs_opt: '-f -s 4096 -O quota,mixed-bg,block-group-tree'
         mount_opt: ''

--- a/fs/xfstests.py.data/btrfs/4k_adv_upstream.yaml
+++ b/fs/xfstests.py.data/btrfs/4k_adv_upstream.yaml
@@ -13,7 +13,7 @@ fs_type: !mux
     fs_btrfs_4k_adv:
         fs: 'btrfs'
         args: '-R xunit -L 10 -g quick'
-        mkfs_opt: '-f -s 4096 -n 4096 -O quota,mixed-bg,block-group-tree'
+        mkfs_opt: '-f -s 4096 -O quota,mixed-bg,block-group-tree'
         mount_opt: ''
 
 run_type: !mux

--- a/fs/xfstests.py.data/btrfs/4k_auto.yaml
+++ b/fs/xfstests.py.data/btrfs/4k_auto.yaml
@@ -13,5 +13,5 @@ fs_type: !mux
     fs_btrfs_4k_auto:
         fs: 'btrfs'
         args: '-R xunit -L 10 -g auto'
-        mkfs_opt: '-f -s 4096 -n 4096'
+        mkfs_opt: '-f -s 4096'
         mount_opt: ''

--- a/fs/xfstests.py.data/btrfs/4k_upstream.yaml
+++ b/fs/xfstests.py.data/btrfs/4k_upstream.yaml
@@ -15,7 +15,7 @@ fs_type: !mux
     fs_btrfs_4k:
         fs: 'btrfs'
         args: '-R xunit -L 10 -g quick'
-        mkfs_opt: '-f -s 4096 -n 4096'
+        mkfs_opt: '-f -s 4096'
         mount_opt: ''
 
 run_type: !mux

--- a/fs/xfstests.py.data/btrfs/ci.yaml
+++ b/fs/xfstests.py.data/btrfs/ci.yaml
@@ -13,5 +13,5 @@ fs_type: !mux
     fs_btrfs_4k:
         fs: 'btrfs'
         args: '-R xunit generic/001'
-        mkfs_opt: '-f -s 4096 -n 4096'
+        mkfs_opt: '-f -s 4096'
         mount_opt: ''

--- a/fs/xfstests.py.data/ext4/dax.yaml
+++ b/fs/xfstests.py.data/ext4/dax.yaml
@@ -4,7 +4,7 @@ test_mnt: '/mnt/test_pmem'
 fs_type: !mux
     fs_ext4_dax:
         fs: 'ext4'
-        args: '-R xunit -e ext4/048 -L 10 -g quick'
+        args: '-R xunit -e ext4/048 -L 10 -g auto'
         mkfs_opt: '-b 65536'
         mount_opt: '-o block_validity,dax'
 

--- a/fs/xfstests.py.data/xfs/dax.yaml
+++ b/fs/xfstests.py.data/xfs/dax.yaml
@@ -4,7 +4,7 @@ test_mnt: '/mnt/test_pmem'
 fs_type: !mux
     fs_xfs_dax:
         fs: 'xfs'
-        args: '-R xunit -L 10 -g quick'
+        args: '-R xunit -L 10 -g auto'
         mkfs_opt: '-b size=65536 -s size=512 -m reflink=0'
         mount_opt: '-o dax'
 

--- a/fs/xfstests.py.data/xfstests_disk.yaml
+++ b/fs/xfstests.py.data/xfstests_disk.yaml
@@ -14,7 +14,7 @@ fs_type: !mux
     fs_btrfs_4k:
         fs: 'btrfs'
         args: '-R xunit -L 10 -g quick'
-        mkfs_opt: '-f -s 4096 -n 4096'
+        mkfs_opt: '-f -s 4096'
         mount_opt: ''
 disk_type: !mux
     type: 'disk'


### PR DESCRIPTION
btrfs: drop explicit -n option to use default nodesize
Recent versions of Btrfs default to a 16K nodesize when using a 4K block size. This commit updates the 4k.yaml configs to remove the '-n' option from mkfs_opt, allowing Btrfs to use its default nodesize logic.

dax: change test group from quick to auto
Update the dax configs to run tests from the 'auto' group instead of 'quick'. The 'auto' group includes a broader set of relevant tests and provides better coverage.

xfstest: remove xmlto and asciidoc package
Remove xmlto and asciidoc packages from prerequisite as they are used for creating documentation and slow down the tests.