### PR TITLE
Fix test_lshw_verification mac address check in lshw command

### DIFF
--- a/ras/lshw.py
+++ b/ras/lshw.py
@@ -142,7 +142,9 @@ class Lshwrun(Test):
                 mac = line.split()[1]
         if not mac:
             self.cancel("Couldn't get mac address from the active interface.")
-        if mac not in self.lshw_output:
+
+        x = re.search(mac, self.lshw_output)
+        if not x:
             self.fail("lshw failed to show correct mac address")
 
         # verify network


### PR DESCRIPTION
Fix mac address check using regex to parse and validate