### PR TITLE
Added support for taking device name as susbys or nqn of nvme disk and added support for shared namespaces.

### DIFF
--- a/io/disk/ssd/nvmetest.py.data/nvmetest_splitter.yaml
+++ b/io/disk/ssd/nvmetest.py.data/nvmetest_splitter.yaml
@@ -1,6 +1,5 @@
 namespace_count:
-#Set shared_namespaces as True if want to work with nvme multipath
-shared_namespaces: False
+shared_namespaces: True
 package: !mux
     upstream-nvme-cli:
         package: upstream


### PR DESCRIPTION
Added changes/support as follows
1. Device name can be provided as follows in yaml file a. subsystem name b. device nqn name
2. Added paramter in yaml to enable shared namespace functionality, Default value is set to False as it should not impact exisitng functionality.
3. Added function calls for shared namespace creation. Conclusion: Changes works for sing controller nvme dis and multi controller nvme disk