### PR TITLE
Modified the existing hackbench test case with new LTP repository.

### DIFF
--- a/perf/hackbench.py
+++ b/perf/hackbench.py
@@ -13,72 +13,158 @@
 #
 # Copyright: 2016 IBM
 # Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+# Modified by: Samir A Mulani <samir@linux.vnet.ibm.com>
 #
-# Based on code by Nikhil Rao <ncrao@google.com>
-#   copyright: 2008 Google
-#   https://github.com/autotest/autotest-client-tests/tree/master/hackbench
 
 import os
-import shutil
-import json
-
+from datetime import datetime
 from avocado import Test
-from avocado.utils import process
+from avocado.utils import process, archive, build
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
 class Hackbench(Test):
 
     """
-    This module will run the hackbench benchmark. Hackbench is a benchmark for
-    measuring the performance, overhead and scalability of the Linux scheduler.
-    The C program was pick from Ingo Molnar's page.
+    Hackbench is both a benchmark and a stress test for the Linux kernel
+    scheduler.  It's  main  job  is  to create  a  specified  number  of
+    pairs of schedulable entities (either threads or traditional processes)
+    which communicate via either sockets or pipes and time how long it takes
+    for each pair to send data  back and forth.
     """
 
     def setUp(self):
         '''
-        Build Hackbench
-        Source:
-        http://people.redhat.com/~mingo/cfs-scheduler/tools/hackbench.c
+        Setting up the hackbench benchmark from the Linux Test Project (LTP).
+        repo: https://github.com/linux-test-project/ltp/archive/master.zip
+
+        This function downloads the LTP source as a ZIP archive, extracts it
+        under the /tmp/ltp directory, and builds the hackbench binary
+        located at: /tmp/ltp/ltp-master/testcases/kernel/sched/cfs-scheduler/
+        After a successful build, the hackbench binary is ready to be used
+        for benchmark runs.
+
+        This setup is intended to prepare the environment before executing
+        hackbench-based performance tests.
         '''
-        self._threshold_time = self.params.get('time_val', default=None)
-        self._num_groups = self.params.get('num_groups', default=90)
-        self._iterations = self.params.get('iterations', default=1)
-        self.results = None
         sm = SoftwareManager()
-        if not sm.check_installed("gcc") and not sm.install("gcc"):
-            self.cancel("Gcc is needed for the test to be run")
-        hackbench = self.fetch_asset('http://people.redhat.com'
-                                     '/~mingo/cfs-scheduler/'
-                                     'tools/hackbench.c')
-        shutil.copyfile(hackbench, os.path.join(self.workdir, 'hackbench.c'))
+        deps = ['gcc', 'make']
+        for package in deps:
+            if not sm.check_installed(package) and not sm.install(package):
+                self.cancel("%s is needed for the test to be run" % package)
 
-        os.chdir(self.workdir)
-
-        if 'CC' in os.environ:
-            cc = '$CC'
+        url = self.params.get(
+            'ltp_url', default='https://github.com/linux-test-project/ltp/archive/master.zip')  # noqa
+        match = next((ext for ext in [".zip", ".tar"] if ext in url), None)
+        tarball = ''
+        if match:
+            tarball = self.fetch_asset(
+                "ltp-master%s" % match, locations=[url], expire='7d')
         else:
-            cc = 'cc'
-        process.system('%s  hackbench.c -o hackbench -lpthread' % cc)
+            self.cancel("Provided LTP Url is not valid")
+
+        self.ltpdir = '/tmp/ltp'
+
+        if not os.path.exists(self.ltpdir):
+            os.mkdir(self.ltpdir)
+        archive.extract(tarball, self.ltpdir)
+
+        ltp_hackbench_dir = os.path.join(
+            self.ltpdir, "ltp-master/testcases/kernel/sched/cfs-scheduler/")
+        self.ltp_dir = os.path.join(self.ltpdir, "ltp-master")
+        os.chdir(self.ltp_dir)
+        build.make(self.ltp_dir, extra_args='autotools')
+        process.run("./configure")
+
+        os.chdir(ltp_hackbench_dir)
+        build.make(ltp_hackbench_dir)
+
+        self.workload_iteration = self.params.get("workload_iter",
+                                                  default="10")
+        self.data_op = self.params.get("data_op", default="")
+        self.num_groups = self.params.get("num_groups", default="10")
+        self.test_type = self.params.get("test_type", default="thread")
+        self.loop = self.params.get("loops", default="100000")
+
+    def parse_hackbench_data(self, file_path):
+        """
+        Parse hackbench output data to extract performance metrics.
+
+        This function reads the benchmark output and computes the following:
+        - min: Minimum time taken to run hackbench across all iterations
+        - max: Maximum time taken to run hackbench across all iterations
+        - avg: Average time across all iterations
+        """
+        hackbench_times = []
+        with open(file_path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("Time:"):
+                    try:
+                        time_value = float(line.split("Time:")[1].strip())
+                        hackbench_times.append(time_value)
+                    except ValueError:
+                        continue  # Skip malformed lines
+        if not hackbench_times:
+            print("No time values found.")
+            return
+
+        min_time = min(hackbench_times)
+        max_time = max(hackbench_times)
+        avg_time = sum(hackbench_times) / len(hackbench_times)
+
+        self.log.info(f"Parsed {len(hackbench_times)} iterations.")
+        self.log.info(f"Min Time: {min_time:.3f} sec")
+        self.log.info(f"Max Time: {max_time:.3f} sec")
+        self.log.info(f"Avg Time: {avg_time:.3f} sec")
 
     def test(self):
+        """
+        Run the hackbench benchmark with user-specified arguments and
+        save logs.
+        This function runs:
+            hackbench [-pipe] <num_groups> [process|thread] [loops]
+            Here where test_type is either [process|thread]
+            -p, --pipe
+              -> Sends the data via a pipe instead of the socket (default)
 
-        hackbench_bin = os.path.join(self.workdir, 'hackbench')
-        cmd = '%s %s' % (hackbench_bin, self._num_groups)
-        time_spent = 0
-        perf_json = {}
-        for run in range(self._iterations):
-            self.log.info("Iteration " + str(run+1))
-            self.results = process.system_output(
-                cmd, shell=True).decode("utf-8")
-            for line in self.results.split('\n'):
-                if line.startswith('Time:'):
-                    time_spent += float(line.split()[1])
-                    break
-        perf_json = {'time': time_spent}
-        self.whiteboard = json.dumps(perf_json)
-        self.log.info("Time Taken:" + str(time_spent))
-        if self._threshold_time:
-            if self._threshold_time <= time_spent:
-                self.error("Test failed: Time Taken "
-                           "greater or equal to threshold")
+        It captures the output and stores timestamped logs under the test job
+        directory (e.g., ./hackbench_logs) for performance analysis.
+
+        Example:
+        pipe=True num_groups=25, mode='thread', loops=100000)
+        """
+        hack_bench = self.logdir + "/hackbench_logs"
+        os.makedirs(hack_bench, exist_ok=True)
+        payload_file = os.path.join(hack_bench, "hackbench_payload.log")
+
+        if self.data_op:
+            cmd = "./hackbench -pipe " + self.num_groups + \
+                " " + self.test_type + " " + self.loop
+        else:
+            cmd = "./hackbench " + self.num_groups + " " + self.test_type + \
+                " " + self.loop
+
+        for ite in range(1, int(self.workload_iteration) + 1):
+            self.log.info(f"Running hackbench iteration {ite}...")
+
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            log_filename = f"hackbench_run_{ite}_{timestamp}.log"
+            log_path = os.path.join(hack_bench, log_filename)
+            # Run the command
+            res = process.run(cmd, ignore_status=True, shell=True)
+            data = res.stdout.decode().splitlines()
+            # Write output to log file
+            with open(payload_file, "a") as fd:
+                fd.write("==================Iteration {}=============\
+                        \n".format(str(ite)))
+                for info in data:
+                    fd.write(info)
+                    fd.write("\n")
+
+            with open(log_path, "w") as fd:
+                for info in data:
+                    fd.write(info)
+                    fd.write("\n")
+
+        self.parse_hackbench_data(payload_file)

--- a/perf/hackbench.py.data/hackbench.yaml
+++ b/perf/hackbench.py.data/hackbench.yaml
@@ -1,8 +1,6 @@
-runargs: !mux
-  default:
-    num_groups: 10
-  threshold:
-    time_val: '0.183'
-  stress:
-    num_groups: 50
-    iterations: 16
+workload_iter: 4
+ltp_url:
+data_op:
+num_groups:
+test_type:
+loops:


### PR DESCRIPTION
Replace unmaintained hackbench source with LTP version and improve logging and analysis

Previously, the hackbench test used an outdated and now-inaccessible source: http://people.redhat.com/~mingo/cfs-scheduler/tools/hackbench.c (also referenced in: https://github.com/autotest/autotest-client-tests/tree/master/hackbench)

This commit updates the setup to use the actively maintained hackbench version from the Linux Test Project (LTP). Along with this, the codebase is improved to:

- Store benchmark logs under a dedicated test directory with structured subdirectories
- Enable easier parsing and analysis of results for performance evaluation
- Introduce a smart log analysis module to extract min, max, and average metrics

These changes make the hackbench test setup more reliable, maintainable, and analysis-friendly.