### PR TITLE
Enable BPF selftests support in distro kernel

### DIFF
--- a/kernel/kselftest.py.data/bpf.yaml
+++ b/kernel/kselftest.py.data/bpf.yaml
@@ -5,3 +5,6 @@ run_type: !mux
     upstream:
         type: 'upstream'
         location: ''
+    distro:
+        type: 'distro'
+        location: "/usr/src/linux"


### PR DESCRIPTION
This commit integrates BPF selftests into the distro kernel tree to enable validation of BPF functionality during automated testing. This patch ensures bpf selftests are correctly packaged and runnable within the Linux distribution (RHEL and SLES) environment