### PR TITLE
HTX: Add support for on-demand MDT file creation in htx_test.py tests

### DIFF
--- a/workload/htx_test.py
+++ b/workload/htx_test.py
@@ -92,6 +92,9 @@ class HtxTest(Test):
         else:
             self.cancel(
                 "running time unit is not proper, please pass as 'm' or 'h' ")
+        if not os.path.exists("/usr/lpp/htx/mdt/"):
+            self.log.info("mdt directory is created")
+
         if str(self.name.name).endswith('test_start'):
             # Build HTX only at the start phase of test
             self.setup_htx()
@@ -180,8 +183,12 @@ class HtxTest(Test):
             time.sleep(10)
         process.run('/usr/lpp/htx/etc/scripts/htxd_run')
 
-        self.log.info("Creating the HTX mdt files")
-        process.run('htxcmdline -createmdt')
+        cmd = "hcl -set_htx_env HTX_ON_DEMAND_MDT_CREATION 1"
+        self.log.info("Enabling on demand HTX mdt support")
+        process.run(cmd)
+        self.log.info("Creating the on demand HTX mdt files")
+        cmd = "hcl -createmdt -mdt %s" % (self.mdt_file)
+        process.run(cmd)
 
     def test_start(self):
         """


### PR DESCRIPTION
Previously, HTX created all MDT files by default, even when not required. To optimize resource usage and improve flexibility, the HTX team has introduced support for on-demand MDT file creation.

With this update, MDT files will only be created as needed under the path: `/usr/lpp/htx/mdt/`.

Commands:
cmd 1: ` hcl -set_htx_env HTX_ON_DEMAND_MDT_CREATION 1`: Enables on-demand MDT file creation. cmd 2: `hcl -createmdt -mdt mdt_file_name`: Creates or modifies MDT files that are not created by default.

Note: cmd 2 supports both pre-existing MDT files and those created on-demand. As a part of "htx_test.py" test case added support for on demand htx mdt creation under "/usr/lpp/htx/mdt/" path