### PR TITLE
nvmetest: ns_list() shows string value error

### DIFF
--- a/io/disk/ssd/nvmetest.py
+++ b/io/disk/ssd/nvmetest.py
@@ -190,7 +190,8 @@ class NVMeTest(Test):
         cmd = "%s list-ns %s" % (self.binary, self.device)
         namespaces = []
         for line in self.run_cmd_return_output_list(cmd):
-            namespaces.append(int(line.split()[1].split(']')[0]) + 1)
+            if line.startswith('['):
+                namespaces.append(int(line.split()[1].split(']')[0]) + 1)
         return namespaces
 
     def list_ns(self):


### PR DESCRIPTION
list-ns command has first line as string and shows below error ValueError: invalid literal for int() with base 10: 'Namespace'

This code change will make sure the string line is ommited