### PR TITLE
Add support to stress all scheduling classes using stress-ng

### DIFF
--- a/cpu/stressng_cpu.py.data/stressng_cpu.yaml
+++ b/cpu/stressng_cpu.py.data/stressng_cpu.yaml
@@ -1,4 +1,6 @@
-runtime: 7200 
+runtime: 100
+sched_runtime: 100
+test_mode:
 url: "https://github.com/ColinIanKing/stress-ng/archive/master.zip"
 crt_stressors: ["bsearch", "context", "cpu", "crypt", "hsearch", "longjmp",
                 "lsearch", "matrix", "qsort", "str", "stream", "tsearch",


### PR DESCRIPTION
This patch introduces functionality to stress individual Linux scheduling classes using stress-ng. Each class is exercised independently to evaluate scheduler behavior and system responsiveness under different policies.

Supported scheduling classes:
1. SCHED_OTHER
2. SCHED_IDLE
3. SCHED_BATCH
4. SCHED_FIFO
5. SCHED_RR

This enhancement enables better coverage of scheduler-related test scenarios as part of system stress and performance validation