### PR TITLE
NVME SED feature tests[depends on avocado/pull/6196]

### DIFF
--- a/io/disk/ssd/nvme_sedtest.py
+++ b/io/disk/ssd/nvme_sedtest.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2025 IBM
+# Author: Maram.Srimannarayana.Murthy <msmurthy@linux.ibm.com>
+
+"""
+NVM-Express user space tooling for Linux, which handles NVMe devices.
+This Suite tests NVME SED functionality.
+"""
+
+from avocado import Test
+from avocado.utils import disk
+from avocado.utils import nvme
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class NVMeSEDTest(Test):
+
+    """
+    NVM-Express user space tooling for Linux, which handles NVMe devices.
+
+    :param device: Name of the nvme device
+    :param namespace: Namespace of the device
+    """
+
+    def setUp(self):
+        """
+        Build 'nvme-cli' and setup the device.
+        """
+        smm = SoftwareManager()
+        if not smm.check_installed("nvme-cli") and not \
+                smm.install("nvme-cli"):
+            self.cancel('nvme-cli is needed for the test to be run')
+        self.namespace = self.params.get("disk", default=None)
+        if not self.namespace:
+            nvme_node = self.params.get('device', default=None)
+            self.shared = False
+            subsys = nvme.get_subsystem_using_ctrl_name(nvme_node)
+            if not nvme_node:
+                self.log.fail("Both disk and device are not provided, Exiting test")
+            elif "subsys" in nvme_node:
+                nvme_node = nvme.get_controllers_with_subsys(subsys)[0]
+            elif nvme_node.startswith("nqn."):
+                nvme_node = nvme.get_controllers_with_nqn(nvme_node)[0]
+            if len(nvme.get_controllers_with_subsys(subsys)) > 1:
+                self.shared = True
+                if not nvme.get_current_ns_list(nvme_node, shared_ns=self.shared):
+                    nvme_node = nvme.get_alternate_controller_name(nvme_node)[0]
+            self.log.info(self.shared)
+            self.log.info(nvme.get_current_ns_list(nvme_node, shared_ns=self.shared))
+            if nvme.get_current_ns_list(nvme_node, shared_ns=self.shared):
+                self.namespace = nvme.get_current_ns_list(nvme_node, shared_ns=self.shared)[0]
+            if not self.namespace:
+                nvme.create_namespaces(nvme_node, 1, shared_ns=self.shared)
+                self.namespace = nvme.get_current_ns_list(nvme_node)[0]
+        self.sed_password = self.params.get("sed_password", default=None)
+        self.change_sed_password = self.params.get("change_sed_password",
+                                                   default=None)
+
+    def lock_unlock(self):
+        """
+        Perform lock and unlock of nvme drive
+        """
+        nvme.lock_drive(self.namespace)
+        if disk.dd_read_records_device(self.namespace):
+            self.log.fail(f"dd read command on {self.namespace} is successful, dd should fail when drive is locked")
+        nvme.unlock_drive(self.namespace)
+        if not disk.dd_read_records_device(self.namespace):
+            self.log.fail(f"dd read command on {self.namespace} is failed, dd should success when drive is unlocked")
+
+    def lock_unlock_with_key(self, password):
+        """
+        Perform lock and unlock with provided key
+        """
+        nvme.lock_drive(self.namespace, with_pass_key=password)
+        if disk.dd_read_records_device(self.namespace):
+            self.log.fail(f"dd read command on {self.namespace} is successful, dd should fail when drive is locked")
+        nvme.unlock_drive(self.namespace, with_pass_key=password)
+        if not disk.dd_read_records_device(self.namespace):
+            self.log.fail(f"dd read command on {self.namespace} is failed, dd should success when drive is unlocked")
+
+    def test_initialize_locking(self):
+        """
+        Initializes nvme SED drive
+        """
+        nvme.initialize_sed_locking(self.namespace, self.sed_password)
+
+    def test_changed_password(self):
+        """
+        Changes SED password
+        Performs lock, unlock and revert of nvme disk
+        """
+        nvme.initialize_sed_locking(self.namespace, self.sed_password)
+        nvme.lock_drive(self.namespace)
+        nvme.change_sed_password(self.namespace, self.sed_password, self.change_sed_password)
+        nvme.unlock_drive(self.namespace)
+        nvme.lock_drive(self.namespace, with_pass_key=self.change_sed_password)
+        nvme.unlock_drive(self.namespace, with_pass_key=self.change_sed_password)
+        nvme.revert_sed_locking(self.namespace, self.change_sed_password)
+
+    def test_changed_password_with_destructive_revert(self):
+        """
+        Changes SED password
+        Performs lock, unlock and destructive revert of nvme disk
+        """
+        nvme.initialize_sed_locking(self.namespace, self.sed_password)
+        self.lock_unlock()
+        nvme.change_sed_password(self.namespace, self.sed_password, self.change_sed_password)
+        self.lock_unlock_with_key(self.change_sed_password)
+        nvme.revert_sed_locking(self.namespace, self.change_sed_password, destructive=True)
+
+    def test_sed_revert(self):
+        """
+        Reverts SED locking on NVME drive
+        """
+        nvme.initialize_sed_locking(self.namespace, self.sed_password)
+        nvme.revert_sed_locking(self.namespace, self.sed_password)
+
+    def test_lock_unlock(self):
+        """
+        Check locking and unlocking of nvme disk after SED initialization
+        """
+        nvme.initialize_sed_locking(self.namespace, self.sed_password)
+        self.lock_unlock()
+        self.lock_unlock_with_key(self.sed_password)
+        nvme.revert_sed_locking(self.namespace, self.sed_password)
+
+    def test_sed_destructive_revert(self):
+        """
+        Destructive reverts SED locking on NVME drive
+        Erases drive data
+        """
+        nvme.initialize_sed_locking(self.namespace, self.sed_password)
+        nvme.lock_drive(self.namespace)
+        nvme.revert_sed_locking(self.namespace, self.sed_password, destructive=True)
+
+    def tearDown(self):
+        """
+        Restore nvme disk with default values
+        """
+        if nvme.is_drive_locked(self.namespace):
+            nvme.unlock_drive(self.namespace, with_pass_key=self.sed_password)
+        if nvme.is_lockdown_enabled(self.namespace):
+            nvme.revert_sed_locking(self.namespace, self.sed_password)

--- a/io/disk/ssd/nvme_sedtest.py.data/README.txt
+++ b/io/disk/ssd/nvme_sedtest.py.data/README.txt
@@ -1,0 +1,22 @@
+"disk": Parameters can be obtained from either the 'nvme list' command output or the 'lsblk' command results, given that the namespace has been created on the NVMe disk.
+Example: "/dev/nvmeXnY"
+
+"sed_password": The password must consist of 8 or more alphanumeric characters and will be utilized for the specified tests.
+"change_sed_password": The password must consist of 8 or more alphanumeric characters and will be utilized for the specified tests.
+Both 'sed_password' and 'change_sed_password' are required fields for executing all tests. The 'sed_password' and 'change_sed_password' values must be distinct.
+
+"device": The value should represent the NVMe controller's name. In the absence of a disk parameter, the script will autonomously generate a disk if not available on the specified subsystem and proceed with the subsequent tests
+The device parameter accepts values in the following formats:
+1. NQN (Name Space Qualifier Name): nqn.1994-11.com.vendor:nvme:modela:2.5-inch:SERIALNUM
+2. Subsystem: nvme-subsysX
+3. Controller: nvmeX
+
+These tests cover 
+1. SED Initialization
+2. SED locking with and without keyring
+3. SED unlocking with and without keyring
+4. SED Revert
+5. SED destructive revert
+
+SED tests has following pre-requisite,
+Ensure that the NVMe disk is not initialized for locking prior to initiating the test.

--- a/io/disk/ssd/nvme_sedtest.py.data/nvme_sedtest.yaml
+++ b/io/disk/ssd/nvme_sedtest.py.data/nvme_sedtest.yaml
@@ -1,0 +1,10 @@
+disk:
+sed_password:
+change_sed_password:
+Devices:
+    device:
+#device parameter accepts values as follows
+#NQN: nqn.1994-11.com.vendor:nvme:modela:2.5-inch:SERIALNUM
+#Subsystem: nvme-subsysX
+#controller: nvmeX 
+


### PR DESCRIPTION
Added following tests as part of nvme SED validation
1. SED Initialization.
2. SED lock and unlock with keyring.
3. SED revert.
4. SED destructive revert.
5. teardown added to bring drive to same state as before.