### PR TITLE
Get bond master from bond slave using utils [wait for avocado/pull/6201]

### DIFF
--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -59,7 +59,11 @@ class Ethtool(Test):
         if device in interfaces:
             self.interface = device
         elif local.validate_mac_addr(device) and device in local.get_all_hwaddr():
-            self.interface = local.get_interface_by_hwaddr(device).name
+            if self.hbond:
+                self.interface = local.get_interface_by_hwaddr(device).name
+                self.interface = self.interface._get_bondingmaster()
+            else:
+                self.interface = local.get_interface_by_hwaddr(device).name
         else:
             self.interface = None
             self.cancel("Please check the network device")


### PR DESCRIPTION
Use the utils changes _get_bondingmaster(self) to get the bond master name and use it as the test interface.