### PR TITLE
Fix: Rectifying arch detection logic

### DIFF
--- a/generic/ipistorm.py
+++ b/generic/ipistorm.py
@@ -41,7 +41,7 @@ class DBLIPIStrom(Test):
         """
         Install necessary packages to build the linux module
         """
-        if 'ppc64' not in cpu.get_arch:
+        if 'powerpc' not in cpu.get_arch():
             self.cancel("Test is supported only on ppc64le architecture")
 
         pkgs = ['gcc', 'make']


### PR DESCRIPTION
Previously, cpu.get_arch was incorrectly called, resulting in TypeError. This commit fixes the same and also, searches the correct keyword for cpu arch.