### PR TITLE
memory/vatest: Fix the logic for 2M/1G pages

### DIFF
--- a/memory/vatest.py.data/va_test.c
+++ b/memory/vatest.py.data/va_test.c
@@ -69,9 +69,9 @@ int set_alt_hugepage()
 	int size = get_hugepage_mbytes();
         if( size == 16384 )
                 return MAP_HUGETLB | MAP_HUGE_16MB;
-        else if ( size == 1024 )
-                return MAP_HUGETLB | MAP_HUGE_2MB;
         else if ( size == 2 )
+                return MAP_HUGETLB | MAP_HUGE_2MB;
+        else if ( size == 1024 )
                 return MAP_HUGETLB | MAP_HUGE_1GB;
         else
                 return MAP_HUGETLB | MAP_HUGE_16GB;


### PR DESCRIPTION
get_hugepage_mbytes returns a number in megabytes for a hugepage.
This number is used in set_alt_hugepage() function to identify
hugepage size. Possibly due to an oversight check for 2M and 1G
hugepages is swapped.

Fix the logic accordingly.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>