### PR TITLE
Add stress-ng interrupt test case yaml

### DIFF
--- a/generic/stress-ng.py.data/stress_ng_interrupt.yaml
+++ b/generic/stress-ng.py.data/stress_ng_interrupt.yaml
@@ -1,0 +1,19 @@
+# While specifying a branch with tag omit `V` from the name.
+# e.g say V0.18.11 is the tag to be used specify
+# branch: '0.18.11'
+#
+branch: 'master'
+workers:
+ttimeout: '5m'
+verify: True
+syslog: True
+metrics: True
+maximize: True
+times: True
+aggressive: True
+parallel: True
+subsystem: !mux
+  interrupt:
+    class: 'interrupt'
+    stressors: "null"
+    exclude: "null"


### PR DESCRIPTION
Stress_ng_interrupt_tc config in stress-ng.yaml to run only interrupt stressors.

Added a new Stress_ng_interrupt_tc config in stress-ng.yaml to run only interrupt stressors.
Purpose: isolate and validate interrupt handling validation without running full stress-ng tests.
Verified locally using avocado run generic/stress-ng.py with the updated stress_ng_interrupt.yaml file