### PR TITLE
error injection on SR-IOV devices

### DIFF
--- a/io/pci/EEH.py
+++ b/io/pci/EEH.py
@@ -87,10 +87,14 @@ class EEH(Test):
             self.interface = pci.get_nics_in_pci_address(self.pci_device)[0]
             self.localhost = LocalHost()
             device = self.interface
-            if self.localhost.validate_mac_addr(device) and device in self.localhost.get_all_hwaddr():
-                self.interface = self.localhost.get_interface_by_hwaddr(device).name
-            else:
-                self.cancel("Please check the network device")
+            # Check if device is a MAC address or interface name
+            if self.localhost.validate_mac_addr(device):
+                if device in self.localhost.get_all_hwaddr():
+                    self.interface = self.localhost.get_interface_by_hwaddr(
+                        device).name
+                else:
+                    self.cancel("Please check the network device")
+            # If it's already an interface name, use it directly
             self.networkinterface = NetworkInterface(self.interface,
                                                      self.localhost)
             if not self.networkinterface.validate_ipv4_format(self.ipaddr):
@@ -107,11 +111,13 @@ class EEH(Test):
             if not wait.wait_for(self.networkinterface.is_link_up, timeout=60):
                 self.cancel("Link up of host interface taking more than 60s")
         if self.is_baremetal():
-            cmd = f"echo {self.max_freeze} > /sys/kernel/debug/powerpc/eeh_max_freezes"
+            cmd = (f"echo {self.max_freeze} > "
+                   f"/sys/kernel/debug/powerpc/eeh_max_freezes")
             process.system(cmd, ignore_status=True, shell=True)
             self.phb = self.pci_device.split(":", 1)[0]
             self.addr = genio.read_file(
-                    f"/sys/bus/pci/devices/{self.pci_device}/eeh_pe_config_addr"
+                    f"/sys/bus/pci/devices/"
+                    f"{self.pci_device}/eeh_pe_config_addr"
             )
             self.addr = str(self.addr).rstrip()
             self.err = 0
@@ -163,29 +169,42 @@ class EEH(Test):
                         if num_of_hit <= self.max_freeze:
                             if not self.check_eeh_pe_recovery():
                                 self.fail(
-                                        f"PE {self.pci_device} recovery failed after {num_of_hit}"
-                                        f" EEH"
-                                )
+                                        f"PE {self.pci_device} recovery"
+                                        f" failed after {num_of_hit} EEH")
                                 break
                             else:
                                 self.log.info("PE recovered successfully")
+                                # Verify network connectivity for net adapters
+                                if (pci.get_pci_class_name(self.pci_device)
+                                        == "net" and hasattr(self, 'peer_ip')
+                                        and self.peer_ip):
+                                    if not self.net_recovery_check(
+                                            self.interface):
+                                        self.fail(
+                                            "Network adapter failed to ping "
+                                            "after EEH recovery")
                         time.sleep(10)
-                        if pci.get_pci_class_name(self.pci_device) == "fc_host":
-                            after_eeh_path_status = multipath.get_multipath_details()
-                            get_diff_bef_aft = data_structures.recursive_compare_dict(
+                        pci_class = pci.get_pci_class_name(self.pci_device)
+                        if pci_class == "fc_host":
+                            after_eeh_path_status = \
+                                multipath.get_multipath_details()
+                            get_diff_bef_aft = \
+                                data_structures.recursive_compare_dict(
                                     before_eeh_path_status,
                                     after_eeh_path_status,
-                                    diff_btw_dict=[]
-                                )
+                                    diff_btw_dict=[])
                             if len(get_diff_bef_aft) != 0:
                                 for value in get_diff_bef_aft[:]:
-                                    if ("path_faults " in value) or ("switch_grp " in value):
+                                    if ("path_faults " in value or
+                                            "switch_grp " in value):
                                         get_diff_bef_aft.remove(value)
                                 if len(get_diff_bef_aft) != 0:
-                                    self.fail("Some devices/disks are failed to recover after EEH")
+                                    self.fail("Some devices/disks are "
+                                              "failed to recover after EEH")
                                     self.log.info(get_diff_bef_aft)
                 else:
-                    self.log.warning(f"EEH inject failed for 5 times with function {func}")
+                    self.log.warning("EEH inject failed for 5 times "
+                                     "with function %s", func)
                     enter_loop = False
                     break
             if not enter_loop:
@@ -195,6 +214,144 @@ class EEH(Test):
                 self.log.info(f"PE {self.pci_device} removed successfully")
             else:
                 self.fail(f"PE {self.pci_device} not removed after max hit")
+
+    def test_eeh_sriov(self):
+        """
+        Test to execute EEH error injection on SR-IOV devices
+        """
+        # Get the bus address from the PCI device
+        bus_id = self.pci_device.split(':')[0]
+
+        # Get interface name from PCI address
+        interface_list = pci.get_nics_in_pci_address(self.pci_device)
+        if not interface_list:
+            self.fail(
+                f"No network interface found for PCI device "
+                f"{self.pci_device}")
+        interface_name = interface_list[0]
+        self.log.info(
+            f"Interface name for {self.pci_device}: {interface_name}")
+
+        # Get bus address from journalctl
+        bus_address = self.get_bus_address_from_journalctl(bus_id)
+        if not bus_address:
+            self.fail(
+                f"Failed to get bus address for {self.pci_device} "
+                f"from journalctl")
+        self.log.info(f"Bus address from journalctl: {bus_address}")
+
+        # Start network traffic on the SR-IOV interface
+        self.log.info(
+            f"Starting traffic on SR-IOV interface: {interface_name}")
+
+        # Start ping flood on the interface
+        if self.peer_ip:
+            networkinterface = NetworkInterface(interface_name,
+                                                self.localhost)
+            networkinterface.ping_flood(interface_name, self.peer_ip,
+                                        1000000)
+
+        # Clear dmesg before error injection
+        dmesg.clear_dmesg()
+
+        # Trigger EEH with the specified command for each function
+        mask = "0xffffffffffc00000"
+        for func in self.function:
+            cmd = (f"errinjct ioa-bus-error-64 -v -f {func}"
+                   f" -s net/{interface_name} ")
+            cmd += f"-a {bus_address} -m {mask}"
+            self.log.info(f"Triggering EEH with command: {cmd}")
+            try:
+                result = process.run(cmd, ignore_status=True, shell=True)
+                output = result.stdout.decode('utf-8')
+                self.log.info(f"EEH injection command output: {output}")
+            except Exception as e:
+                self.log.error(f"Error during EEH injection: {str(e)}")
+
+        # Stop the network traffic after error inject
+        for ps in psutil.process_iter(['name']):
+            if ps.info['name'] == 'ping':
+                ps.kill()
+
+        # Check if EEH was hit
+        if not self.check_eeh_hit():
+            self.fail(
+                f"EEH hit failed for SR-IOV device {self.pci_device}")
+        else:
+            self.log.info(
+                f"EEH hit successful for SR-IOV device {self.pci_device}")
+
+        # Check for PE recovery
+        if not self.check_eeh_pe_recovery():
+            self.fail(
+                f"SR-IOV device {self.pci_device} recovery failed "
+                f"after EEH")
+        else:
+            self.log.info(
+                f"SR-IOV device {self.pci_device} recovered successfully")
+
+        # Additional validation for network interface
+        time.sleep(10)
+        net_interface = NetworkInterface(interface_name, self.localhost)
+        if not wait.wait_for(net_interface.is_link_up, timeout=60):
+            self.fail(
+                f"Interface {interface_name} failed to come up after EEH")
+        self.log.info(
+            f"Interface {interface_name} is up after EEH recovery")
+
+        # Verify network connectivity with ping check
+        if self.peer_ip and not self.net_recovery_check(interface_name):
+            self.fail("Network adapter failed to ping after EEH recovery")
+
+    def net_recovery_check(self, interface_name):
+        """
+        Checks if the network adapter functionality like ping/link_state,
+        after EEH recovery.
+        Returns True on proper Recovery, False if not.
+        """
+        self.log.info("Performing network recovery check")
+        local = LocalHost()
+        networkinterface = NetworkInterface(interface_name, local)
+        if wait.wait_for(networkinterface.is_link_up, timeout=120):
+            if networkinterface.ping_check(self.peer_ip, count=5) is None:
+                self.log.info("Interface is up and pinging")
+                return True
+        return False
+
+    def get_bus_address_from_journalctl(self, bus_id):
+        """
+        Extract bus address from journalctl for the given bus ID
+        Example output:
+        pci_bus 40xx:xx: root bus resource
+        [mem 0x4xxxc000000-0x4xxxxffffff 64bit]
+        (bus address [0x60xxxx000000-0x6xxxxxffffff])
+        """
+        cmd = "journalctl | grep 'bus address'"
+        try:
+            output = process.system_output(cmd, ignore_status=True,
+                                           shell=True).decode("utf-8")
+
+            # Parse the output to find the matching bus ID
+            for line in output.splitlines():
+                if f"pci_bus {bus_id}" in line:
+                    # Extract bus address from the line
+                    # Format: (bus address [0x60xxxx000000-0x6xxxxxffffff])
+                    if 'bus address' in line:
+                        start_idx = line.find('[', line.find('bus address'))
+                        end_idx = line.find('-', start_idx)
+                        if start_idx != -1 and end_idx != -1:
+                            bus_address = line[start_idx + 1:end_idx].strip()
+                            self.log.info(
+                                f"Found bus address: {bus_address}")
+                            return bus_address
+
+            self.log.warning(
+                f"Bus address not found for bus ID {bus_id} in journalctl")
+            return None
+        except Exception as e:
+            self.log.error(
+                f"Error getting bus address from journalctl: {str(e)}")
+            return None
 
     def basic_eeh(self, func, pci_class_name, pci_interface,
                   pci_mem_addr, pci_mask, add_cmd):
@@ -236,11 +393,13 @@ class EEH(Test):
         """
         if self.is_baremetal():
             cmd = f"echo {addr}:{err}:{func}:{pci_mem_addr}:{pci_mask} > "
-            cmd += f"/sys/kernel/debug/powerpc/PCI{phb}/err_injct && lspci; echo $?"
+            cmd += (f"/sys/kernel/debug/powerpc/PCI{phb}"
+                    f"/err_injct && lspci; echo $?")
             return int(process.system_output(cmd, ignore_status=True,
                                              shell=True).decode("utf-8")[-1])
         else:
-            cmd = f"errinjct eeh -v -f {func} -s {pci_class_name}/{pci_interface}"
+            cmd = (f"errinjct eeh -v -f {func}"
+                   f" -s {pci_class_name}/{pci_interface}")
             cmd += f" -a {pci_mem_addr} -m {pci_mask}; echo $?"
             res = process.system_output(cmd, ignore_status=True,
                                         shell=True).decode("utf-8")


### PR DESCRIPTION
- Added new test test_eeh_sriov() to test EEH error injection on SR-IOV devices 
- Added helper method get_bus_address_from_journalctl() - Used by test_eeh_sriov() to get the bus address parameter 
- Added helper method net_recovery_check() - Reusable method to verify network adapter recovery. Included in both test_eeh_basic_pe() and test test_eeh_sriov() 
- Fixed setUp() network device validation where MAC addresses and interface names were giving issue as pci address is passed.