### PR TITLE
generic/ltp: Replace runltp with kirk tool

### DIFF
--- a/generic/ltp.py
+++ b/generic/ltp.py
@@ -37,7 +37,7 @@ class LTP(Test):
 
     """
     LTP (Linux Test Project) testsuite
-    :param args: Extra arguments ("runltp" can use with
+    :param args: Extra arguments ("kirk" can use with
                  "-f $test")
     LTP Network test can run on Single host or Two host
     :param two_host_configuration: must be set to True
@@ -84,6 +84,8 @@ class LTP(Test):
         smg = SoftwareManager()
         dist = distro.detect()
         self.args = self.params.get('args', default='')
+        self.use_kirk = self.params.get('use_kirk', default=True)
+        # Available only with runltp
         self.mem_leak = self.params.get('mem_leak', default=0)
         self.peer_public_ip = self.params.get("peer_public_ip", default="")
         self.peer_user = self.params.get("peer_user", default="root")
@@ -140,6 +142,23 @@ class LTP(Test):
         archive.extract(tarball, self.ltpdir)
         ltp_dir = os.path.join(self.ltpdir, "ltp-master")
         os.chdir(ltp_dir)
+
+        # Initialize and update kirk submodule only if use_kirk is True
+        if self.use_kirk:
+            kirk_dir = f"{ltp_dir}/tools/kirk/kirk-src/"
+            if os.path.exists(kirk_dir):
+                shutil.rmtree(kirk_dir)
+
+            # Initialize and update kirk submodule
+            process.run('git init', shell=True, ignore_status=True)
+            process.run('git submodule add \
+                        https://github.com/linux-test-project/kirk.git \
+                        tools/kirk/kirk-src',
+                        shell=True, ignore_status=True)
+            process.run('git submodule update --init \
+                        --recursive tools/kirk/kirk-src',
+                        shell=True, ignore_status=True)
+
         build.make(ltp_dir, extra_args='autotools')
         if not self.ltpbin_dir:
             self.ltpbin_dir = os.path.join(self.teststmpdir, 'bin')
@@ -202,6 +221,16 @@ class LTP(Test):
         build.make(ltp_dir)
         build.make(ltp_dir, extra_args='install')
 
+        # Verify the appropriate runner is installed
+        if self.use_kirk:
+            kirk_path = os.path.join(self.ltpbin_dir, 'kirk')
+            if not os.path.exists(kirk_path):
+                self.cancel("kirk was not installed properly")
+        else:
+            runltp_path = os.path.join(self.ltpbin_dir, 'runltp')
+            if not os.path.exists(runltp_path):
+                self.cancel("runltp was not installed properly")
+
     def test(self):
         logfile = os.path.join(self.logdir, 'ltp.log')
         failcmdfile = os.path.join(self.logdir, 'failcmdfile')
@@ -213,30 +242,60 @@ class LTP(Test):
         else:
             skipfilepath = self.get_data('skipfile')
         os.chmod(self.teststmpdir, 0o755)
-        self.args += (" -q -p -l %s -C %s -d %s -S %s"
-                      % (logfile, failcmdfile, self.teststmpdir,
-                         skipfilepath))
-        if self.mem_leak:
-            self.args += " -M %s" % self.mem_leak
-        self.ltpbin_path = os.path.join(self.ltpbin_dir, 'runltp')
-        with open(self.ltpbin_path, 'r') as lfile:
-            data = lfile.read()
-            data = data.replace("    ${LTPROOT}/IDcheck.sh || \\", "    echo -e \"y\" | ${LTPROOT}/IDcheck.sh || \\")
-        with open(self.ltpbin_path, 'w') as ofile:
-            ofile.write(data)
-        cmd = '%s %s' % (self.ltpbin_path, self.args)
-        process.run(cmd, ignore_status=True)
-        # Walk the ltp.log and try detect failed tests from lines like these:
-        # msgctl04                                           FAIL       2
-        with open(logfile, 'r') as file_p:
-            lines = file_p.readlines()
-            for line in lines:
-                if 'FAIL' in line:
-                    value = re.split(r'\s+', line)
-                    self.failed_tests.append(value[0])
+        failed_tests = []
 
-        if self.failed_tests:
-            self.fail("LTP tests failed: %s" % self.failed_tests)
+        if self.use_kirk:
+            # Kirk runner execution path
+            self.args += (" -v -d %s -S %s"
+                          % (self.teststmpdir, skipfilepath))
+            self.kirkbin_path = os.path.join(self.ltpbin_dir, 'kirk')
+            # Set LTPROOT environment variable to tell kirk where LTP
+            # is installed
+            env_vars = os.environ.copy()
+            env_vars['LTPROOT'] = self.ltpbin_dir
+            cmd = '%s %s' % (self.kirkbin_path, self.args)
+            result = process.run(cmd, ignore_status=True, env=env_vars)
+            # Walk the stdout and try detect failed tests from lines
+            # like these:
+            # aio01       5  TPASS  :  Test 5: 10 reads and
+            # writes in  0.000022 sec
+            # vhangup02    1  TFAIL  :  vhangup02.c:88:
+            # vhangup() failed, errno:1
+            # and check for fail_status The first part contain test name
+            fail_status = ['TFAIL', 'TBROK', 'TWARN']
+            split_lines = (line.split(None, 3)
+                           for line in result.stdout.splitlines())
+            failed_tests = [items[0] for items in split_lines
+                            if len(items) == 4 and items[2] in fail_status]
+        else:
+            # Legacy runltp execution path
+            self.args += (" -q -p -l %s -C %s -d %s -S %s"
+                          % (logfile, failcmdfile, self.teststmpdir,
+                             skipfilepath))
+            if self.mem_leak:
+                self.args += " -M %s" % self.mem_leak
+            self.ltpbin_path = os.path.join(self.ltpbin_dir, 'runltp')
+            # Apply IDcheck.sh workaround for runltp
+            with open(self.ltpbin_path, 'r') as lfile:
+                data = lfile.read()
+                data = data.replace("    ${LTPROOT}/IDcheck.sh || \\",
+                                    "    echo -e \"y\" | ${LTPROOT}/IDcheck.sh || \\")
+            with open(self.ltpbin_path, 'w') as ofile:
+                ofile.write(data)
+            cmd = '%s %s' % (self.ltpbin_path, self.args)
+            process.run(cmd, ignore_status=True)
+            # Walk the ltp.log and try detect failed tests from lines like these:
+            # msgctl04                                           FAIL       2
+            with open(logfile, 'r') as file_p:
+                lines = file_p.readlines()
+                failed_tests = []
+                for line in lines:
+                    if 'FAIL' in line:
+                        value = re.split(r'\s+', line)
+                        failed_tests.append(value[0])
+
+        if failed_tests:
+            self.fail("LTP tests failed: %s" % ", ".join(failed_tests))
 
         error = dmesg.collect_errors_dmesg(['WARNING: CPU:', 'Oops', 'Segfault',
                                             'soft lockup', 'Unable to handle'])

--- a/generic/ltp.py.data/ltp-fs.yaml
+++ b/generic/ltp.py.data/ltp-fs.yaml
@@ -1,6 +1,7 @@
 url: 'https://github.com/linux-test-project/ltp/archive/master.zip'
 skipfileurl: "null"
-runltp: !mux
+use_kirk: True
+kirk: !mux
     fs:
         args: '-f fs'
     fs_perms_simple:

--- a/generic/ltp.py.data/ltp-mem.yaml
+++ b/generic/ltp.py.data/ltp-mem.yaml
@@ -1,6 +1,6 @@
-mem_leak: 0
+use_kirk: True
 general: !mux
-    runltp: !mux
+    kirk: !mux
         mm:
             args: '-f mm'
             overcommit: True

--- a/generic/ltp.py.data/ltp-net.yaml
+++ b/generic/ltp.py.data/ltp-net.yaml
@@ -1,9 +1,10 @@
-peer_public_ip: 
-peer_password: 
-peer_user: 
-two_host_configuration : 
-runltp: !mux
-    script: 'runltp'
+peer_public_ip:
+peer_password:
+peer_user:
+two_host_configuration :
+use_kirk: True
+kirk: !mux
+    script: 'kirk'
     net.ipv6:
         args: '-f net.ipv6'
     net.ipv6_lib:

--- a/generic/ltp.py.data/ltp-sched.yaml
+++ b/generic/ltp.py.data/ltp-sched.yaml
@@ -1,4 +1,5 @@
-runltp:
-    script: 'runltp'
+use_kirk: True
+kirk:
+    script: 'kirk'
     sched:
         args: '-f sched'

--- a/generic/ltp.py.data/ltp-security-stress.yaml
+++ b/generic/ltp.py.data/ltp-security-stress.yaml
@@ -1,5 +1,6 @@
-runltp: !mux
-    script: 'runltp'
+use_kirk: True
+kirk: !mux
+    script: 'kirk'
     net_stress.ipsec_dccp:
         args: '-f net_stress.ipsec_dccp'
     net_stress.ipsec_icmp:

--- a/generic/ltp.py.data/ltp-security.yaml
+++ b/generic/ltp.py.data/ltp-security.yaml
@@ -1,5 +1,6 @@
-runltp: !mux
-    script: 'runltp'
+use_kirk: True
+kirk: !mux
+    script: 'kirk'
     crashme:
         args: '-f crashme'
     crypto:

--- a/generic/ltp.py.data/ltp-syscalls.yaml
+++ b/generic/ltp.py.data/ltp-syscalls.yaml
@@ -1,6 +1,7 @@
 mem_leak: 0
 url: 'https://github.com/linux-test-project/ltp/archive/master.zip'
 skipfileurl: "null"
-runltp: !mux
+use_kirk: True
+kirk: !mux
     syscalls:
         args: '-f syscalls'

--- a/generic/ltp.py.data/ltp-tracing.yaml
+++ b/generic/ltp.py.data/ltp-tracing.yaml
@@ -1,4 +1,5 @@
-runltp:
-    script: 'runltp'
+use_kirk: True
+kirk:
+    script: 'kirk'
     tracing:
         args: '-f tracing'

--- a/generic/ltp.py.data/ltp.yaml
+++ b/generic/ltp.py.data/ltp.yaml
@@ -1,7 +1,8 @@
 mem_leak: 0
 url: 'https://github.com/linux-test-project/ltp/archive/master.zip'
 skipfileurl: "null"
-runltp: !mux
+use_kirk: True
+kirk: !mux
     syscalls:
         args: '-f syscalls'
     mm:

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -23,6 +23,7 @@ LTP Filesystem tests
 """
 
 
+import shutil
 import os
 import time
 from avocado import Test
@@ -69,6 +70,7 @@ class LtpFs(Test):
 
         self.fstype = self.params.get('fs', default='ext4')
         self.args = self.params.get('args', default='')
+        self.use_kirk = self.params.get('use_kirk', default=True)
         smm = SoftwareManager()
         detected_distro = distro.detect()
         packages = ['gcc', 'make', 'automake', 'autoconf']
@@ -121,6 +123,23 @@ class LtpFs(Test):
         archive.extract(tarball, self.teststmpdir)
         ltp_dir = os.path.join(self.teststmpdir, "ltp-master")
         os.chdir(ltp_dir)
+
+        # Initialize and update kirk submodule only if use_kirk is True
+        if self.use_kirk:
+            kirk_dir = f"{ltp_dir}/tools/kirk/kirk-src/"
+            if os.path.exists(kirk_dir):
+                shutil.rmtree(kirk_dir)
+
+            # Initialize and update kirk submodule
+            process.system('git init', shell=True, ignore_status=True)
+            process.system('git submodule add \
+                           https://github.com/linux-test-project/kirk.git \
+                           tools/kirk/kirk-src',
+                           shell=True, ignore_status=True)
+            process.system('git submodule update --init \
+                           --recursive tools/kirk/kirk-src',
+                           shell=True, ignore_status=True)
+
         build.make(ltp_dir, extra_args='autotools')
         self.ltpbin_dir = os.path.join(ltp_dir, 'bin')
         if not os.path.isdir(self.ltpbin_dir):
@@ -129,6 +148,16 @@ class LtpFs(Test):
                            self.ltpbin_dir, ignore_status=True)
             build.make(ltp_dir)
             build.make(ltp_dir, extra_args='install')
+
+            # Verify the appropriate runner is installed
+            if self.use_kirk:
+                kirk_path = os.path.join(self.ltpbin_dir, 'kirk')
+                if not os.path.exists(kirk_path):
+                    self.cancel("kirk was not installed properly")
+            else:
+                runltp_path = os.path.join(self.ltpbin_dir, 'runltp')
+                if not os.path.exists(runltp_path):
+                    self.cancel("runltp was not installed properly")
 
     def create_raid(self, l_disk, l_raid_name):
         """
@@ -225,7 +254,8 @@ class LtpFs(Test):
         if wait.wait_for(is_raid_deleted, timeout=10):
             self.log.info("software raid  %s deleted" % self.raid_name)
         else:
-            self.err_mesg.extend(["failed to delete swraid %s" % self.raid_name])
+            self.err_mesg.extend(["failed to delete swraid %s" %
+                                  self.raid_name])
 
     def delete_lv(self):
         """
@@ -317,17 +347,35 @@ class LtpFs(Test):
         '''
         logfile = os.path.join(self.logdir, 'ltp.log')
         failcmdfile = os.path.join(self.logdir, 'failcmdfile')
-        self.args += (" -q -p -l %s -C %s -d %s"
-                      % (logfile, failcmdfile, self.dir))
-        self.log.info("Args = %s", self.args)
-        self.ltpbin_path = os.path.join(self.ltpbin_dir, 'runltp')
-        with open(self.ltpbin_path, 'r') as lfile:
-            data = lfile.read()
-            data = data.replace("    ${LTPROOT}/IDcheck.sh || \\", "    echo -e \"y\" | ${LTPROOT}/IDcheck.sh || \\")
-        with open(self.ltpbin_path, 'w') as ofile:
-            ofile.write(data)
-        cmd = '%s %s' % (self.ltpbin_path, self.args)
-        result = process.run(cmd, ignore_status=True)
+        result = None
+
+        if self.use_kirk:
+            # Kirk runner execution path
+            self.args += (" -v -d %s" % (self.dir))
+            self.log.info("Args = %s", self.args)
+            self.kirkbin_path = os.path.join(self.ltpbin_dir, 'kirk')
+            # Set LTPROOT environment variable to tell kirk where
+            # LTP is installed
+            env_vars = os.environ.copy()
+            env_vars['LTPROOT'] = self.ltpbin_dir
+            cmd = '%s %s' % (self.kirkbin_path, self.args)
+            result = process.run(cmd, ignore_status=True, env=env_vars)
+        else:
+            # Legacy runltp execution path
+            self.args += (" -q -p -l %s -C %s -d %s"
+                          % (logfile, failcmdfile, self.dir))
+            self.log.info("Args = %s", self.args)
+            self.ltpbin_path = os.path.join(self.ltpbin_dir, 'runltp')
+            # Apply IDcheck.sh workaround for runltp
+            with open(self.ltpbin_path, 'r') as lfile:
+                data = lfile.read()
+                data = data.replace("    ${LTPROOT}/IDcheck.sh || \\",
+                                    "    echo -e \"y\" | ${LTPROOT}/IDcheck.sh || \\")
+            with open(self.ltpbin_path, 'w') as ofile:
+                ofile.write(data)
+            cmd = '%s %s' % (self.ltpbin_path, self.args)
+            result = process.run(cmd, ignore_status=True)
+
         # Walk the stdout and try detect failed tests from lines
         # like these:
         # aio01       5  TPASS  :  Test 5: 10 reads and
@@ -358,4 +406,5 @@ class LtpFs(Test):
             self.delete_raid()
         dmesg.clear_dmesg()
         if self.err_mesg:
-            self.log.warning("test failed due to following errors %s" % self.err_mesg)
+            self.log.warning("test failed due to following errors %s" %
+                             self.err_mesg)

--- a/io/disk/ltp_fs.py.data/README.txt
+++ b/io/disk/ltp_fs.py.data/README.txt
@@ -1,10 +1,10 @@
-This program downloads the LTP test suite, compiles it and runs filesystem related tests the following tests by invoking the runltp test script.
+This program downloads the LTP test suite, compiles it and runs filesystem related tests the following tests by invoking the kirk test script.
 * fs_di
 * fs_inod
 * fs_fill
 * fs_perm
 
-This program creates a filesystem on a disk and then mounts it to the mount point specified and then the runltp script is triggered that runs the 2 tests on the mount point.
+This program creates a filesystem on a disk and then mounts it to the mount point specified and then the kirk script is triggered that runs the 2 tests on the mount point.
 The disk and the mount point has to be provided by the user. Do not pass the root disk. Make sure an empty disk is passed.
 The user can also give a filesystem of choice to be created and to start the test.
 

--- a/io/disk/ltp_fs.py.data/ltp_fs_runltp.yaml
+++ b/io/disk/ltp_fs.py.data/ltp_fs_runltp.yaml
@@ -1,15 +1,15 @@
 disk:
 dir:
-use_kirk: True
+use_kirk: False
 args: !mux
     fs_di:
-        args: '-f fs -p fs_di'
+        args: '-s fs_di'
     fs_inod:
-        args: '-f fs -p fs_inod'
+        args: '-s fs_inod'
     fs_fill:
-        args: '-f fs -p fs_fill'
+        args: '-s fs_fill'
     fs_perm:
-        args: '-f fs_perms_simple -p fs_perm'
+        args: '-s fs_perm'
 fs: !mux
     ext4:
         fs: 'ext4'


### PR DESCRIPTION
Following LTP commit 6efd3605d which removed runltp, update
avocado-misc-tests to use kirk as the test runner instead.
V4 Changes:
Keep backward compatibility support for runltp to be used with older LTP releases.
V3 Changes:
Kirk uses the LTPROOT environment variable (defaulting to /opt/ltp) to locate LTP, but avocado-misc-tests installs it to a custom location. Modified generic/ltp.py to set the LTPROOT environment variable before running kirk:
V2 Changes:
Updated command line options used in YAML to match with kirk
V1 Changes:
Updated generic/ltp.py and io/disk/ltp_fs.py to download kirk submodule and use kirk instead of runltp
Removed IDcheck.sh workaround (no longer needed with kirk)
Added kirk installation verification
Updated YAML configuration files to use 'kirk' key instead of 'runltp'
Updated script references from 'runltp' to 'kirk' in YAML files
Updated command line parameters to match with options supported by kirk.
Updated log analysis logic to parse kirk generated output

Kirk supports some of command-line options as runltp (-f, -d, -S,
etc.) and is now the official LTP test runner.

Reference: https://github.com/linux-test-project/kirk
Code changes assisted by AI

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>