### PR TITLE
Adding seperate yaml files for CR and CI.

### DIFF
--- a/kernel/kselftest.py.data/kselftest_CI.yaml
+++ b/kernel/kselftest.py.data/kselftest_CI.yaml
@@ -1,0 +1,13 @@
+component: !mux
+    mm:
+        comp: 'mm'
+    mm_powerpc:
+        comp: 'powerpc/mm'
+    cpu_hotplug:
+        comp: 'cpu-hotplug'
+    memory_hotplug:
+        comp: 'memory-hotplug'
+run_type: !mux
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"

--- a/kernel/kselftest.py.data/kselftest_CR.yaml
+++ b/kernel/kselftest.py.data/kselftest_CR.yaml
@@ -1,0 +1,12 @@
+component: !mux
+    mm:
+        comp: 'mm'
+    mm_powerpc:
+        comp: 'powerpc/mm'
+    cpu_hotplug:
+        comp: 'cpu-hotplug'
+    memory_hotplug:
+        comp: 'memory-hotplug'
+run_type: !mux
+    distro:
+        type: 'distro'


### PR DESCRIPTION
Adding kselftest_CR.yaml file to run on distros and kselftest_CI.yaml to run on upstream. Have added and tested mm, cpu-hotplug and mem-hotplug