### PR TITLE
io/iommu: Cancel IOMMU domain change tests on SNP hosts

### DIFF
--- a/io/iommu/iommu_tests.py
+++ b/io/iommu/iommu_tests.py
@@ -116,6 +116,21 @@ class IommuTest(Test):
         else:
             self.log.info("Device is in default domain")
 
+    # TODO: Move this function to avocado utility.
+    def verify_snp_host(self):
+        """
+        Verify if SNP feature is enabled on the host
+        """
+        secure_module_path = "/sys/module/kvm_amd/parameters/sev_snp"
+        try:
+            with open(secure_module_path) as f:
+                output = f.read().strip()
+                if output not in ("Y", "y", "1"):
+                    return False
+            return True
+        except IOError:
+            return False
+
     def test_unbind_bind(self):
         """
         Test device for unbind and bind
@@ -136,6 +151,9 @@ class IommuTest(Test):
         """
         Test device for unbind, change domain of device and bind
         """
+        if self.verify_snp_host():
+            self.cancel("IOMMU domain change is not supported on SNP hosts")
+
         for pci_addr in self.pci_devices.split(" "):
             driver, def_dom = self.get_params(pci_addr)
             self.log.info("PCI_ID = %s", pci_addr)
@@ -172,6 +190,9 @@ class IommuTest(Test):
         """
         Test device for unbind, change domain of group(n times) and bind
         """
+        if self.verify_snp_host():
+            self.cancel("IOMMU domain change is not supported on SNP hosts")
+
         for pci_addr in self.pci_devices.split(" "):
             driver, def_dom = self.get_params(pci_addr)
             for _ in range(self.count):
@@ -229,6 +250,9 @@ class IommuTest(Test):
         """
         Test device for unbind, change domain of group, bind and rescan
         """
+        if self.verify_snp_host():
+            self.cancel("IOMMU domain change is not supported on SNP hosts")
+
         for pci_addr in self.pci_devices.split(" "):
             driver, def_dom = self.get_params(pci_addr)
             self.log.info("PCI_ID = %s", pci_addr)


### PR DESCRIPTION
IOMMU domain change is not supported on SNP enabled hosts machine. 

Add verify_snp_host() to detect SNP support enabled on host and cancel tests having IOMMU domain change step.
```
JOB ID     : 171de78d1fc5ac9af03115ddab5e7bf60cc56856
JOB LOG    : /home/results/job-2026-03-30T13.31-171de78/job.log
(1/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind: STARTED
(1/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind: PASS (5.23 s)
(2/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind: STARTED
(2/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind: CANCEL: IOMMU domain change is not supported on SNP hosts (0.13 s)
(3/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind: STARTED
(3/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_ntimes_bind: CANCEL: IOMMU domain change is not supported on SNP hosts (0.15 s)
(4/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan: STARTED
(4/6) /home/suneeth/elves/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_bind_rescan: PASS (5.31 s)
(5/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan: STARTED
(5/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_unbind_changedomain_bind_rescan: CANCEL: IOMMU domain change is not supported on SNP hosts (0.14 s)
(6/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_reset_rescan: STARTED
(6/6) /home/tests/avocado-misc-tests/io/iommu/iommu_tests.py:IommuTest.test_reset_rescan: PASS (0.35 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 3
```