### PR TITLE
cpu: Add scheduler load balancing test with wait_stressor

### DIFF
--- a/cpu/wait_stressor_perf.py
+++ b/cpu/wait_stressor_perf.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2026 IBM
+# Author: Samir M <samir@linux.ibm.com>
+#
+# Test Description:
+# This test runs wait_stressor.c to generate load balancing stress
+# and captures perf.data to analyze scheduler functions:
+# - enqueue_task_fair
+# - newidle_balance
+# Expected: Both functions should consume less than 2.0% of cycles
+# Note: This test is only applicable for SUSE Linux distributions
+
+import os
+import re
+
+from avocado import Test
+from avocado.utils import process, distro
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class WaitStressorPerf(Test):
+    """
+    Test load balancing with wait_stressor and perf monitoring.
+    Validates that enqueue_task_fair and newidle_balance consume
+    less than 2.0% of CPU cycles.
+
+    Note: This test is only applicable for SUSE Linux distributions.
+
+    :avocado: tags=cpu,scheduler,perf,loadbalancing,suse
+    """
+
+    def setUp(self):
+        """
+        Setup test environment and dependencies
+        Note: This test is only applicable for SUSE Linux distributions
+        """
+        distro_name = distro.detect().name
+        if 'SuSE' not in distro_name and 'SUSE' not in distro_name:
+            self.cancel(
+                "This test is only applicable for SUSE Linux distributions")
+
+        sm = SoftwareManager()
+        deps = ['gcc', 'make', 'perf']
+        for package in deps:
+            if not sm.check_installed(package) and not sm.install(package):
+                self.cancel("%s is needed for the test to be run" % package)
+
+        self.duration = self.params.get('duration', default=30)
+        self.threshold = self.params.get('threshold', default=2.0)
+
+        source_file = os.path.join(os.path.dirname(__file__),
+                                   'wait_stressor_perf.py.data',
+                                   'wait_stressor.c')
+        self.binary = os.path.join(self.teststmpdir, 'wait_stressor')
+        self.perf_data = os.path.join(self.teststmpdir, 'perf.data')
+
+        self.log.info("Compiling wait_stressor.c")
+        compile_cmd = f"gcc -o {self.binary} {source_file} -Wall"
+        result = process.run(compile_cmd, shell=True, ignore_status=True)
+        if result.exit_status != 0:
+            self.fail(
+                f"Failed to compile wait_stressor.c: {result.stderr.decode()}")
+
+    def test(self):
+        """
+        Main test execution:
+        1. Start wait_stressor in background
+        2. Run perf record to capture data
+        3. Analyze perf report for target functions
+        4. Validate cycle consumption is below threshold
+        """
+        self.log.info(f"Starting wait_stressor for {self.duration} seconds")
+        stressor_cmd = f"timeout {self.duration} {self.binary}"
+        stressor_process = process.SubProcess(stressor_cmd, shell=True)
+        stressor_process.start()
+
+        import time
+        time.sleep(2)
+
+        self.log.info("Recording perf data")
+        perf_record_cmd = (
+            f"perf record -a -g "
+            f"-o {self.perf_data} -- sleep {self.duration - 3}"
+        )
+
+        try:
+            result = process.run(
+                perf_record_cmd, shell=True, ignore_status=True)
+            if result.exit_status != 0:
+                self.log.warning(
+                    f"perf record warning: {result.stderr.decode()}")
+        except Exception as e:
+            self.log.error(f"perf record failed: {str(e)}")
+            stressor_process.terminate()
+            self.fail("Failed to record perf data")
+
+        stressor_process.wait()
+
+        self.log.info("Analyzing perf data for target scheduler functions")
+        target_functions = ['enqueue_task_fair', 'newidle_balance']
+        results = {}
+
+        for func in target_functions:
+            perf_report_cmd = (
+                f"perf report -i {self.perf_data} --stdio --no-children "
+                f"--symbol-filter={func} 2>/dev/null | head -20"
+            )
+
+            try:
+                result = process.run(
+                    perf_report_cmd, shell=True, ignore_status=True)
+                if result.exit_status == 0:
+                    output = result.stdout.decode()
+                    self.log.debug(f"perf report output for {func}:\n{output}")
+
+                    # Parse the output for this function
+                    for line in output.splitlines():
+                        if func in line and '%' in line:
+                            # Match pattern like: "0.09%  swapper,
+                            # [kernel.vmlinux]  [k] enqueue_task_fair"
+                            match = re.match(r'\s*([\d.]+)%', line)
+                            if match:
+                                percentage = float(match.group(1))
+                                results[func] = percentage
+                                self.log.info(f"Found {func}: {percentage}%")
+                                break
+            except Exception as e:
+                self.log.warning(
+                    f"Failed to get perf report for {func}: {str(e)}")
+
+        for func in target_functions:
+            if func not in results:
+                self.log.info(f"{func}: Not detected (< 0.01% or not called)")
+                results[func] = 0.0
+
+        self.log.info("=" * 60)
+        self.log.info("RESULTS:")
+        self.log.info("=" * 60)
+
+        target_functions = ['enqueue_task_fair', 'newidle_balance']
+        failures = []
+
+        for func in target_functions:
+            if func in results:
+                percentage = results[func]
+                status = "PASS" if percentage < self.threshold else "FAIL"
+                self.log.info(f"{func}: {percentage}% [{status}]")
+
+                if percentage >= self.threshold:
+                    failures.append(
+                        f"{func} consumed {percentage}% (threshold:\
+                        {self.threshold}%)"
+                    )
+            else:
+                self.log.warning(f"{func}: Not found in perf report")
+                # Not finding the function might be acceptable if,
+                # load is very low
+                self.log.info(f"{func}: 0.00% [PASS - not detected]")
+
+        self.log.info("=" * 60)
+        self.log.info(f"Threshold: < {self.threshold}%")
+        self.log.info("=" * 60)
+
+        if failures:
+            self.fail(
+                f"Load balancing functions exceeded threshold:\n" +
+                "\n".join(failures)
+            )
+        else:
+            self.log.info("SUCCESS: All functions below threshold")
+
+    def tearDown(self):
+        """
+        Cleanup test artifacts
+        """
+        # Clean up perf.data if it exists
+        if hasattr(self, 'perf_data') and os.path.exists(self.perf_data):
+            try:
+                os.remove(self.perf_data)
+            except Exception as e:
+                self.log.warning(f"Failed to remove perf.data: {str(e)}")

--- a/cpu/wait_stressor_perf.py
+++ b/cpu/wait_stressor_perf.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2026 IBM
+# Author: Samir M <samir@linux.ibm.com>
+#
+# Test Description:
+# This test runs wait_stressor.c to generate load balancing stress
+# and captures perf.data to analyze scheduler functions:
+# - enqueue_task_fair
+# - newidle_balance
+# Expected: Both functions should consume less than 2.0% of cycles
+# Note: This test is only applicable for SUSE Linux distributions
+
+import os
+import re
+import time
+
+from avocado import Test
+from avocado.utils import process, distro
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class WaitStressorPerf(Test):
+    """
+    Test load balancing with wait_stressor and perf monitoring.
+    Validates that enqueue_task_fair and newidle_balance consume
+    less than 2.0% of CPU cycles.
+
+    Note: This test is only applicable for SUSE Linux distributions.
+
+    :avocado: tags=cpu,scheduler,perf,loadbalancing,suse
+    """
+
+    def setUp(self):
+        """
+        Setup test environment and dependencies
+        Note: This test is only applicable for SUSE Linux distributions
+        """
+        distro_name = distro.detect().name.lower()
+        if 'suse' not in distro_name:
+            self.cancel(
+                "This test is only applicable for SUSE Linux distributions")
+
+        sm = SoftwareManager()
+        deps = ['gcc', 'make', 'perf']
+        for package in deps:
+            if not sm.check_installed(package) and not sm.install(package):
+                self.cancel("%s is needed for the test to be run" % package)
+
+        self.duration = self.params.get('duration', default=30)
+        self.threshold = self.params.get('threshold', default=2.0)
+
+        source_file = os.path.join(os.path.dirname(__file__),
+                                   'wait_stressor_perf.py.data',
+                                   'wait_stressor.c')
+        self.binary = os.path.join(self.teststmpdir, 'wait_stressor')
+        self.perf_data = os.path.join(self.teststmpdir, 'perf.data')
+
+        self.log.info("Compiling wait_stressor.c")
+        compile_cmd = f"gcc -o {self.binary} {source_file} -Wall"
+        result = process.run(compile_cmd, shell=True, ignore_status=True)
+        if result.exit_status != 0:
+            self.fail(
+                f"Failed to compile wait_stressor.c: {result.stderr.decode()}")
+
+    def test(self):
+        """
+        Main test execution:
+        1. Start wait_stressor in background
+        2. Run perf record to capture data
+        3. Analyze perf report for target functions
+        4. Validate cycle consumption is below threshold
+        """
+        self.log.info(f"Starting wait_stressor for {self.duration} seconds")
+        stressor_cmd = f"timeout {self.duration} {self.binary}"
+        stressor_process = process.SubProcess(stressor_cmd, shell=True)
+        stressor_process.start()
+
+        time.sleep(2)
+
+        self.log.info("Recording perf data")
+        perf_record_cmd = (
+            f"perf record -a -g "
+            f"-o {self.perf_data} -- sleep {self.duration - 3}"
+        )
+
+        try:
+            result = process.run(
+                perf_record_cmd, shell=True, ignore_status=True)
+            if result.exit_status != 0:
+                self.log.warning(
+                    f"perf record warning: {result.stderr.decode()}")
+        except Exception as e:
+            self.log.error(f"perf record failed: {str(e)}")
+            stressor_process.terminate()
+            try:
+                stressor_process.wait(timeout=5)
+            except process.CmdError:
+                self.log.warning(
+                    "Stressor didn't terminate, killing forcefully")
+                stressor_process.kill()
+                stressor_process.wait()
+            self.fail("Failed to record perf data")
+
+        stressor_process.wait()
+
+        if not os.path.exists(self.perf_data):
+            self.fail(f"perf.data file not created at {self.perf_data}")
+
+        # Check if kernel symbols are available
+        kallsyms_check = "grep -E \
+                'enqueue_task_fair|newidle_balance' /proc/kallsyms"
+        result = process.run(kallsyms_check, shell=True, ignore_status=True)
+        if result.exit_status != 0:
+            self.log.warning(
+                "Target scheduler functions not found in /proc/kallsyms. "
+                "Kernel may not have these symbols or CONFIG_KALLSYMS is "
+                "disabled."
+            )
+
+        self.log.info("Analyzing perf data for target scheduler functions")
+        target_functions = ['enqueue_task_fair', 'newidle_balance']
+        results = {}
+
+        for func in target_functions:
+            perf_report_cmd = (
+                f"perf report -i {self.perf_data} --stdio --no-children "
+                f"--symbol-filter={func} 2>/dev/null | head -20"
+            )
+
+            try:
+                result = process.run(
+                    perf_report_cmd, shell=True, ignore_status=True)
+                if result.exit_status == 0:
+                    output = result.stdout.decode()
+                    self.log.debug(f"perf report output for {func}:\n{output}")
+
+                    # Parse the output for this function
+                    for line in output.splitlines():
+                        if func in line and '%' in line:
+                            # Match pattern like: "0.09%  swapper
+                            # [kernel.vmlinux][k] enqueue_task_fair"
+                            match = re.match(r'\s*([\d.]+)%', line)
+                            if match:
+                                percentage = float(match.group(1))
+                                results[func] = percentage
+                                self.log.info(f"Found {func}: {percentage}%")
+                                break
+            except Exception as e:
+                self.log.warning(
+                    f"Failed to get perf report for {func}: {str(e)}")
+
+        for func in target_functions:
+            if func not in results:
+                self.log.info(f"{func}: Not detected (< 0.01% or not called)")
+                results[func] = 0.0
+
+        self.log.info("=" * 60)
+        self.log.info("RESULTS:")
+        self.log.info("=" * 60)
+
+        failures = []
+
+        for func in target_functions:
+            if func in results:
+                percentage = results[func]
+                status = "PASS" if percentage < self.threshold else "FAIL"
+                self.log.info(f"{func}: {percentage}% [{status}]")
+
+                if percentage >= self.threshold:
+                    failures.append(
+                        f"{func} consumed {percentage}% "
+                        f"(threshold: {self.threshold}%)"
+                    )
+            else:
+                self.log.warning(f"{func}: Not found in perf report")
+                self.log.info(f"{func}: 0.00% [PASS - not detected]")
+
+        self.log.info("=" * 60)
+        self.log.info(f"Threshold: < {self.threshold}%")
+        self.log.info("=" * 60)
+
+        if failures:
+            self.fail(
+                f"Load balancing functions exceeded threshold:\n" +
+                "\n".join(failures)
+            )
+        else:
+            self.log.info("SUCCESS: All functions below threshold")
+
+    def tearDown(self):
+        """
+        Cleanup test artifacts
+        """
+        if hasattr(self, 'perf_data') and os.path.exists(self.perf_data):
+            try:
+                os.remove(self.perf_data)
+            except Exception as e:
+                self.log.warning(f"Failed to remove perf.data: {str(e)}")

--- a/cpu/wait_stressor_perf.py.data/README.md
+++ b/cpu/wait_stressor_perf.py.data/README.md
@@ -1,0 +1,219 @@
+# Wait Stressor Performance Test
+
+## Overview
+
+This test validates Linux kernel scheduler load balancing performance by running the `wait_stressor.c` program while monitoring scheduler functions with `perf`. The test ensures that critical scheduler functions consume minimal CPU cycles during load balancing operations.
+
+**Note: This test is only applicable for SUSE Linux distributions.**
+
+## Performance Optimization
+
+The test uses targeted perf analysis with `--symbol-filter` to query only specific scheduler functions, making it fast and efficient:
+- Avoids generating massive full perf reports
+- Queries only the 2 target functions: `enqueue_task_fair` and `newidle_balance`
+- Completes analysis in seconds instead of minutes
+- Keeps logs clean and readable
+
+## Test Description
+
+The test performs the following steps:
+
+1. **Compiles wait_stressor.c** - A stress test program that creates 100 child processes, each spawning runner and killer processes that continuously send SIGSTOP/SIGCONT signals
+2. **Runs wait_stressor** - Generates load balancing stress by creating multiple processes that exercise the wait system call
+3. **Captures perf data** - Records performance data using `perf record` during the stress test execution
+4. **Analyzes results** - Uses `perf report --symbol-filter` to efficiently query only the target scheduler functions and extract their cycle percentages
+
+## Target Functions
+
+The test monitors two critical scheduler functions:
+
+1. **enqueue_task_fair** - Handles task enqueueing in the Completely Fair Scheduler (CFS)
+2. **newidle_balance** - Performs load balancing when a CPU becomes idle
+
+## Expected Results
+
+Both functions should consume **less than 2.0%** of CPU cycles:
+
+```
+Expected output example:
+0.09%  swapper  [kernel.vmlinux]  [k] enqueue_task_fair
+0.09%  wait     [kernel.vmlinux]  [k] newidle_balance
+```
+
+If either function exceeds the 2.0% threshold, it indicates potential scheduler inefficiency or load balancing issues.
+
+## Source
+
+The wait_stressor.c program is based on Aboorva Devarajan's implementation.
+
+## Prerequisites
+
+### Required Packages
+
+- **gcc** - For compiling wait_stressor.c
+- **make** - Build tools
+- **perf** - Linux performance analysis tool (SUSE package)
+
+### System Requirements
+
+- **SUSE Linux distribution** (SLES, openSUSE)
+- Linux kernel with scheduler tracepoints enabled
+- Root or CAP_SYS_ADMIN privileges for perf recording
+- Sufficient CPU cores for load balancing (recommended: 4+ cores)
+
+## Configuration
+
+The test can be configured using the YAML file (`wait_stressor_perf.yaml`):
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `duration` | 30 | Test duration in seconds |
+| `threshold` | 2.0 | Maximum acceptable cycle percentage |
+
+### Configuration Variants
+
+#### Default Configuration
+```yaml
+duration: 30
+threshold: 2.0
+```
+
+#### Short Test
+```yaml
+duration: 15
+threshold: 2.0
+```
+
+#### Long Test with Relaxed Threshold
+```yaml
+duration: 60
+threshold: 4.0
+```
+
+## Running the Test
+
+### Basic Execution
+
+```bash
+avocado run wait_stressor_perf.py
+```
+
+### With Custom Configuration
+
+```bash
+avocado run wait_stressor_perf.py --mux-yaml wait_stressor_perf.py.data/wait_stressor_perf.yaml
+```
+
+### With Specific Variant
+
+```bash
+avocado run wait_stressor_perf.py --mux-yaml wait_stressor_perf.py.data/wait_stressor_perf.yaml --mux-filter-only /run/duration/long
+```
+
+### With Custom Parameters
+
+```bash
+avocado run wait_stressor_perf.py -p duration=45 -p threshold=3.5
+```
+
+## Output
+
+### Test Logs
+
+The test generates the following output files in the test log directory:
+
+1. **perf_report.txt** - Full perf report output
+2. **test.log** - Detailed test execution log
+3. **debug.log** - Debug information
+
+### Console Output
+
+```
+INFO | Analyzing perf data for target scheduler functions
+INFO | Found enqueue_task_fair: 0.09%
+INFO | Found newidle_balance: 0.09%
+INFO | ============================================================
+INFO | RESULTS:
+INFO | ============================================================
+INFO | enqueue_task_fair: 0.09% [PASS]
+INFO | newidle_balance: 0.09% [PASS]
+INFO | ============================================================
+INFO | Threshold: < 2.0%
+INFO | ============================================================
+INFO | SUCCESS: All functions below threshold
+```
+
+### Log Files
+
+The test generates minimal log output:
+- **debug.log** - Contains only targeted function analysis (not full perf report)
+- **test.log** - Test execution summary
+- No separate perf_report.txt file (optimization to reduce disk I/O)
+
+## Troubleshooting
+
+### Permission Denied for perf
+
+If you encounter permission errors:
+
+```bash
+# Temporarily allow perf for non-root users
+sudo sysctl -w kernel.perf_event_paranoid=-1
+
+# Or run test with sudo
+sudo avocado run wait_stressor_perf.py
+```
+
+### Functions Not Found in perf Report
+
+If a function shows 0.0% or "Not detected":
+- The function consumed less than 0.01% of cycles (excellent performance)
+- The load may be too low to trigger significant scheduler activity
+- Kernel symbols may not be available
+
+This is typically a PASS condition as it indicates minimal scheduler overhead.
+
+To increase scheduler activity, try:
+- Increasing test duration
+- Running on a system with more CPU cores
+- Ensuring the system has other background load
+
+### Compilation Errors
+
+Ensure gcc and development headers are installed on SUSE:
+
+```bash
+# SUSE/openSUSE
+sudo zypper install gcc make perf
+```
+
+### Test Skipped on Non-SUSE Systems
+
+This test will be automatically skipped (cancelled) if run on non-SUSE distributions with the message:
+```
+CANCEL: This test is only applicable for SUSE Linux distributions
+```
+
+## Test Tags
+
+- `cpu` - CPU/scheduler related test
+- `scheduler` - Scheduler specific test
+- `perf` - Uses perf tool
+- `loadbalancing` - Load balancing validation
+- `suse` - SUSE Linux specific test
+
+## References
+
+- Linux Scheduler Documentation: https://www.kernel.org/doc/html/latest/scheduler/
+- Perf Wiki: https://perf.wiki.kernel.org/
+- CFS Scheduler: https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt
+
+## Author
+
+- Aboorva Devarajan <aboorvad@linux.vnet.ibm.com>
+
+## License
+
+This test is part of avocado-misc-tests and is licensed under the GNU General Public License v2.0 or later.

--- a/cpu/wait_stressor_perf.py.data/wait_stressor.c
+++ b/cpu/wait_stressor_perf.py.data/wait_stressor.c
@@ -1,0 +1,109 @@
+/*
+ * Wait System Call Stressor
+ *
+ * Copyright: 2024 IBM
+ * Author: Aboorva Devarajan <aboorvad@linux.ibm.com>
+ *
+ * This program creates multiple processes that stress the wait system call
+ * by continuously sending SIGSTOP/SIGCONT signals, exercising scheduler
+ * load balancing functionality.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define TIMEOUT_INTERVAL (0.0025)
+#define ONE_MILLIONTH (1.0E-6)
+#define PROCESS_COUNT 100
+
+pid_t spawnNewProcess(void (*func)(const pid_t pid), const pid_t pid_arg) {
+	pid_t pid = fork();
+	if (pid == 0) {
+		func(pid_arg);
+		_exit(EXIT_SUCCESS);
+	}
+	return pid;
+}
+
+void killerProcess(const pid_t pid) {
+	pid_t parentPid = getppid();
+	while (1) {
+		//printf("Killer process with PID: %d is stopping process with PID: %d\n", getpid(), pid);
+		kill(pid, SIGSTOP);
+		sleep(0);
+		kill(pid, SIGCONT);
+	}
+	printf("Killer process with PID: %d is sending SIGALRM to its parent\n", getpid());
+	kill(getppid(), SIGALRM);
+	_exit(EXIT_SUCCESS);
+}
+
+void runnerProcess(const pid_t pid) {
+	(void)pid;
+	while (1) {
+		//printf("Runner process with PID: %d is pausing\n", getpid());
+		pause();
+	}
+	printf("Runner process with PID: %d is sending SIGALRM to its parent\n", getpid());
+	kill(getppid(), SIGALRM);
+	_exit(EXIT_SUCCESS);
+}
+
+int stressWaitSystemCall(void) {
+	int ret = EXIT_SUCCESS;
+	pid_t runnerPid, killerPid, waitReturn;
+	int options = WUNTRACED | WCONTINUED;
+	runnerPid = spawnNewProcess(runnerProcess, 0);
+	if (runnerPid < 0) {
+		fprintf(stderr, "Error spawning runner process: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+	killerPid = spawnNewProcess(killerProcess, runnerPid);
+	if (killerPid < 0) {
+		fprintf(stderr, "Error spawning killer process: %s\n", strerror(errno));
+		ret = EXIT_FAILURE;
+	}
+	do {
+		int status;
+		waitReturn = waitpid(runnerPid, &status, options);
+		if ((waitReturn < 0) && (errno != EINTR) && (errno != ECHILD)) {
+			break;
+		}
+		waitReturn = wait(&status);
+		if ((waitReturn < 0) && (errno != EINTR) && (errno != ECHILD)) {
+			break;
+		}
+	} while (1);
+	return ret;
+}
+
+int main(void) {
+	for (int i = 0; i < PROCESS_COUNT; i++) {
+		pid_t pid = fork();
+		if (pid == -1) {
+			perror("fork");
+			exit(EXIT_FAILURE);
+		} else if (pid == 0) {
+			printf("Main process has spawned a child with PID: %d\n", getpid());
+			stressWaitSystemCall();
+			exit(EXIT_SUCCESS);
+		}
+	}
+	for (int i = 0; i < PROCESS_COUNT; i++) {
+		printf("Main process is waiting for all children to exit\n");
+		wait(NULL);
+	}
+	printf("All child processes have exited\n");
+	return 0;
+}
+

--- a/cpu/wait_stressor_perf.py.data/wait_stressor.c
+++ b/cpu/wait_stressor_perf.py.data/wait_stressor.c
@@ -1,0 +1,105 @@
+/*
+ * Wait System Call Stressor
+ *
+ * Copyright: 2024 IBM
+ * Author: Aboorva Devarajan <aboorvad@linux.ibm.com>
+ *
+ * This program creates multiple processes that stress the wait system call
+ * by continuously sending SIGSTOP/SIGCONT signals, exercising scheduler
+ * load balancing functionality.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define PROCESS_COUNT 100
+
+pid_t spawnNewProcess(void (*func)(const pid_t pid), const pid_t pid_arg) {
+	pid_t pid = fork();
+	if (pid == -1) {
+		/* Fork failed */
+		return -1;
+	} else if (pid == 0) {
+		/* Child process */
+		func(pid_arg);
+		_exit(EXIT_SUCCESS);
+	}
+	/* Parent process - return child PID */
+	return pid;
+}
+
+void killerProcess(const pid_t pid) {
+	while (1) {
+		kill(pid, SIGSTOP);
+		sleep(0);
+		kill(pid, SIGCONT);
+	}
+}
+
+void runnerProcess(const pid_t pid) {
+	(void)pid;
+	while (1) {
+		pause();
+	}
+}
+
+int stressWaitSystemCall(void) {
+	int ret = EXIT_SUCCESS;
+	pid_t runnerPid, killerPid, waitReturn;
+	int options = WUNTRACED | WCONTINUED;
+	runnerPid = spawnNewProcess(runnerProcess, 0);
+	if (runnerPid < 0) {
+		fprintf(stderr, "Error spawning runner process: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+	killerPid = spawnNewProcess(killerProcess, runnerPid);
+	if (killerPid < 0) {
+		fprintf(stderr, "Error spawning killer process: %s\n", strerror(errno));
+		kill(runnerPid, SIGKILL);
+		waitpid(runnerPid, NULL, 0);
+		return EXIT_FAILURE;
+	}
+	do {
+		int status;
+		waitReturn = waitpid(runnerPid, &status, options);
+		if ((waitReturn < 0) && (errno != EINTR) && (errno != ECHILD)) {
+			break;
+		}
+		waitReturn = wait(&status);
+		if ((waitReturn < 0) && (errno != EINTR) && (errno != ECHILD)) {
+			break;
+		}
+	} while (1);
+	
+	/* Cleanup: Kill both processes and wait for them */
+	kill(killerPid, SIGKILL);
+	kill(runnerPid, SIGKILL);
+	waitpid(killerPid, NULL, 0);
+	waitpid(runnerPid, NULL, 0);
+	
+	return ret;
+}
+
+int main(void) {
+	for (int i = 0; i < PROCESS_COUNT; i++) {
+		pid_t pid = fork();
+		if (pid == -1) {
+			perror("fork");
+			exit(EXIT_FAILURE);
+		} else if (pid == 0) {
+			stressWaitSystemCall();
+			exit(EXIT_SUCCESS);
+		}
+	}
+	for (int i = 0; i < PROCESS_COUNT; i++) {
+		wait(NULL);
+	}
+	printf("All %d child processes have exited\n", PROCESS_COUNT);
+	return 0;
+}

--- a/cpu/wait_stressor_perf.py.data/wait_stressor_perf.yaml
+++ b/cpu/wait_stressor_perf.py.data/wait_stressor_perf.yaml
@@ -1,0 +1,25 @@
+# Configuration file for wait_stressor_perf test
+#
+# This test validates load balancing by running wait_stressor.c
+# and monitoring scheduler functions with perf.
+#
+# Expected: enqueue_task_fair and newidle_balance should consume
+# less than 2.0% of CPU cycles
+#
+# Note: This test is only applicable for SUSE Linux distributions
+
+duration: !mux
+    default:
+        # Duration to run the test in seconds
+        duration: 30
+    short:
+        duration: 15
+    long:
+        duration: 60
+
+threshold: !mux
+    default:
+        # Maximum acceptable percentage of cycles for scheduler functions
+        threshold: 2.0
+    relaxed:
+        threshold: 4.0


### PR DESCRIPTION
Add wait_stressor_perf test to validate that enqueue_task_fair and newidle_balance scheduler functions consume less than 2.0% of CPU cycles under load. Test is SUSE Linux specific and uses optimized perf analysis with --symbol-filter for fast execution.