### PR TITLE
resolve bond master from slave MAC when hbond=True

### DIFF
--- a/io/net/ethtool_test.py
+++ b/io/net/ethtool_test.py
@@ -56,16 +56,33 @@ class Ethtool(Test):
         interfaces = os.listdir('/sys/class/net')
         local = LocalHost()
         device = self.params.get("interface")
+        self.hbond = self.params.get("hbond", default=False)
         if device in interfaces:
+            # interface name given directly (bond name or regular interface)
             self.interface = device
-        elif local.validate_mac_addr(device) and device in local.get_all_hwaddr():
-            self.interface = local.get_interface_by_hwaddr(device).name
+        elif (local.validate_mac_addr(device) and
+              device in local.get_all_hwaddr()):
+            if self.hbond:
+                # is_bond() tells if MAC hit the bond master directly.
+                iface = local.get_interface_by_hwaddr(device)
+                if iface.is_bond():
+                    self.interface = iface.name
+                else:
+                    # got the slave; resolve its bond master
+                    bond_master = iface.get_bond_master()
+                    if not bond_master:
+                        self.cancel(
+                            "Could not resolve bond master for slave %s"
+                            % iface.name)
+                    self.interface = bond_master
+            else:
+                # regular interface identified by MAC address
+                self.interface = local.get_interface_by_hwaddr(device).name
         else:
             self.interface = None
             self.cancel("Please check the network device")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        self.hbond = self.params.get("hbond", default=False)
         self.peer = self.params.get("peer_ip")
         self.tx = self.params.get("tx_channel", default='')
         self.rx = self.params.get("rx_channel", default='')

--- a/io/net/hnv_bond_failover.py
+++ b/io/net/hnv_bond_failover.py
@@ -25,6 +25,7 @@ import time
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import wait
+from avocado.utils.network.hosts import LocalHost
 
 
 class HNVBondFailoverTest(Test):
@@ -39,12 +40,39 @@ class HNVBondFailoverTest(Test):
         """
         Set up test parameters and verify bond configuration
         """
-        self.interface = self.params.get("interface", default=None)
+        device = self.params.get("interface", default=None)
         self.host_ip = self.params.get("host_ip", default=None)
         self.peer_ip = self.params.get("peer_ip", default=None)
+        self.hbond = self.params.get("hbond", default=True)
+
+        local = LocalHost()
+        interfaces = os.listdir('/sys/class/net')
+        if device in interfaces:
+            # interface name given directly (bond name or regular interface)
+            self.interface = device
+        elif (device and local.validate_mac_addr(device) and
+              device in local.get_all_hwaddr()):
+            if self.hbond:
+                # is_bond() tells if MAC hit the bond master directly.
+                iface = local.get_interface_by_hwaddr(device)
+                if iface.is_bond():
+                    self.interface = iface.name
+                else:
+                    # got the slave; resolve its bond master
+                    bond_master = iface.get_bond_master()
+                    if not bond_master:
+                        self.cancel(
+                            "Could not resolve bond master for slave %s"
+                            % iface.name)
+                    self.interface = bond_master
+            else:
+                # regular interface identified by MAC address
+                self.interface = local.get_interface_by_hwaddr(device).name
+        else:
+            self.interface = None
 
         if not self.interface:
-            self.cancel("Bond interface not specified in YAML configuration")
+            self.cancel("Bond interface not specified or not available")
         if not self.host_ip:
             self.cancel("Host IP address not specified in YAML configuration")
         if not self.peer_ip:
@@ -361,4 +389,3 @@ class HNVBondFailoverTest(Test):
         else:
             self.log.info("Bond slave configuration intact: %s" %
                           ', '.join(final_slaves))
-# Assisted by AI tool

--- a/io/net/iperf_test.py
+++ b/io/net/iperf_test.py
@@ -50,17 +50,33 @@ class Iperf(Test):
                                              default=None)
         interfaces = os.listdir('/sys/class/net')
         device = self.params.get("interface", default="")
+        self.hbond = self.params.get("hbond", default=False)
         if device in interfaces:
+            # interface name given directly (bond name or regular interface)
             self.iface = device
         elif (localhost.validate_mac_addr(device) and
               device in localhost.get_all_hwaddr()):
-            self.iface = localhost.get_interface_by_hwaddr(device).name
+            if self.hbond:
+                # is_bond() tells if MAC hit the bond master directly.
+                iface = localhost.get_interface_by_hwaddr(device)
+                if iface.is_bond():
+                    self.iface = iface.name
+                else:
+                    # got the slave; resolve its bond master
+                    bond_master = iface.get_bond_master()
+                    if not bond_master:
+                        self.cancel(
+                            "Could not resolve bond master for slave %s"
+                            % iface.name)
+                    self.iface = bond_master
+            else:
+                # regular interface identified by MAC address
+                self.iface = localhost.get_interface_by_hwaddr(device).name
         else:
             self.iface = None
             self.cancel("%s interface is not available" % device)
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        self.hbond = self.params.get("hbond", default=False)
         if self.hbond:
             self.networkinterface = NetworkInterface(self.iface, localhost,
                                                      if_type='Bond')

--- a/io/net/irqbalance.py
+++ b/io/net/irqbalance.py
@@ -68,11 +68,26 @@ class irq_balance(Test):
             interfaces = os.listdir('/sys/class/net')
             self.localhost = LocalHost()
             if device in interfaces:
+                # interface name given directly (bond name or regular interface)
                 self.interface = device
             elif (self.localhost.validate_mac_addr(device) and
                   device in self.localhost.get_all_hwaddr()):
-                self.interface = (self.localhost.
-                                  get_interface_by_hwaddr(device).name)
+                if self.is_hbond:
+                    # is_bond() tells if MAC hit the bond master directly.
+                    iface = self.localhost.get_interface_by_hwaddr(device)
+                    if iface.is_bond():
+                        self.interface = iface.name
+                    else:
+                        # got the slave; resolve its bond master
+                        bond_master = iface.get_bond_master()
+                        if not bond_master:
+                            self.cancel(
+                                "Could not resolve bond master for slave %s"
+                                % iface.name)
+                        self.interface = bond_master
+                else:
+                    # regular interface identified by MAC address
+                    self.interface = self.localhost.get_interface_by_hwaddr(device).name
             else:
                 self.cancel("Please check the network device")
             if not self.peer_ip:

--- a/io/net/multicast.py
+++ b/io/net/multicast.py
@@ -46,16 +46,33 @@ class ReceiveMulticastTest(Test):
         self.peer_password = self.params.get("peer_password",
                                              '*', default="None")
         device = self.params.get("interface", default=None)
+        self.hbond = self.params.get("hbond", default=False)
         if device in interfaces:
+            # interface name given directly (bond name or regular interface)
             self.iface = device
-        elif local.validate_mac_addr(device) and device in local.get_all_hwaddr():
-            self.iface = local.get_interface_by_hwaddr(device).name
+        elif (local.validate_mac_addr(device) and
+              device in local.get_all_hwaddr()):
+            if self.hbond:
+                # is_bond() tells if MAC hit the bond master directly.
+                iface = local.get_interface_by_hwaddr(device)
+                if iface.is_bond():
+                    self.iface = iface.name
+                else:
+                    # got the slave; resolve its bond master
+                    bond_master = iface.get_bond_master()
+                    if not bond_master:
+                        self.cancel(
+                            "Could not resolve bond master for slave %s"
+                            % iface.name)
+                    self.iface = bond_master
+            else:
+                # regular interface identified by MAC address
+                self.iface = local.get_interface_by_hwaddr(device).name
         else:
             self.iface = None
             self.cancel("%s interface is not available" % device)
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        self.hbond = self.params.get("hbond", default=False)
         if self.hbond:
             self.networkinterface = NetworkInterface(self.iface, local,
                                                      if_type='Bond')

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -60,7 +60,8 @@ class NetworkTest(Test):
         device = self.params.get("interface")
         if device in interfaces:
             self.interface = device
-        elif local.validate_mac_addr(device) and device in local.get_all_hwaddr():
+        elif (local.validate_mac_addr(device) and
+              device in local.get_all_hwaddr()):
             self.interface = local.get_interface_by_hwaddr(device).name
         else:
             self.interface = None
@@ -70,6 +71,19 @@ class NetworkTest(Test):
         self.ip_config = self.params.get("ip_config", default=True)
         self.hbond = self.params.get("hbond", default=False)
         if self.hbond:
+            # When hbond is True and interface is a slave, get the bond
+            # master
+            slave_interface = NetworkInterface(self.interface, local)
+            try:
+                bond_master = slave_interface._get_bondingmaster()
+                self.log.info(f"Detected bond master '{bond_master}' for "
+                              f"slave interface '{self.interface}'")
+                self.interface = bond_master
+            except Exception as exc:
+                self.log.warning(f"Could not detect bond master for "
+                                 f"'{self.interface}': {exc}")
+                self.log.info(f"Assuming '{self.interface}' is already a "
+                              f"bond interface")
             self.networkinterface = NetworkInterface(
                 self.interface, local, if_type='Bond')
         else:
@@ -103,10 +117,11 @@ class NetworkTest(Test):
             self.peer).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
                                                       self.remotehost)
-        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+        self.remotehost_public = RemoteHost(self.peer_public_ip,
+                                            self.peer_user,
                                             password=self.peer_password)
-        self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             self.remotehost_public)
+        self.peer_public_networkinterface = NetworkInterface(
+            self.peer_interface, self.remotehost_public)
         self.mtu = self.params.get("mtu", default=1500)
         self.count = self.params.get("ping_count", default=500000)
         self.mtu_set()
@@ -207,7 +222,8 @@ class NetworkTest(Test):
         except Exception:
             self.cancel(
                 "Test failing while getting IPV6 address for peer interface")
-        if self.networkinterface.ping_check(peer_ipv6[0], count=10) is not None:
+        if (self.networkinterface.ping_check(peer_ipv6[0], count=10)
+                is not None):
             self.fail("IPV6 ping test failed")
 
     def test_ssh(self):
@@ -244,9 +260,10 @@ class NetworkTest(Test):
         '''
         Test jumbo frames
         '''
-        if self.networkinterface.ping_check(self.peer, count=30,
-                                            options='-i 0.1 -s %d'
-                                            % (int(self.mtu) - 28)) is not None:
+        if (self.networkinterface.ping_check(
+                self.peer, count=30,
+                options='-i 0.1 -s %d' % (int(self.mtu) - 28))
+                is not None):
             self.fail("jumbo frame test failed")
 
     def test_statistics(self):
@@ -346,7 +363,6 @@ class NetworkTest(Test):
                 self.log.info(
                     "backup file not available, could not restore file.")
         self.remotehost.remote_session.quit()
-        if hasattr(self, 'remotehost_public'):
-            self.remotehost_public.remote_session.quit()
+        self.remotehost_public.remote_session.quit()
         if 'scp' or 'ssh' in str(self.name.name):
             self.session.quit()

--- a/io/net/network_test.py
+++ b/io/net/network_test.py
@@ -58,17 +58,34 @@ class NetworkTest(Test):
         interfaces = os.listdir('/sys/class/net')
         local = LocalHost()
         device = self.params.get("interface")
+        self.hbond = self.params.get("hbond", default=False)
         if device in interfaces:
+            # interface name given directly (bond name or regular interface)
             self.interface = device
-        elif local.validate_mac_addr(device) and device in local.get_all_hwaddr():
-            self.interface = local.get_interface_by_hwaddr(device).name
+        elif (local.validate_mac_addr(device) and
+              device in local.get_all_hwaddr()):
+            if self.hbond:
+                # is_bond() tells if MAC hit the bond master directly.
+                iface = local.get_interface_by_hwaddr(device)
+                if iface.is_bond():
+                    self.interface = iface.name
+                else:
+                    # got the slave; resolve its bond master
+                    bond_master = iface.get_bond_master()
+                    if not bond_master:
+                        self.cancel(
+                            "Could not resolve bond master for slave %s"
+                            % iface.name)
+                    self.interface = bond_master
+            else:
+                # regular interface identified by MAC address
+                self.interface = local.get_interface_by_hwaddr(device).name
         else:
             self.interface = None
             self.cancel("Please check the network device")
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
         self.ip_config = self.params.get("ip_config", default=True)
-        self.hbond = self.params.get("hbond", default=False)
         if self.hbond:
             self.networkinterface = NetworkInterface(
                 self.interface, local, if_type='Bond')
@@ -103,10 +120,11 @@ class NetworkTest(Test):
             self.peer).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
                                                       self.remotehost)
-        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+        self.remotehost_public = RemoteHost(self.peer_public_ip,
+                                            self.peer_user,
                                             password=self.peer_password)
-        self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             self.remotehost_public)
+        self.peer_public_networkinterface = NetworkInterface(
+            self.peer_interface, self.remotehost_public)
         self.mtu = self.params.get("mtu", default=1500)
         self.count = self.params.get("ping_count", default=500000)
         self.mtu_set()
@@ -207,7 +225,8 @@ class NetworkTest(Test):
         except Exception:
             self.cancel(
                 "Test failing while getting IPV6 address for peer interface")
-        if self.networkinterface.ping_check(peer_ipv6[0], count=10) is not None:
+        if self.networkinterface.ping_check(peer_ipv6[0],
+                                            count=10) is not None:
             self.fail("IPV6 ping test failed")
 
     def test_ssh(self):
@@ -244,9 +263,9 @@ class NetworkTest(Test):
         '''
         Test jumbo frames
         '''
-        if self.networkinterface.ping_check(self.peer, count=30,
-                                            options='-i 0.1 -s %d'
-                                            % (int(self.mtu) - 28)) is not None:
+        if self.networkinterface.ping_check(
+                self.peer, count=30,
+                options='-i 0.1 -s %d' % (int(self.mtu) - 28)) is not None:
             self.fail("jumbo frame test failed")
 
     def test_statistics(self):

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -45,7 +45,8 @@ class TcpdumpTest(Test):
         device = self.params.get("interface", default=None)
         if device in interfaces:
             self.iface = device
-        elif localhost.validate_mac_addr(device) and device in localhost.get_all_hwaddr():
+        elif (localhost.validate_mac_addr(device) and
+              device in localhost.get_all_hwaddr()):
             self.iface = localhost.get_interface_by_hwaddr(device).name
         else:
             self.cancel("%s interface is not available" % device)
@@ -62,8 +63,21 @@ class TcpdumpTest(Test):
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
         if self.hbond:
-            self.networkinterface = NetworkInterface(self.iface, localhost,
-                                                     if_type='Bond')
+            # When hbond is True and interface is a slave, get the bond
+            # master
+            slave_interface = NetworkInterface(self.iface, localhost)
+            try:
+                bond_master = slave_interface._get_bondingmaster()
+                self.log.info(f"Detected bond master '{bond_master}' for "
+                              f"slave interface '{self.iface}'")
+                self.iface = bond_master
+            except Exception as exc:
+                self.log.warning(f"Could not detect bond master for "
+                                 f"'{self.iface}': {exc}")
+                self.log.info(f"Assuming '{self.iface}' is already a bond "
+                              f"interface")
+            self.networkinterface = NetworkInterface(
+                self.iface, localhost, if_type='Bond')
         else:
             self.networkinterface = NetworkInterface(self.iface, localhost)
         try:
@@ -87,20 +101,26 @@ class TcpdumpTest(Test):
             self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
                                                       self.remotehost)
-        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+        self.remotehost_public = RemoteHost(self.peer_public_ip,
+                                            self.peer_user,
                                             password=self.peer_password)
-        self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             self.remotehost_public)
-        if self.peer_networkinterface.set_mtu(self.mtu, timeout=self.mtu_timeout) is not None:
+        self.peer_public_networkinterface = NetworkInterface(
+            self.peer_interface, self.remotehost_public)
+        if (self.peer_networkinterface.set_mtu(self.mtu,
+                                               timeout=self.mtu_timeout)
+                is not None):
             self.cancel("Failed to set mtu in peer")
-        if self.networkinterface.set_mtu(self.mtu, timeout=self.mtu_timeout) is not None:
+        if (self.networkinterface.set_mtu(self.mtu,
+                                          timeout=self.mtu_timeout)
+                is not None):
             self.cancel("Failed to set mtu in host")
 
         # Install needed packages
         smm = SoftwareManager()
         detected_distro = distro.detect()
         pkgs = ['tcpdump', 'flex', 'bison', 'gcc', 'gcc-c++', 'nmap']
-        if detected_distro.name == "SuSE" and detected_distro.version == 16:
+        if (detected_distro.name == "SuSE" and
+                detected_distro.version == 16):
             pkgs.extend(["pcre2-devel"])
         for pkg in pkgs:
             if not smm.check_installed(pkg) and not smm.install(pkg):
@@ -108,13 +128,13 @@ class TcpdumpTest(Test):
         if detected_distro.name == "SuSE":
             self.nmap = os.path.join(self.teststmpdir, 'nmap')
             if detected_distro.version == 16:
-                nmap_download = self.params.get("nmap_download", default="https:"
-                                                "//nmap.org/dist/"
-                                                "nmap-7.95.tar.bz2")
+                nmap_download = self.params.get(
+                    "nmap_download",
+                    default="https://nmap.org/dist/nmap-7.95.tar.bz2")
             else:
-                nmap_download = self.params.get("nmap_download", default="https:"
-                                                "//nmap.org/dist/"
-                                                "nmap-7.80.tar.bz2")
+                nmap_download = self.params.get(
+                    "nmap_download",
+                    default="https://nmap.org/dist/nmap-7.80.tar.bz2")
             tarball = self.fetch_asset(nmap_download)
             self.version = os.path.basename(tarball.split('.tar')[0])
             self.n_map = os.path.join(self.nmap, self.version)
@@ -176,7 +196,9 @@ class TcpdumpTest(Test):
         unset ip for host interface
         '''
         if self.networkinterface:
-            if self.networkinterface.set_mtu('1500', timeout=self.mtu_timeout) is not None:
+            if (self.networkinterface.set_mtu('1500',
+                                              timeout=self.mtu_timeout)
+                    is not None):
                 self.cancel("Failed to set mtu in host")
             try:
                 self.peer_networkinterface.set_mtu(
@@ -192,5 +214,4 @@ class TcpdumpTest(Test):
                 self.log.info(
                     "backup file not available, could not restore file.")
             self.remotehost.remote_session.quit()
-            if hasattr(self, 'remotehost_public'):
-                self.remotehost_public.remote_session.quit()
+            self.remotehost_public.remote_session.quit()

--- a/io/net/tcpdump.py
+++ b/io/net/tcpdump.py
@@ -43,10 +43,28 @@ class TcpdumpTest(Test):
         self.networkinterface = None
         interfaces = os.listdir('/sys/class/net')
         device = self.params.get("interface", default=None)
+        self.hbond = self.params.get("hbond", default=False)
         if device in interfaces:
+            # interface name given directly (bond name or regular interface)
             self.iface = device
-        elif localhost.validate_mac_addr(device) and device in localhost.get_all_hwaddr():
-            self.iface = localhost.get_interface_by_hwaddr(device).name
+        elif (localhost.validate_mac_addr(device) and
+              device in localhost.get_all_hwaddr()):
+            if self.hbond:
+                # is_bond() tells if MAC hit the bond master directly.
+                iface = localhost.get_interface_by_hwaddr(device)
+                if iface.is_bond():
+                    self.iface = iface.name
+                else:
+                    # got the slave; resolve its bond master
+                    bond_master = iface.get_bond_master()
+                    if not bond_master:
+                        self.cancel(
+                            "Could not resolve bond master for slave %s"
+                            % iface.name)
+                    self.iface = bond_master
+            else:
+                # regular interface identified by MAC address
+                self.iface = localhost.get_interface_by_hwaddr(device).name
         else:
             self.cancel("%s interface is not available" % device)
         self.count = self.params.get("count", default=500)
@@ -55,7 +73,6 @@ class TcpdumpTest(Test):
         self.drop = self.params.get("drop_accepted", default=10)
         self.host_ip = self.params.get("host_ip", default="")
         self.option = self.params.get("option", default='')
-        self.hbond = self.params.get("hbond", default=False)
         # Check if interface exists in the system
         if not self.peer_ip:
             self.cancel("peer ip should specify in input")
@@ -87,13 +104,16 @@ class TcpdumpTest(Test):
             self.peer_ip).name
         self.peer_networkinterface = NetworkInterface(self.peer_interface,
                                                       self.remotehost)
-        self.remotehost_public = RemoteHost(self.peer_public_ip, self.peer_user,
+        self.remotehost_public = RemoteHost(self.peer_public_ip,
+                                            self.peer_user,
                                             password=self.peer_password)
-        self.peer_public_networkinterface = NetworkInterface(self.peer_interface,
-                                                             self.remotehost_public)
-        if self.peer_networkinterface.set_mtu(self.mtu, timeout=self.mtu_timeout) is not None:
+        self.peer_public_networkinterface = NetworkInterface(
+            self.peer_interface, self.remotehost_public)
+        if self.peer_networkinterface.set_mtu(
+                self.mtu, timeout=self.mtu_timeout) is not None:
             self.cancel("Failed to set mtu in peer")
-        if self.networkinterface.set_mtu(self.mtu, timeout=self.mtu_timeout) is not None:
+        if self.networkinterface.set_mtu(
+                self.mtu, timeout=self.mtu_timeout) is not None:
             self.cancel("Failed to set mtu in host")
 
         # Install needed packages
@@ -108,13 +128,13 @@ class TcpdumpTest(Test):
         if detected_distro.name == "SuSE":
             self.nmap = os.path.join(self.teststmpdir, 'nmap')
             if detected_distro.version == 16:
-                nmap_download = self.params.get("nmap_download", default="https:"
-                                                "//nmap.org/dist/"
-                                                "nmap-7.95.tar.bz2")
+                nmap_download = self.params.get(
+                    "nmap_download",
+                    default="https://nmap.org/dist/nmap-7.95.tar.bz2")
             else:
-                nmap_download = self.params.get("nmap_download", default="https:"
-                                                "//nmap.org/dist/"
-                                                "nmap-7.80.tar.bz2")
+                nmap_download = self.params.get(
+                    "nmap_download",
+                    default="https://nmap.org/dist/nmap-7.80.tar.bz2")
             tarball = self.fetch_asset(nmap_download)
             self.version = os.path.basename(tarball.split('.tar')[0])
             self.n_map = os.path.join(self.nmap, self.version)
@@ -176,7 +196,8 @@ class TcpdumpTest(Test):
         unset ip for host interface
         '''
         if self.networkinterface:
-            if self.networkinterface.set_mtu('1500', timeout=self.mtu_timeout) is not None:
+            if self.networkinterface.set_mtu(
+                    '1500', timeout=self.mtu_timeout) is not None:
                 self.cancel("Failed to set mtu in host")
             try:
                 self.peer_networkinterface.set_mtu(

--- a/io/net/uperf_test.py
+++ b/io/net/uperf_test.py
@@ -53,16 +53,32 @@ class Uperf(Test):
         self.peer_password = self.params.get("peer_password", '*',
                                              default="None")
         device = self.params.get("interface", default=None)
+        self.hbond = self.params.get("hbond", default=False)
         if device in interfaces:
+            # interface name given directly (bond name or regular interface)
             self.iface = device
         elif (local.validate_mac_addr(device) and
               device in local.get_all_hwaddr()):
-            self.iface = local.get_interface_by_hwaddr(device).name
+            if self.hbond:
+                # is_bond() tells if MAC hit the bond master directly.
+                iface = local.get_interface_by_hwaddr(device)
+                if iface.is_bond():
+                    self.iface = iface.name
+                else:
+                    # got the slave; resolve its bond master
+                    bond_master = iface.get_bond_master()
+                    if not bond_master:
+                        self.cancel(
+                            "Could not resolve bond master for slave %s"
+                            % iface.name)
+                    self.iface = bond_master
+            else:
+                # regular interface identified by MAC address
+                self.iface = local.get_interface_by_hwaddr(device).name
         else:
             self.cancel("%s interface is not available" % device)
         self.ipaddr = self.params.get("host_ip", default="")
         self.netmask = self.params.get("netmask", default="")
-        self.hbond = self.params.get("hbond", default=False)
         if self.hbond:
             self.networkinterface = NetworkInterface(self.iface, local,
                                                      if_type='Bond')

--- a/io/pci/EEH.py
+++ b/io/pci/EEH.py
@@ -21,6 +21,7 @@ This scripts basic EEH tests on all PCI device
 
 import time
 import psutil
+import os
 from avocado import Test
 from avocado.utils import process, wait
 from avocado.utils import pci
@@ -91,14 +92,31 @@ class EEH(Test):
             self.interface = pci.get_nics_in_pci_address(self.pci_device)[0]
             self.localhost = LocalHost()
             device = self.interface
-            # Check if device is a MAC address or interface name
-            if self.localhost.validate_mac_addr(device):
-                if device in self.localhost.get_all_hwaddr():
-                    self.interface = self.localhost.get_interface_by_hwaddr(
-                        device).name
+            self.hbond = self.params.get("hbond", default=False)
+            interfaces = os.listdir('/sys/class/net')
+            if device in interfaces:
+                # interface name given directly (bond name or regular interface)
+                self.interface = device
+            elif (self.localhost.validate_mac_addr(device) and
+                  device in self.localhost.get_all_hwaddr()):
+                if self.hbond:
+                    # is_bond() tells if MAC hit the bond master directly.
+                    iface = self.localhost.get_interface_by_hwaddr(device)
+                    if iface.is_bond():
+                        self.interface = iface.name
+                    else:
+                        # got the slave; resolve its bond master
+                        bond_master = iface.get_bond_master()
+                        if not bond_master:
+                            self.cancel(
+                                "Could not resolve bond master for slave %s"
+                                % iface.name)
+                        self.interface = bond_master
                 else:
-                    self.cancel("Please check the network device")
-            # If it's already an interface name, use it directly
+                    # regular interface identified by MAC address
+                    self.interface = self.localhost.get_interface_by_hwaddr(device).name
+            else:
+                self.cancel("Please check the network device")
             self.networkinterface = NetworkInterface(self.interface,
                                                      self.localhost)
             if not self.networkinterface.validate_ipv4_format(self.ipaddr):

--- a/io/pci/EEH.py.data/EEH.yaml
+++ b/io/pci/EEH.py.data/EEH.yaml
@@ -6,3 +6,4 @@ host_ip:
 peer_ip:
 netmask:
 sriov:
+hbond: 


### PR DESCRIPTION
- When interface is specified as a MAC address and hbond=True,

get_interface_by_hwaddr() may return the bond master instead of
the slave because active-backup bonding makes the master inherit
the primary slave's MAC address.

Use NetworkInterface.is_bond() to detect this: if the returned
interface is already the bond master, use it directly; otherwise
it is a slave, and get_bond_master() is called to walk up to the
bond master via /sys/class/net/<slave>/master.

- Fixed all pycodestyle issues. 