### PR TITLE
perf: Fix and add tearDown() methods for proper cleanup

### DIFF
--- a/perf/perf_basic.py
+++ b/perf/perf_basic.py
@@ -128,5 +128,5 @@ class PerfBasic(Test):
         self.run_cmd("perf bench sched all")
 
     def tearDown(self):
-        if os.path.isfile(self.temp_file):
-            process.run('rm -f %s' % self.temp_file)
+        if hasattr(self, 'temp_file') and os.path.isfile(self.temp_file):
+            os.remove(self.temp_file)

--- a/perf/perf_sched.py
+++ b/perf/perf_sched.py
@@ -99,5 +99,5 @@ class perf_sched(Test):
 
     def tearDown(self):
         # Delete the temporary file
-        if os.path.isfile(self.temp_file):
-            process.run('rm -f %s' % self.temp_file)
+        if hasattr(self, 'temp_file') and os.path.isfile(self.temp_file):
+            os.remove(self.temp_file)

--- a/perf/perf_script_bug.py
+++ b/perf/perf_script_bug.py
@@ -69,3 +69,7 @@ class PerfScript(Test):
         process.run(probe_del)
         if output.exit_status == -11:
             self.fail("perf script command segfaulted")
+
+    def tearDown(self):
+        if hasattr(self, 'temp_file') and os.path.isfile(self.temp_file):
+            os.remove(self.temp_file)

--- a/perf/perf_top.py
+++ b/perf/perf_top.py
@@ -100,5 +100,5 @@ class perf_top(Test):
             self.fail("ebizzy workload not captured in perf top")
 
     def tearDown(self):
-        if os.path.isfile(self.temp_file):
-            process.system('rm -f %s' % self.temp_file)
+        if hasattr(self, 'temp_file') and os.path.isfile(self.temp_file):
+            os.remove(self.temp_file)

--- a/perf/perf_trace.py
+++ b/perf/perf_trace.py
@@ -88,5 +88,5 @@ class perf_trace(Test):
 
     def tearDown(self):
         # Delete the temporary file
-        if os.path.isfile(self.temp_file):
-            process.run('rm -f %s' % self.temp_file)
+        if hasattr(self, 'temp_file') and os.path.isfile(self.temp_file):
+            os.remove(self.temp_file)


### PR DESCRIPTION
Fix tearDown() in multiple perf test files to prevent AttributeError and improve cleanup efficiency.

Changes:
- Add hasattr() check before accessing self.temp_file
- Replace process.run('rm -f') with os.remove()
- Replace process.system('rm -f') with os.remove()
- Add missing tearDown() in perf_script_bug.py

Before fix:
  AttributeError: 'PerfBasic' object has no attribute 'temp_file' when setUp() fails before temp_file creation

After fix:
  Tests properly CANCEL instead of ERROR when setUp() fails Temporary files cleaned up efficiently