### PR TITLE
kselftest: Fix futex test setup by skipping unnecessary builds

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -156,8 +156,11 @@ class kselftest(Test):
             if (self.comp != "cpufreq" and self.comp != "bpf"):
                 process.system("make headers -C %s" % self.buldir, shell=True,
                                sudo=True)
-                process.system("make install -C %s" % self.sourcedir,
-                               shell=True, sudo=True)
+                # Only run 'make install' if no specific component is selected
+                # Component-specific builds will be done later in the build phase
+                if not self.comp:
+                    process.system("make install -C %s" % self.sourcedir,
+                                   shell=True, sudo=True)
             else:
                 self.buldir = self.params.get('location', default='')
         else:


### PR DESCRIPTION
When running futex tests with upstream kernel source, the setup was failing because 'make install' tried to build all selftests including the net directory, which needs clang for BPF programs. Since futex doesn't need clang, this was causing unnecessary failures.

This patch skips 'make install' when testing a specific component. The component gets built later anyway, so we don't lose anything. This makes futex tests work without needing clang installed, and also speeds up the setup since we're not building tests we won't run.

Full test suite runs (without specifying a component) still work the same way as before.