### PR TITLE
blktest liburing package addition and error handling improvement

### DIFF
--- a/io/disk/blktests.py
+++ b/io/disk/blktests.py
@@ -41,13 +41,13 @@ class Blktests(Test):
 
         packages = ['gcc', 'make', 'util-linux', 'fio']
         if dist.name in ['Ubuntu', 'debian']:
-            packages += ['libdevmapper-dev', 'g++']
+            packages += ['libdevmapper-dev', 'g++', 'liburing-dev']
         elif dist.name in ['rhel', 'CentOS', 'fedora']:
             packages += ['device-mapper', 'gcc-c++', 'blktrace',
-                         'ktls-utils', 'device-mapper-multipath']
+                         'ktls-utils', 'device-mapper-multipath', 'liburing-devel']
         elif dist.name in ['SuSE']:
             packages += ['device-mapper', 'gcc-c++', 'blktrace',
-                         'ktls-utils', 'multipath-tools']
+                         'ktls-utils', 'multipath-tools', 'liburing-devel']
 
         # Enable io_uring if disabled
         knob = "/proc/sys/kernel/io_uring_disabled"
@@ -89,13 +89,17 @@ class Blktests(Test):
         fail_pattern = re.compile(r'^(\S+/\S+).*?\[failed\]', re.MULTILINE)
         failed_tests = [m.group(1).strip() for m in fail_pattern.finditer(stdout)]
 
-        if result.exit_status != 0 or failed_tests:
-            if failed_tests:
-                failed_list = ", ".join(failed_tests)
-                summary = f"{len(failed_tests)} test(s) failed: {failed_list}"
-            else:
-                summary = f"blktests exited with code {result.exit_status}"
+        # Only fail if there are actual test failures, not just exit code 1
+        # blktests returns exit code 1 when tests are skipped, which is expected
+        if failed_tests:
+            failed_list = ", ".join(failed_tests)
+            summary = f"{len(failed_tests)} test(s) failed: {failed_list}"
             self.fail(summary)
+
+        # Log exit status for informational purposes
+        if result.exit_status != 0:
+            self.log.warning(f"blktests exited with code {result.exit_status}. "
+                             "This may indicate some tests were skipped.")
 
         dmesg = process.system_output('dmesg')
         match = re.search(br'Call Trace:', dmesg, re.M | re.I)

--- a/io/disk/blktests.py
+++ b/io/disk/blktests.py
@@ -41,13 +41,13 @@ class Blktests(Test):
 
         packages = ['gcc', 'make', 'util-linux', 'fio']
         if dist.name in ['Ubuntu', 'debian']:
-            packages += ['libdevmapper-dev', 'g++']
+            packages += ['libdevmapper-dev', 'g++', 'liburing-dev']
         elif dist.name in ['rhel', 'CentOS', 'fedora']:
             packages += ['device-mapper', 'gcc-c++', 'blktrace',
-                         'ktls-utils', 'device-mapper-multipath']
+                         'ktls-utils', 'device-mapper-multipath', 'liburing-devel']
         elif dist.name in ['SuSE']:
             packages += ['device-mapper', 'gcc-c++', 'blktrace',
-                         'ktls-utils', 'multipath-tools']
+                         'ktls-utils', 'multipath-tools', 'liburing-devel']
 
         # Enable io_uring if disabled
         knob = "/proc/sys/kernel/io_uring_disabled"


### PR DESCRIPTION
Added liburing Dependency:
Added liburing-devel (SUSE/RHEL) and liburing-dev to pkg dependencies - Ensures nvme-passthru-admin-uring binary is built
Enables nvme/067 test to execute successfully
Supports io_uring-based NVMe admin command testing

Improved Exit Code Handling:
Modified test failure logic -
Before: Failed on ANY non-zero exit code (including when tests were skipped) After: Only fails when actual test failures are detected ([failed] markers) Added informational warning when exit code is 1 due to skipped tests Eliminates false positive failures