### PR TITLE
kselftest_CI.yaml: Add static_keys

### DIFF
--- a/kernel/kselftest.py.data/kselftest_CI.yaml
+++ b/kernel/kselftest.py.data/kselftest_CI.yaml
@@ -9,6 +9,8 @@ component: !mux
         comp: 'cpu-hotplug'
     memory_hotplug:
         comp: 'memory-hotplug'
+    static_keys:
+        comp: 'static_keys'
 run_type: !mux
     upstream:
         type: 'upstream'

--- a/kernel/kselftest.py.data/kselftest_CI.yaml
+++ b/kernel/kselftest.py.data/kselftest_CI.yaml
@@ -11,6 +11,8 @@ component: !mux
         comp: 'memory-hotplug'
     vDSO:
         comp: 'vDSO'
+    static_keys:
+        comp: 'static_keys'
 run_type: !mux
     upstream:
         type: 'upstream'


### PR DESCRIPTION
Add static_keys, which validates zero-cost runtime-patchable conditional branches in the kernel.