### PR TITLE
Make test vendor-agnostic with YAML profiles

### DIFF
--- a/io/net/switch_test.py
+++ b/io/net/switch_test.py
@@ -21,6 +21,7 @@ test lro and gro and interface
 
 import os
 import time
+import yaml
 import paramiko
 from avocado import Test
 from avocado.utils.network.interfaces import NetworkInterface
@@ -42,7 +43,8 @@ class SwitchTest(Test):
         device = self.params.get("interface", default=None)
         if device in interfaces:
             self.iface = device
-        elif local.validate_mac_addr(device) and device in local.get_all_hwaddr():
+        elif (local.validate_mac_addr(device) and
+              device in local.get_all_hwaddr()):
             self.iface = local.get_interface_by_hwaddr(device).name
         else:
             self.cancel("%s interface is not available" % device)
@@ -66,11 +68,26 @@ class SwitchTest(Test):
         self.port_id = self.params.get("port_id", default="")
         if not self.port_id:
             self.cancel("user should specify port id")
+
+        # Load switch profile configuration
+        profile_name = self.params.get("switch_profile",
+                                       default="juniper_switch")
+        # Get the data directory for this test
+        test_dir = os.path.dirname(os.path.abspath(__file__))
+        data_dir = os.path.join(test_dir, f"{os.path.basename(__file__)}.data")
+        profile_path = os.path.join(data_dir, f"{profile_name}.yaml")
+        if not os.path.exists(profile_path):
+            self.cancel(f"Switch profile {profile_path} not found")
+
+        with open(profile_path, 'r') as f:
+            self.switch_config = yaml.safe_load(f)['switch_profile']
+
+        self.log.info(f"Using switch profile: {self.switch_config['vendor']}")
         self.switch_login(self.switch_name, self.userid, self.password)
 
     def switch_login(self, ip, username, password):
         '''
-        Login method for remote fc switch
+        Login method for remote switch
         '''
         self.tnc = paramiko.SSHClient()
         self.tnc.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -80,7 +97,13 @@ class SwitchTest(Test):
         self.remote_conn = self.tnc.invoke_shell()
         self.log.info("Interactive SSH session established")
         assert self.remote_conn
-        self.remote_conn.send("iscli" + '\n')
+
+        # Send login command if specified in profile
+        login_cmd = self.switch_config.get('login_command', '')
+        if login_cmd:
+            self.log.info(f"Sending login command: {login_cmd}")
+            self.remote_conn.send(login_cmd + '\n')
+            time.sleep(2)  # Wait for command to execute
 
     def _send_only_result(self, command, response):
         output = response.decode("utf-8").splitlines()
@@ -105,30 +128,119 @@ class SwitchTest(Test):
         response = self.remote_conn.recv(1000)
         return self._send_only_result(command, response)
 
+    def _enter_config_mode(self):
+        '''
+        Enter switch configuration mode
+        '''
+        cmds = self.switch_config['commands']
+        if cmds.get('enter_config'):
+            self.log.info("Entering configuration mode")
+            self.run_switch_command(cmds['enter_config'])
+
+    def _select_interface(self):
+        '''
+        Select interface on switch
+        '''
+        cmds = self.switch_config['commands']
+        if cmds.get('select_interface'):
+            interface_cmd = cmds['select_interface'].format(
+                port_id=self.port_id)
+            self.log.info(f"Selecting interface: {interface_cmd}")
+            self.run_switch_command(interface_cmd)
+
+    def _exit_config_mode(self):
+        '''
+        Exit switch configuration mode
+        '''
+        cmds = self.switch_config['commands']
+        if cmds.get('exit_config'):
+            self.log.info("Exiting configuration mode")
+            self.run_switch_command(cmds['exit_config'])
+
+    def _disable_port(self):
+        '''
+        Disable switch port
+        '''
+        cmds = self.switch_config['commands']
+        if cmds.get('disable_port'):
+            disable_cmd = cmds['disable_port'].format(port_id=self.port_id)
+            self.log.info(f"Disabling port: {disable_cmd}")
+            self.run_switch_command(disable_cmd)
+
+    def _enable_port(self):
+        '''
+        Enable switch port
+        '''
+        cmds = self.switch_config['commands']
+        if cmds.get('enable_port'):
+            enable_cmd = cmds['enable_port'].format(port_id=self.port_id)
+            self.log.info(f"Enabling port: {enable_cmd}")
+            self.run_switch_command(enable_cmd)
+
     def test(self):
         '''
         switch port enable and disable test
         '''
-        self.log.info("Enabling the privilege mode")
-        self.run_switch_command("enable")
-        self.log.info("Entering configuration mode")
-        self.run_switch_command("conf t")
-        cmd = "interface port %s" % self.port_id
-        self.run_switch_command(cmd)
-        self.run_switch_command("shutdown")
-        time.sleep(5)
-        if self.networkinterface.ping_check(self.peer, count=5) is None:
-            self.fail("pinging after disable port")
-        self.run_switch_command("no shutdown")
-        time.sleep(5)
+        wait_time = self.switch_config.get('wait_time', 5)
+
+        # Disable port
+        self._enter_config_mode()
+        self._select_interface()
+        self._disable_port()
+        self._exit_config_mode()
+
+        # Verify port is disabled (ping should fail)
+        time.sleep(wait_time)
+        try:
+            result = self.networkinterface.ping_check(self.peer, count=5)
+            if result is None:
+                self.fail("Port not disabled - "
+                          "ping succeeded when it should fail")
+        except Exception:
+            # Expected: ping should fail when port is disabled
+            self.log.info("Port disabled successfully - "
+                          "ping failed as expected")
+
+        # Enable port
+        self._enter_config_mode()
+        self._select_interface()
+        self._enable_port()
+        self._exit_config_mode()
+
+        # Verify port is enabled (ping should succeed)
+        time.sleep(wait_time)
         if self.networkinterface.ping_check(self.peer, count=5) is not None:
-            self.fail("ping test failed")
-        self.run_switch_command("end")
+            self.fail("Port not enabled - ping failed when it should succeed")
 
     def tearDown(self):
         '''
-        unset ip address
+        Cleanup: unset ip address and ensure switch port is enabled
         '''
+        # Ensure switch port is always enabled before cleanup
+        try:
+            if hasattr(self, 'switch_config') and hasattr(self, 'tnc'):
+                self.log.info("Ensuring switch port is enabled in tearDown")
+                self._enter_config_mode()
+                self._select_interface()
+                self._enable_port()
+                self._exit_config_mode()
+                self.log.info("Switch port enabled successfully in tearDown")
+        except Exception as e:
+            self.log.warning(f"Failed to enable switch port in tearDown: {e}")
+
+        # Close SSH connection to switch
+        try:
+            if hasattr(self, 'remote_conn') and self.remote_conn:
+                self.remote_conn.close()
+                self.log.info("Closed SSH shell connection")
+            if hasattr(self, 'tnc') and self.tnc:
+                self.tnc.close()
+                self.log.info("Closed SSH client connection to switch")
+        except Exception as e:
+            self.log.warning(
+                f"Failed to close SSH connection in tearDown: {e}")
+
+        # Cleanup network interface
         if self.networkinterface:
             self.networkinterface.remove_ipaddr(self.ipaddr, self.netmask)
             try:

--- a/io/net/switch_test.py.data/README.txt
+++ b/io/net/switch_test.py.data/README.txt
@@ -1,20 +1,47 @@
 description:
 ------------------------
-This Program to test switch port enable.
+This Program to test switch port enable/disable functionality.
+The test is now generic and supports multiple switch vendors through YAML profiles.
+
 -----------------------------
 Inputs Needed To Run Tests:
 -----------------------------
 interface --> host interface name eth3 or mac addr 02:5d:c7:xx:xx:03
 peer_ip --> peer interface to perform test.
-host-IP --> Specify host-IP for ip configuration.
+host_ip --> Specify host-IP for ip configuration.
 netmask --> specify netmask for ip configuration.
 switch_name --> switch ip address to test.
 userid --> switch userid
 password --> switch password
 port_id --> port id to perform test.
+switch_profile --> (optional) switch profile YAML file name (default: juniper_switch)
+                   Available profiles
+                    - cisco_switch.yaml (Cisco switches)
+                    - juniper_switch.yaml (Juniper switches)
+
+-----------------------
+Switch Profile Configuration:
+-----------------------
+Each switch vendor has a YAML profile that defines:
+- login_command: Command to execute after SSH login (e.g., "iscli", "enable", "cli")
+- commands: Dictionary of commands for different operations
+  - enter_config: Enter configuration mode
+  - select_interface: Select interface (supports {port_id} placeholder)
+  - disable_port: Disable port command
+  - enable_port: Enable port command
+  - exit_config: Exit configuration mode
+- wait_time: Time to wait after port state changes (default: 5 seconds)
+- prompt: Expected command prompt
+
+To add support for a new switch vendor:
+1. Create a new YAML file in switch_test.py.data/ (e.g., myswitch.yaml)
+2. Define the switch_profile with appropriate commands
+3. Reference it in switch_test.yaml using switch_profile parameter
+
 -----------------------
 Requirements:
 -----------------------
 1. install paramiko using pip
 command: pip install paramiko
-
+2. install pyyaml using pip
+command: pip install pyyaml

--- a/io/net/switch_test.py.data/cisco_switch.yaml
+++ b/io/net/switch_test.py.data/cisco_switch.yaml
@@ -1,0 +1,13 @@
+# Cisco/Brocade Switch Profile : This profile defines commands for Cisco-style switches
+switch_profile:
+  vendor: "cisco"
+  login_command: "enable"
+  commands:
+    enter_config: "conf t"
+    select_interface: "interface port {port_id}"
+    disable_port: "shutdown"
+    enable_port: "no shutdown"
+    exit_config: "end"
+  wait_time: 5
+  prompt: "#"
+

--- a/io/net/switch_test.py.data/juniper_switch.yaml
+++ b/io/net/switch_test.py.data/juniper_switch.yaml
@@ -1,0 +1,13 @@
+# Juniper Switch Profile : defines commands for Juniper switches
+switch_profile:
+  vendor: "juniper"
+  login_command: "cli"
+  commands:
+    enter_config: "configure"
+    select_interface: ""
+    disable_port: "set interfaces {port_id} disable"
+    enable_port: "delete interfaces {port_id} disable"
+    exit_config: "commit and-quit"
+  wait_time: 5
+  prompt: ">"
+

--- a/io/net/switch_test.py.data/switch_test.yaml
+++ b/io/net/switch_test.py.data/switch_test.yaml
@@ -6,3 +6,5 @@ switch_name:
 userid:
 password:
 port_id:
+switch_profile: juniper_switch
+


### PR DESCRIPTION
Refactored switch_test.py to support multiple switch vendors through YAML-based configuration profiles instead of hardcoded commands.

Changes:
- switch_test.py: Generic command execution via profiles
- switch_test.yaml: Added switch_profile parameter
- Load switch commands from vendor-specific YAML profiles
- Support dynamic command templates with {port_id} placeholder
- Add profiles for Cisco, Juniper switches