### PR TITLE
kernel/kselftest: Add vDSO component to test configuration

### DIFF
--- a/kernel/kselftest.py.data/kselftest_CI.yaml
+++ b/kernel/kselftest.py.data/kselftest_CI.yaml
@@ -9,6 +9,8 @@ component: !mux
         comp: 'cpu-hotplug'
     memory_hotplug:
         comp: 'memory-hotplug'
+    vDSO:
+        comp: 'vDSO'
 run_type: !mux
     upstream:
         type: 'upstream'

--- a/kernel/kselftest.py.data/kselftest_CR.yaml
+++ b/kernel/kselftest.py.data/kselftest_CR.yaml
@@ -9,6 +9,8 @@ component: !mux
         comp: 'cpu-hotplug'
     memory_hotplug:
         comp: 'memory-hotplug'
+    vDSO:
+        comp: 'vDSO'
 run_type: !mux
     distro:
         type: 'distro'


### PR DESCRIPTION
- Added vDSO component entry to kselftest_CI.yaml for CI testing
- Added vDSO component entry to kselftest_CR.yaml for CR testing