### PR TITLE
Update kselftest.yaml to run only distro kselftest.

### DIFF
--- a/kernel/kselftest.py.data/kselftest.yaml
+++ b/kernel/kselftest.py.data/kselftest.yaml
@@ -12,6 +12,3 @@ component: !mux
 run_type: !mux
     distro:
         type: 'distro'
-    upstream:
-        type: 'upstream'
-        location: "https://github.com/torvalds/linux/archive/master.zip"


### PR DESCRIPTION
Deleted run_type:'upstream' to run only distro specific selftests on distro.