### PR TITLE
cpu/ppc64_cpu_test.py: Removed the upstream as a target while running  the test on distro.

### DIFF
--- a/cpu/ppc64_cpu_test.py.data/ppc64_cpu_test.yaml
+++ b/cpu/ppc64_cpu_test.py.data/ppc64_cpu_test.yaml
@@ -1,7 +1,4 @@
 test_loop : 10
 run_type: !mux
-    upstream:
-        ppcutils_url: 'https://github.com/ibm-power-utilities/powerpc-utils/archive/refs/heads/master.zip'
-        type: 'upstream'
     distro:
         type: 'distro'


### PR DESCRIPTION

Updated cpu/ppc64_cpu_test.py.data/ppc64_cpu_test.yaml to have only distro has target.
Removed upstream target.