### PR TITLE
Fix memtester compilation failure with latest gcc-15

### DIFF
--- a/memory/memtester.py
+++ b/memory/memtester.py
@@ -39,9 +39,16 @@ class Memtester(Test):
         '''
         smm = SoftwareManager()
 
-        for pkg in ['gcc', 'make']:
+        for pkg in ['gcc', 'make', 'patch']:
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel('%s is needed for the test to be run' % pkg)
+        try:
+            gcc_version_output = process.run('gcc --version', shell=True).stdout_text
+            gcc_major_version = int(gcc_version_output.split()[2].split('.')[0])
+            self.log.info(f"Detected GCC version: {gcc_major_version}")
+        except Exception as e:
+            self.log.warning(f"Could not detect GCC version: {e}. Assuming patch is needed.")
+            gcc_major_version = 15
         tarball = self.fetch_asset('memtester.zip',
                                    locations=['https://github.com/jnavila/'
                                               'memtester/archive/master.zip'],
@@ -49,6 +56,18 @@ class Memtester(Test):
         archive.extract(tarball, self.workdir)
         sourcedir = os.path.join(self.workdir, 'memtester-master')
         os.chdir(sourcedir)
+        if gcc_major_version >= 15:
+            memtester_patch = 'patch -p0 < %s' % os.path.abspath(
+                self.get_data('memtester_gcc15.patch'))
+            try:
+                process.run(memtester_patch, shell=True)
+                self.log.info("Applied memtester patch to fix GCC 15+ compilation issues")
+            except Exception as e:
+                self.cancel(f"Failed to apply required GCC 15+ patch: {e}. "
+                            f"This patch is mandatory for GCC {gcc_major_version} to avoid "
+                            f"implicit function declaration errors during compilation.")
+        else:
+            self.log.info(f"GCC version {gcc_major_version} detected. Patch not required.")
         process.system('chmod 755 extra-libs.sh', shell=True, sudo=True,
                        ignore_status=True)
         build.make(sourcedir)

--- a/memory/memtester.py.data/memtester_gcc15.patch
+++ b/memory/memtester.py.data/memtester_gcc15.patch
@@ -1,0 +1,26 @@
+--- output.h	2024-01-01 00:00:00.000000000 +0000
++++ output.h	2024-01-01 00:00:00.000000000 +0000
+@@ -9,11 +9,11 @@
+ void out_initialize();
+
+ void out_test_start();
+-void out_test_setting();
+-void out_test_testing();
++void out_test_setting(unsigned int j);
++void out_test_testing(unsigned int j);
+ void out_test_end();
+
+ void out_wheel_start();
+-void out_wheel_advance();
++void out_wheel_advance(unsigned int i);
+ void out_wheel_end();
+
+--- types.h	2024-01-01 00:00:00.000000000 +0000
++++ types.h	2024-01-01 00:00:00.000000000 +0000
+@@ -22,5 +22,5 @@
+
+ struct test {
+     char *name;
+-    int (*fp)();
++    int (*fp)(ulv *bufa, ulv *bufb, size_t count);
+ };


### PR DESCRIPTION
memtester testsuite compilation is failing on latest distros with gcc-15, modified code to use gcc-13 for memtester if default gcc version is 15 or higher and revert it back.