### PR TITLE
xfstests: Add sys group creation/deletion support

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -390,7 +390,10 @@ class Xfstests(Test):
         os.chmod(self.workdir, 0o755)
         subprocess.check_call(["chmod", "-R", "a+rX", self.teststmpdir])
 
-        # Ensure test users exist
+        # Ensure test users and groups exist
+        if process.system('getent group sys', ignore_status=True):
+            process.system('groupadd sys', sudo=True)
+
         for user in ['fsgqa', 'fsgqa2', '123456-fsgqa']:
             if process.system(f'id {user}', ignore_status=True):
                 cmd = f'useradd -m {"-U " if user == "fsgqa" else ""}{user}'
@@ -448,8 +451,8 @@ class Xfstests(Test):
         for user in ['fsgqa', '123456-fsgqa', 'fsgqa2']:
             if not process.system(f'id {user}', ignore_status=True):
                 process.system(f'userdel -r -f {user}', sudo=True, ignore_status=True)
-        if not process.system('getent group fsgqa', ignore_status=True):
-            process.system('groupdel fsgqa', sudo=True, ignore_status=True)
+        if not process.system('getent group sys', ignore_status=True):
+            process.system('groupdel sys', sudo=True)
 
         # In case if any test has been interrupted
         process.system(f'umount {self.scratch_mnt} {self.test_mnt} {self.disk_mnt}',


### PR DESCRIPTION
Some xfstests require the 'sys' group to exist and skip with "[not run] sys group not defined" when it's missing. This change ensures the sys group is created before tests run and cleaned up afterward, preventing unnecessary test skips.

Before PR changes:
```
[stdlog] 2026-05-22 10:00:41,577 avocado.utils.process process          L0662 INFO | Running './check -R xunit xfs/026'
[stdlog] 2026-05-22 10:00:41,578 avocado.utils.process process          L0711 INFO | Command ./check -R xunit xfs/026 running on a thread
[stdlog] 2026-05-22 10:00:41,904 avocado.utils.process process          L0475 DEBUG| [stdout] FSTYP         -- xfs (non-debug)
[stdlog] 2026-05-22 10:00:41,914 avocado.utils.process process          L0475 DEBUG| [stdout] PLATFORM      -- Linux/ppc64le ltcrain108-lp4 7.1.0-rc4-00100-g8bc67e4db64a #6 SMP PREEMPT Thu May 21 09:02:51 CEST 2026
[stdlog] 2026-05-22 10:00:41,914 avocado.utils.process process          L0475 DEBUG| [stdout] MKFS_OPTIONS  -- -f -f -b size=4096 /dev/loop3
[stdlog] 2026-05-22 10:00:41,916 avocado.utils.process process          L0475 DEBUG| [stdout] MOUNT_OPTIONS -- -o context=system_u:object_r:root_t:s0 /dev/loop3 /mnt/scratch
[stdlog] 2026-05-22 10:00:41,916 avocado.utils.process process          L0475 DEBUG| [stdout]
[stdlog] 2026-05-22 10:00:43,814 avocado.utils.process process          L0475 DEBUG| [stdout] xfs/026
[stdlog] 2026-05-22 10:00:43,822 avocado.utils.process process          L0475 DEBUG| [stdout]
[stdlog] 2026-05-22 10:00:44,352 avocado.utils.process process          L0475 DEBUG| [stdout] [not run]
[stdlog] 2026-05-22 10:00:44,353 avocado.utils.process process          L0475 DEBUG| [stdout] sys group not defined.
[stdlog] 2026-05-22 10:00:44,373 avocado.utils.process process          L0475 DEBUG| [stdout] Ran: xfs/026
[stdlog] 2026-05-22 10:00:44,374 avocado.utils.process process          L0475 DEBUG| [stdout] Not run: xfs/026
[stdlog] 2026-05-22 10:00:44,374 avocado.utils.process process          L0475 DEBUG| [stdout] Passed all 1 tests
```
After PR changes:
```
[stdlog] 2026-05-22 10:03:56,356 avocado.utils.process process          L0662 INFO | Running './check -R xunit xfs/026'
[stdlog] 2026-05-22 10:03:56,357 avocado.utils.process process          L0711 INFO | Command ./check -R xunit xfs/026 running on a thread
[stdlog] 2026-05-22 10:03:56,593 avocado.utils.process process          L0475 DEBUG| [stdout] FSTYP         -- xfs (non-debug)
[stdlog] 2026-05-22 10:03:56,598 avocado.utils.process process          L0475 DEBUG| [stdout] PLATFORM      -- Linux/ppc64le ltcrain108-lp4 7.1.0-rc4-00100-g8bc67e4db64a #6 SMP PREEMPT Thu May 21 09:02:51 CEST 2026
[stdlog] 2026-05-22 10:03:56,599 avocado.utils.process process          L0475 DEBUG| [stdout] MKFS_OPTIONS  -- -f -f -b size=4096 /dev/loop3
[stdlog] 2026-05-22 10:03:56,600 avocado.utils.process process          L0475 DEBUG| [stdout] MOUNT_OPTIONS -- -o context=system_u:object_r:root_t:s0 /dev/loop3 /mnt/scratch
[stdlog] 2026-05-22 10:03:56,601 avocado.utils.process process          L0475 DEBUG| [stdout]
[stdlog] 2026-05-22 10:03:58,345 avocado.utils.process process          L0475 DEBUG| [stdout] xfs/026
[stdlog] 2026-05-22 10:03:58,351 avocado.utils.process process          L0475 DEBUG| [stdout]
[stdlog] 2026-05-22 10:04:11,989 avocado.utils.process process          L0475 DEBUG| [stdout]  13s
[stdlog] 2026-05-22 10:04:11,998 avocado.utils.process process          L0475 DEBUG| [stdout] Ran: xfs/026
[stdlog] 2026-05-22 10:04:11,998 avocado.utils.process process          L0475 DEBUG| [stdout] Passed all 1 tests
```
```
avocado run xfstests.py -m xfstests.py.data/xfs/ci.yaml
/usr/local/lib/python3.13/site-packages/avocado/core/__init__.py:18: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
JOB ID     : 825a4f6317b0b7830c0b9ef7355c16c77bd9a097
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2026-05-22T10.03-825a4f6/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_xfs_4k-loop_type-d875: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_xfs_4k-loop_type-d875: PASS (54.40 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2026-05-22T10.03-825a4f6/results.html
JOB TIME   : 66.83 s
```