### PR TITLE
memory/memhotplug: Fix stress tarball download and tearDown

### DIFF
--- a/memory/memhotplug.py
+++ b/memory/memhotplug.py
@@ -92,6 +92,7 @@ class MemStress(Test):
     '''
 
     def setUp(self):
+        self.blocks_hotpluggable = []
 
         if not memory.check_hotplug():
             self.cancel("UnSupported : memory hotplug not enabled\n")
@@ -99,7 +100,7 @@ class MemStress(Test):
         for package in ['automake', 'make', 'autoconf']:
             if not smm.check_installed(package) and not smm.install(package):
                 self.cancel('%s is needed for the test to be run' % package)
-        default_url = 'https://fossies.org/linux/privat/stress-1.0.7.tar.gz'
+        default_url = 'https://github.com/resurrecting-open-source-projects/stress/releases/download/1.0.7/stress-1.0.7.tar.gz'
         stress_tar_url = self.params.get('stress_tar_url', default=default_url)
         if not smm.check_installed('stress') and not smm.install('stress'):
             tarball = self.fetch_asset(stress_tar_url)
@@ -232,4 +233,6 @@ class MemStress(Test):
         self.__error_check()
 
     def tearDown(self):
-        self.hotplug_all(self.blocks_hotpluggable)
+        # Only attempt to hotplug if blocks were successfully initialized
+        if hasattr(self, 'blocks_hotpluggable') and self.blocks_hotpluggable:
+            self.hotplug_all(self.blocks_hotpluggable)

--- a/memory/memhotplug.py.data/memhotplug.yaml
+++ b/memory/memhotplug.py.data/memhotplug.yaml
@@ -1,4 +1,4 @@
-stress_tar_url: 'https://fossies.org/linux/privat/old/stress-1.0.5.tar.gz'
+stress_tar_url: 'https://github.com/resurrecting-open-source-projects/stress/releases/download/1.0.7/stress-1.0.7.tar.gz'
 iteration: 1
 stresstime: 10
 vmcount: 4


### PR DESCRIPTION
Test is failing with error "'MemStress' object has no attribute 'blocks_hotpluggable'" this patch fix below two issues:

1. Replace fossies.org stress tarball URL with GitHub mirror
   - The fossies.org URL returns HTTP 401 Unauthorized when accessed via avocado's fetch_asset(), though wget works fine
   - Switch to reliable GitHub mirror that doesn't require authentication: https://github.com/resurrecting-open-source-projects/stress/releases/download/1.0.7/stress-1.0.7.tar.gz

2. Prevent AttributeError crash in tearDown() when setUp() fails
   - Initialize self.blocks_hotpluggable = [] early in setUp()
   - Add safety check in tearDown() before calling hotplug_all()
   - Prevents crash when setUp() fails before blocks_hotpluggable is set