### PR TITLE
Removed upstream part as part of Distro CR run only distro related te…

### DIFF
--- a/kernel/kselftest.py.data/trace_tests.yaml
+++ b/kernel/kselftest.py.data/trace_tests.yaml
@@ -14,6 +14,3 @@ component: !mux
 run_type: !mux
     distro:
         type: 'distro'
-    upstream:
-        type: 'upstream'
-        location: 'https://github.com/torvalds/linux/archive/master.zip'


### PR DESCRIPTION
…sts to get run

Validate CR YAML files to track distro is used as the target instead of upstream so Removed upstream part as part of Distro CR run only distro related tests to get run 

As part of Trace CR bucket only distro testcases only to run ----> https://github.ibm.com/ltctest/avocado-fvt-wrapper/blob/master/config/tests/host/trace_sanity.cfg