### PR TITLE
kernel/kselftest.py.data/pmu.yaml & kernel/kselftest.py.data/upstream_pmu.yaml

### DIFF
--- a/kernel/kselftest.py.data/upstream_pmu.yaml
+++ b/kernel/kselftest.py.data/upstream_pmu.yaml
@@ -1,6 +1,7 @@
 run_type: !mux
-    distro:
-        type: 'distro'
+    upstream:
+        type: 'upstream'
+        location: "https://github.com/torvalds/linux/archive/master.zip"
 component: !mux
     pmu/ebb:
        comp: 'powerpc'


### PR DESCRIPTION
Removing upstream kselftest from distro runs, and creating a seperate upstream pmu yaml file for CI runs.