### PR TITLE
Handling decimal digit cpu between Shared and Dedicated value

### DIFF
--- a/dlpar/dlpar_main.py
+++ b/dlpar/dlpar_main.py
@@ -146,8 +146,8 @@ class DlparTests(Test):
         to get random values rather than using the same list which is generated
         through cpu_payload_data for performing mix operations
         '''
-        # Calculate the sum of the given list
-        total_sum = sum(values)
+        # Calculate the sum of the given list and convert to int for dedicated CPU
+        total_sum = int(sum(values))
         random_values = []
         remaining_sum = total_sum
 
@@ -233,7 +233,8 @@ class DlparTests(Test):
             self.log.info("======list of cpu's to be added :%s======" %
                           self.cpu_payload)
             for cpu in self.cpu_payload:
-                rvalue = Ded_obj.add_ded_cpu(cpu)
+                # Convert to int for dedicated mode as HMC requires integer values
+                rvalue = Ded_obj.add_ded_cpu(int(cpu))
                 if rvalue == 1:
                     # gives output printed by the last DLPAR command that ran on the HMC
                     stdout = Ded_obj.cmd_result.stdout_text
@@ -308,7 +309,8 @@ class DlparTests(Test):
             cpupayload = eval(str(loaded_payload_data[0]))
             self.log.info("list of cpu's to be removed :%s" % cpupayload)
             for cpu in cpupayload:
-                rvalue = Ded_obj.rem_ded_cpu(cpu)
+                # Convert to int for dedicated mode as HMC requires integer values
+                rvalue = Ded_obj.rem_ded_cpu(int(cpu))
                 if rvalue == 1:
                     # gives output printed by the last DLPAR command that ran on the HMC
                     stdout = Ded_obj.cmd_result.stdout_text
@@ -366,7 +368,8 @@ class DlparTests(Test):
             cpu_mix.append(sum_of_allcpu)
             self.log.info("list of cpu's :%s" % cpu_mix)
             for cpu in cpu_mix:
-                rvalue = Ded_obj.add_ded_cpu(cpu)
+                # Convert to int for dedicated mode as HMC requires integer values
+                rvalue = Ded_obj.add_ded_cpu(int(cpu))
                 if rvalue == 1:
                     # gives output printed by the last DLPAR command that ran on the HMC
                     stdout = Ded_obj.cmd_result.stdout_text
@@ -375,7 +378,8 @@ class DlparTests(Test):
                     self.fail("CPU add Command failed please check the logs")
                 self.log.info(
                     "===============>%s cpus got added=======>\n " % cpu)
-                rvalue = Ded_obj.rem_ded_cpu(cpu)
+                # Convert to int for dedicated mode as HMC requires integer values
+                rvalue = Ded_obj.rem_ded_cpu(int(cpu))
                 if rvalue == 1:
                     # gives output printed by the last DLPAR command that ran on the HMC
                     stdout = Ded_obj.cmd_result.stdout_text


### PR DESCRIPTION
Last PR I fixed shared dlpar float value control  which affected dedicated dlpar I fixed this issue in this PR

In dedicated mode without fix
==============================
ltcden14-lp11:~ # tail -f /root/avocado-fvt-wrapper/results/job-2026-06-10T11.56-863e33e
[stdlog] 2026-06-10 11:53:08,303 avocado.test dlpar_main       L0233 INFO | ======list of cpu's to be added :[1.0, 2.0, 3.0]======
[stdlog] 2026-06-10 11:53:08,303 avocado.utils.process process          L0662 INFO | Running '/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs''
[stdlog] 2026-06-10 11:53:08,304 avocado.utils.process process          L0711 INFO | Command /bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs' running on a thread
[stdlog] 2026-06-10 11:53:08,384 avocado.utils.process process          L0475 DEBUG| [stdout] 1
[stdlog] 2026-06-10 11:53:08,385 avocado.utils.process process          L0719 INFO | Command '/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs'' finished with 0 after 0.081010928s
[stdlog] 2026-06-10 11:54:08,385 avocado.utils.process process          L0662 INFO | Running '/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'chhwres -m ltcden14 -r proc -o a --procs 1.0 -p "ltcden14-lp11-Yeswanth" -w 0 ''
[stdlog] 2026-06-10 11:54:08,386 avocado.utils.process process          L0711 INFO | Command /bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'chhwres -m ltcden14 -r proc -o a --procs 1.0 -p "ltcden14-lp11-Yeswanth" -w 0 ' running on a thread
[stdlog] 2026-06-10 11:54:08,461 avocado.utils.process process          L0475 DEBUG| [stdout] The command entered is either missing a required parameter or a parameter value is invalid. The parameters that are missing or have an invalid value are --procs. Please check your entry and retry the command.
[stdlog] 2026-06-10 11:54:08,482 avocado.utils.process process          L0719 INFO | Command '/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'chhwres -m ltcden14 -r proc -o a --procs 1.0 -p "ltcden14-lp11-Yeswanth" -w 0 '' finished with 1 after 0.096240559s

In dedicated mode with my fix
=============================
ltcden14-lp11:~ # tail -f /root/avocado-fvt-wrapper/results/job-2026-06-10T11.56-863e33e/test-results/1-dlpar_main.py_DlparTests.test_cpu_add_run-config-lpar_mode-4012/debug.log 
[stderr] INFO    : Test finished successfully.
[stdlog] 2026-06-10 12:00:01,469 avocado.test dlpar_main       L0244 INFO | ===============> 1.0 cpu got added=======>
[stdlog]  
[stdlog] 2026-06-10 12:00:01,470 avocado.utils.process process          L0662 INFO | Running '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs''
[stdlog] 2026-06-10 12:00:01,470 avocado.utils.process process          L0711 INFO | Command /usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs' running on a thread
[stdlog] 2026-06-10 12:00:01,547 avocado.utils.process process          L0475 DEBUG| [stdout] 2
[stdlog] 2026-06-10 12:00:01,548 avocado.utils.process process          L0719 INFO | Command '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs'' finished with 0 after 0.077783254s
[stdlog] 2026-06-10 12:01:01,548 avocado.utils.process process          L0662 INFO | Running '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'chhwres -m ltcden14 -r proc -o a --procs 2 -p "ltcden14-lp11-Yeswanth" -w 0 ''
[stdlog] 2026-06-10 12:01:01,549 avocado.utils.process process          L0711 INFO | Command /usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'chhwres -m ltcden14 -r proc -o a --procs 2 -p "ltcden14-lp11-Yeswanth" -w 0 ' running on a thread
[stdlog] 2026-06-10 12:01:05,429 avocado.utils.process process          L0719 INFO | Command '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'chhwres -m ltcden14 -r proc -o a --procs 2 -p "ltcden14-lp11-Yeswanth" -w 0 '' finished with 0 after 3.880426471s
[stdlog] 2026-06-10 12:02:05,430 avocado.utils.process process          L0662 INFO | Running '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs''
[stdlog] 2026-06-10 12:02:05,431 avocado.utils.process process          L0711 INFO | Command /usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs' running on a thread
[stdlog] 2026-06-10 12:02:05,513 avocado.utils.process process          L0475 DEBUG| [stdout] 4
[stdlog] 2026-06-10 12:02:05,514 avocado.utils.process process          L0719 INFO | Command '/usr/bin/ssh -o 'StrictHostKeyChecking=no' -o 'UpdateHostKeys=no' -o 'ControlPath=~/.ssh/avocado-master-%r@%h:%p' -l hscroot -q 10.48.33.37 'lshwres -m ltcden14 --level lpar -r proc --filter lpar_names="ltcden14-lp11-Yeswanth" -F curr_procs'' finished with 0 after 0.083226972s
[stderr] INFO    : [PASS] Adding 2 dedicated cpus to partition ltcden14-lp11-Yeswanth.
[stderr] INFO    : Test finished successfully.