### PR TITLE
io/disk: Added disk_cleanup module and refactor test teardown [depended on util PR : 6312]

### DIFF
--- a/io/disk/bonnie.py
+++ b/io/disk/bonnie.py
@@ -23,11 +23,9 @@ Bonnie test
 """
 
 import os
-import time
 import getpass
 from avocado import Test
 from avocado.utils import archive
-from avocado.utils import wait
 from avocado.utils import build
 from avocado.utils import disk
 from avocado.utils import dmesg
@@ -37,6 +35,7 @@ from avocado.utils import process, distro
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class Bonnie(Test):
@@ -194,138 +193,18 @@ class Bonnie(Test):
 
     def pre_cleanup(self):
         """
-        cleanup the disk and directory before test starts on it
+        Cleanup disk before test using full mode.
+
+        full mode wipes the partition table and zeros the disk to ensure a
+        clean slate before bonnie++ runs.  Cancels the test on failure to
+        avoid running on a dirty disk.
         """
         self.log.info("Pre_cleaning of disk and directories...")
-        disk_list = ['/dev/mapper/avocado_vg-avocado_lv', self.raid_name,
-                     self.disk]
-        for disk in disk_list:
-            self.delete_fs(disk)
-        self.log.info("checking ...lv/vg existence...")
-        if lv_utils.lv_check(self.vgname, self.lvname):
-            self.log.info("found lv existence... deleting it")
-            self.delete_lv()
-        elif lv_utils.vg_check(self.vgname):
-            self.log.info("found vg existence ... deleting it")
-            lv_utils.vg_remove(self.vgname)
-        self.log.info("checking for softwareraid existence...")
-        if self.sw_raid.exists():
-            self.log.info("found softwareraid existence... deleting it")
-            self.delete_raid()
-        else:
-            self.log.info("No softwareraid detected ")
-        self.log.info("\n End of pre_cleanup")
-
-    def delete_raid(self):
-        """
-        it checks for existing of raid and deletes it if exists
-        """
-        self.log.info("deleting Sraid %s" % self.raid_name)
-
-        def is_raid_deleted():
-            self.sw_raid.stop()
-            self.sw_raid.clear_superblock()
-            self.log.info("checking for raid metadata")
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if self.sw_raid.exists():
-                return False
-            return True
-        self.log.info("checking lvm_metadata on %s" % self.raid_name)
-        cmd = 'blkid -o value -s TYPE %s' % self.raid_name
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.raid_name
-            process.system(cmd, shell=True, ignore_status=True)
-        if wait.wait_for(is_raid_deleted, timeout=10):
-            self.log.info("software raid  %s deleted" % self.raid_name)
-        else:
-            self.err_mesg.append("failed to delete sraid %s" % self.raid_name)
-
-    def delete_lv(self):
-        """
-        checks if lv/vg exists and delete them along with its metadata
-        if exists.
-        """
-        def is_lv_deleted():
-            lv_utils.lv_remove(self.vgname, self.lvname)
-            time.sleep(5)
-            lv_utils.vg_remove(self.vgname)
-            if lv_utils.lv_check(self.vgname, self.lvname):
-                return False
-            return True
-        if wait.wait_for(is_lv_deleted, timeout=10):
-            self.log.info("lv %s deleted" % self.lvname)
-        else:
-            self.err_mesg.append("failed to delete lv %s" % self.lvname)
-        # checking and deleting if lvm_meta_data exists after lv removed
-        cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.lv_disk
-            process.system(cmd, shell=True, ignore_status=True)
-
-    def delete_fs(self, l_disk):
-        """
-        checks for disk/dir mount, unmount if mounted and checks for
-        filesystem existence and wipe it off after dir/disk unmount.
-
-        :param l_disk: disk name for which you want to check the mount status
-        :return: None
-        """
-        def is_fs_deleted():
-            cmd = "wipefs -af %s" % l_disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.fs_exists(l_disk):
-                return False
-            return True
-
-        def is_disk_unmounted():
-            cmd = "umount %s" % l_disk
-            cmd1 = 'umount /dev/mapper/avocado_vg-avocado_lv'
-            process.system(cmd, shell=True, ignore_status=True)
-            process.system(cmd1, shell=True, ignore_status=True)
-            if disk.is_disk_mounted(l_disk):
-                return False
-            return True
-
-        def is_dir_unmounted():
-            cmd = 'umount %s' % self.dir
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.is_dir_mounted(self.dir):
-                return False
-            return True
-
-        self.log.info("checking if disk is mounted.")
-        if disk.is_disk_mounted(l_disk):
-            self.log.info("%s is mounted, unmounting it ....", l_disk)
-            if wait.wait_for(is_disk_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % l_disk)
-            else:
-                self.err_mesg.append("%s unmount failed", l_disk)
-        else:
-            self.log.info("disk %s not mounted." % l_disk)
-        self.log.info("checking if dir %s is mounted." % self.dir)
-        if disk.is_dir_mounted(self.dir):
-            self.log.info("%s is mounted, unmounting it ....", self.dir)
-            if wait.wait_for(is_dir_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % self.dir)
-            else:
-                self.err_mesg.append("failed to unount %s", self.dir)
-        else:
-            self.log.info("dir %s not mounted." % self.dir)
-        self.log.info("checking if fs exists in {}" .format(l_disk))
-        if disk.fs_exists(l_disk):
-            self.log.info("found fs on %s, removing it....", l_disk)
-            if wait.wait_for(is_fs_deleted, timeout=10):
-                self.log.info("fs removed successfully..")
-            else:
-                self.err_mesg.append(f'failed to delete fs on {l_disk}')
-        else:
-            self.log.info(f'No fs detected on {self.disk}')
-        self.log.info("Running dd...")
+        try:
+            cleanup_disks([self.disk], logger=self.log, mode="full")
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
 
     def test(self):
         """
@@ -345,12 +224,16 @@ class Bonnie(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if self.fs_create:
-            self.delete_fs(self.target)
-        if self.lv_create:
-            self.delete_lv()
-        if self.raid_create:
-            self.delete_raid()
-        dmesg.clear_dmesg()
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)
+
+        try:
+            dmesg.clear_dmesg()
+        except Exception as e:
+            self.log.warning("Failed to clear dmesg: %s", e)
+
         if self.err_mesg:
             self.warn("test failed due to following errors %s" % self.err_mesg)

--- a/io/disk/dbench.py
+++ b/io/disk/dbench.py
@@ -34,6 +34,7 @@ from avocado.utils import softwareraid
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
 from avocado.utils.software_manager.manager import SoftwareManager
+from avocado.utils.disk import cleanup_disks
 
 
 class Dbench(Test):
@@ -127,29 +128,27 @@ class Dbench(Test):
                     self.fs_create = True
 
     def pre_cleanup(self):
-        umount_dir = "umount -f %s" % self.mountpoint
-        process.system(umount_dir, shell=True, ignore_status=True)
-        delete_lv = "lvremove -f /dev/mapper/avocado_vg-avocado_lv"
-        process.system(delete_lv, shell=True, ignore_status=True)
-        delete_vg = "vgremove -f avocado_vg"
-        process.system(delete_vg, shell=True, ignore_status=True)
-        delete_rd = 'mdadm --stop /dev/%s' % self.md_name
-        process.system(delete_rd, shell=True, ignore_status=True)
+        """
+        Cleanup disk before test using light mode (default).
 
-    def clear_disk(self, obj, disk):
-        obj.unmount()
-        delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % disk
-        if process.system(delete_fs, shell=True, ignore_status=False):
-            self.fail("Failed to delete filesystem on %s", disk)
+        light mode removes LVM/RAID/mounts but keeps the partition table,
+        which is sufficient since a new filesystem is created right after.
+        cleanup_disks() validates that disk_list is non-empty, all entries
+        resolve to existing /dev paths, and mode is one of light/full/auto —
+        raising ValueError for invalid input.
+        Cancels the test on failure to avoid running on a dirty disk.
+        """
+        self.log.info("Pre_cleaning of disk and directories...")
+        try:
+            cleanup_disks([self.disk], logger=self.log)
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
 
     def create_raid(self, l_disk, l_raid_name):
         self.sraid = softwareraid.SoftwareRaid(l_raid_name, '0',
                                                l_disk.split(), '1.2')
         self.sraid.create()
-
-    def delete_raid(self):
-        self.sraid.stop()
-        self.sraid.clear_superblock()
 
     def create_lv(self, l_disk):
         vgname = 'avocado_vg'
@@ -158,12 +157,6 @@ class Dbench(Test):
         lv_utils.vg_create(vgname, l_disk, force=True)
         lv_utils.lv_create(vgname, lvname, lv_size)
         return '/dev/mapper/%s-%s' % (vgname, lvname)
-
-    def delete_lv(self):
-        vgname = 'avocado_vg'
-        lvname = 'avocado_lv'
-        lv_utils.lv_remove(vgname, lvname)
-        lv_utils.vg_remove(vgname)
 
     def create_fs(self, l_disk, fstype):
         self.part_obj = Partition(l_disk, mountpoint=self.mountpoint)
@@ -200,9 +193,8 @@ class Dbench(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if self.fs_create:
-            self.clear_disk(self.part_obj, self.disk)
-        if self.lv_create:
-            self.delete_lv()
-        if self.raid_create:
-            self.delete_raid()
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)

--- a/io/disk/disk_info.py
+++ b/io/disk/disk_info.py
@@ -33,6 +33,7 @@ from avocado.utils.partition import Partition
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.process import CmdError
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class DiskInfo(Test):
@@ -297,11 +298,16 @@ class DiskInfo(Test):
         '''
         Unmount the directory at the end if in case of test fails in between
         '''
-        if hasattr(self, "part_obj"):
-            if self.disk is not None:
-                self.log.info("Unmounting directory %s" % self.dirs)
-                self.part_obj.unmount()
-        self.log.info("Removing the filesystem created on %s" % self.disk)
-        delete_fs = f"dd if=/dev/zero bs=512 count=512 of={self.disk}"
-        if process.system(delete_fs, shell=True, ignore_status=True):
-            self.fail(f"Failed to delete filesystem on {self.disk}")
+        try:
+            if hasattr(self, "part_obj"):
+                if self.disk is not None:
+                    self.log.info("Unmounting directory %s" % self.dirs)
+                    self.part_obj.unmount()
+        except Exception as e:
+            self.log.warning("Failed to unmount: %s", e)
+
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)

--- a/io/disk/disktest.py
+++ b/io/disk/disktest.py
@@ -25,7 +25,6 @@ Disktest test
 import glob
 import os
 import shutil
-import time
 
 from avocado import Test
 from avocado.utils import build
@@ -34,11 +33,11 @@ from avocado.utils import dmesg
 from avocado.utils import process, distro
 from avocado.utils import disk
 from avocado.utils import lv_utils
-from avocado.utils import wait
 from avocado.utils.partition import Partition
 from avocado.utils import softwareraid
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class Disktest(Test):
@@ -134,7 +133,7 @@ class Disktest(Test):
                       self.dir)
 
         dmesg.clear_dmesg()
-        self.pre_cleanup()
+        cleanup_disks([self.disk], logger=self.log)
         if self.raid_needed:
             self.create_raid(self.target, self.raid_name)
             self.raid_create = True
@@ -178,27 +177,18 @@ class Disktest(Test):
 
     def pre_cleanup(self):
         """
-        cleanup the disk and directory before test starts on it
+        Cleanup disk before test using light mode (default).
+
+        light mode tears down LVM/RAID/mounts but preserves the partition
+        table — sufficient here since a fresh filesystem is created right
+        after.  Cancels the test on failure to avoid running on a dirty disk.
         """
         self.log.info("Pre_cleaning of disk and directories...")
-        disk_list = ['/dev/mapper/avocado_vg-avocado_lv', self.raid_name,
-                     self.disk]
-        for disk1 in disk_list:
-            self.delete_fs(disk1)
-        self.log.info("checking ...lv/vg existence...")
-        if lv_utils.lv_check(self.vgname, self.lvname):
-            self.log.info("found lv existence... deleting it")
-            self.delete_lv()
-        elif lv_utils.vg_check(self.vgname):
-            self.log.info("found vg existence ... deleting it")
-            lv_utils.vg_remove(self.vgname)
-        self.log.info("checking for softwareraid existence...")
-        if self.sw_raid.exists():
-            self.log.info("found softwareraid existence... deleting it")
-            self.delete_raid()
-        else:
-            self.log.info("No softwareraid detected ")
-        self.log.info("\n End of pre_cleanup")
+        try:
+            cleanup_disks([self.disk], logger=self.log)
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
 
     def _compile_disktest(self):
         """
@@ -224,116 +214,6 @@ class Disktest(Test):
         pid = proc.start()
         return pid, proc
 
-    def delete_raid(self):
-        """
-        it checks for existing of raid and deletes it if exists
-        """
-        self.log.info("deleting Sraid %s" % self.raid_name)
-
-        def is_raid_deleted():
-            self.sw_raid.stop()
-            self.sw_raid.clear_superblock()
-            self.log.info("checking for raid metadata")
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if self.sw_raid.exists():
-                return False
-            return True
-        self.log.info("checking lvm_metadata on %s" % self.raid_name)
-        cmd = 'blkid -o value -s TYPE %s' % self.raid_name
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.raid_name
-            process.system(cmd, shell=True, ignore_status=True)
-        if wait.wait_for(is_raid_deleted, timeout=10):
-            self.log.info("software raid  %s deleted" % self.raid_name)
-        else:
-            self.err_mesg.append("failed to delete sraid %s" % self.raid_name)
-
-    def delete_lv(self):
-        """
-        checks if lv/vg exists and delete them along with its metadata
-        if exists.
-        """
-        def is_lv_deleted():
-            lv_utils.lv_remove(self.vgname, self.lvname)
-            time.sleep(5)
-            lv_utils.vg_remove(self.vgname)
-            if lv_utils.lv_check(self.vgname, self.lvname):
-                return False
-            return True
-        if wait.wait_for(is_lv_deleted, timeout=10):
-            self.log.info("lv %s deleted" % self.lvname)
-        else:
-            self.err_mesg.append("failed to delete lv %s" % self.lvname)
-        # checking and deleting if lvm_meta_data exists after lv removed
-        cmd = 'blkid -o value -s TYPE %s' % self.disk
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-
-    def delete_fs(self, l_disk):
-        """
-        checks for disk/dir mount, unmount if mounted and checks for
-        filesystem existence and wipe it off after dir/disk unmount.
-
-        :param l_disk: disk name for which you want to check the mount status
-        :return: None
-        """
-        def is_fs_deleted():
-            cmd = "wipefs -af %s" % l_disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.fs_exists(l_disk):
-                return False
-            return True
-
-        def is_disk_unmounted():
-            cmd = "umount %s" % l_disk
-            cmd1 = 'umount /dev/mapper/avocado_vg-avocado_lv'
-            process.system(cmd, shell=True, ignore_status=True)
-            process.system(cmd1, shell=True, ignore_status=True)
-            if disk.is_disk_mounted(l_disk):
-                return False
-            return True
-
-        def is_dir_unmounted():
-            cmd = 'umount %s' % self.dir
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.is_dir_mounted(self.dir):
-                return False
-            return True
-
-        self.log.info("checking if disk is mounted.")
-        if disk.is_disk_mounted(l_disk):
-            self.log.info("%s is mounted, unmounting it ....", l_disk)
-            if wait.wait_for(is_disk_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % l_disk)
-            else:
-                self.err_mesg.append("%s unmount failed", l_disk)
-        else:
-            self.log.info("disk %s not mounted." % l_disk)
-        self.log.info("checking if dir %s is mounted." % self.dir)
-        if disk.is_dir_mounted(self.dir):
-            self.log.info("%s is mounted, unmounting it ....", self.dir)
-            if wait.wait_for(is_dir_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % self.dir)
-            else:
-                self.err_mesg.append("failed to unount %s", self.dir)
-        else:
-            self.log.info("dir %s not mounted." % self.dir)
-        self.log.info("checking if fs exists in {}" .format(l_disk))
-        if disk.fs_exists(l_disk):
-            self.log.info("found fs on %s, removing it....", l_disk)
-            if wait.wait_for(is_fs_deleted, timeout=10):
-                self.log.info("fs removed successfully..")
-            else:
-                self.err_mesg.append(f'failed to delete fs on {l_disk}')
-        else:
-            self.log.info(f'No fs detected on {self.disk}')
-
     def test(self):
         """
         Runs one iteration of disktest.
@@ -352,15 +232,28 @@ class Disktest(Test):
 
     def tearDown(self):
         """
-        To clean all the testfiles generated
+        Remove test files and fully wipe the disk.
+
+        Uses full mode (wipes partition table + zeros disk) to return the
+        disk to a pristine state for subsequent tests.  Contrast with
+        pre_cleanup() which uses light mode since a new FS follows immediately.
         """
-        for disk1 in getattr(self, "dir", []):
-            for filename in glob.glob("%s/testfile.*" % disk1):
-                os.remove(filename)
-        if self.fs_create:
-            self.delete_fs(self.target)
-        if self.raid_create:
-            self.delete_raid()
-        dmesg.clear_dmesg()
+        try:
+            for disk1 in getattr(self, "dir", []):
+                for filename in glob.glob("%s/testfile.*" % disk1):
+                    os.remove(filename)
+        except Exception as e:
+            self.log.warning("Failed to remove test files: %s", e)
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)
+
+        try:
+            dmesg.clear_dmesg()
+        except Exception as e:
+            self.log.warning("Failed to clear dmesg: %s", e)
+
         if self.err_mesg:
             self.warn("test failed due to following errors %s" % self.err_mesg)

--- a/io/disk/fiotest.py
+++ b/io/disk/fiotest.py
@@ -23,7 +23,6 @@ FIO Test
 """
 
 import os
-import time
 import avocado
 
 from avocado import Test
@@ -32,12 +31,13 @@ from avocado.utils import build
 from avocado.utils import pmem
 from avocado.utils import disk
 from avocado.utils import dmesg
-from avocado.utils import lv_utils, wait
+from avocado.utils import lv_utils
 from avocado.utils import process, distro
 from avocado.utils import softwareraid
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class FioTest(Test):
@@ -211,26 +211,11 @@ class FioTest(Test):
         cleanup the disk and directory before test starts on it
         """
         self.log.info("Pre_cleaning of disk and directories...")
-        disk_list = ['/dev/mapper/avocado_vg-avocado_lv', self.raid_name,
-                     self.disk]
-        for disk in disk_list:
-            self.delete_fs(disk)
-        self.log.info("checking ...lv/vg existence...")
-        if lv_utils.lv_check(self.vgname, self.lvname):
-            self.log.info("found lv existence... deleting it")
-            self.delete_lv()
-        elif lv_utils.vg_check(self.vgname):
-            self.log.info("found vg existence ... deleting it")
-            lv_utils.vg_remove(self.vgname)
-        else:
-            self.log.info("No VG/LV detected")
-        self.log.info("checking for sraid existence...")
-        if self.sraid.exists():
-            self.log.info("found sraid existence... deleting it")
-            self.delete_raid()
-        else:
-            self.log.info("No softwareraid detected ")
-        self.log.info("\n End of pre_cleanup")
+        try:
+            cleanup_disks([self.disk], logger=self.log)
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
 
     def create_raid(self, l_disk, l_raid_name):
         """
@@ -279,116 +264,6 @@ class FioTest(Test):
             self.fail("Mounting disk %s on directory %s failed"
                       % (l_disk, mountpoint))
 
-    def delete_raid(self):
-        """
-        it checks for existing of raid and deletes it if exists
-        """
-        self.log.info("deleting Sraid %s" % self.raid_name)
-
-        def is_raid_deleted():
-            self.sraid.stop()
-            self.sraid.clear_superblock()
-            self.log.info("checking for raid metadata")
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if self.sraid.exists():
-                return False
-            return True
-        self.log.info("checking lvm_metadata on %s" % self.raid_name)
-        cmd = 'blkid -o value -s TYPE %s' % self.raid_name
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.raid_name
-            process.system(cmd, shell=True, ignore_status=True)
-        if wait.wait_for(is_raid_deleted, timeout=10):
-            self.log.info("software raid  %s deleted" % self.raid_name)
-        else:
-            self.err_mesg.append("failed to delete raid %s" % self.raid_name)
-
-    def delete_lv(self):
-        """
-        checks if lv/vg exists and delete them along with its metadata
-        if exists.
-        """
-        def is_lv_deleted():
-            lv_utils.lv_remove(self.vgname, self.lvname)
-            time.sleep(5)
-            lv_utils.vg_remove(self.vgname)
-            if lv_utils.lv_check(self.vgname, self.lvname):
-                return False
-            return True
-        if wait.wait_for(is_lv_deleted, timeout=10):
-            self.log.info("lv %s deleted" % self.lvname)
-        else:
-            self.err_mesg.append("lv %s not deleted" % self.lvname)
-        # checking and deleting if lvm_meta_data exists after lv removed
-        cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.lv_disk
-            process.system(cmd, shell=True, ignore_status=True)
-
-    def delete_fs(self, l_disk):
-        """
-        checks for disk/dir mount, unmount if mounted and checks for
-        filesystem existence and wipe it off after dir/disk unmount.
-
-        :param l_disk: disk name for which you want to check the mount status
-        :return: None
-        """
-        def is_fs_deleted():
-            cmd = "wipefs -af %s" % l_disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.fs_exists(l_disk):
-                return False
-            return True
-
-        def is_disk_unmounted():
-            cmd = "umount %s" % l_disk
-            cmd1 = 'umount /dev/mapper/avocado_vg-avocado_lv'
-            process.system(cmd, shell=True, ignore_status=True)
-            process.system(cmd1, shell=True, ignore_status=True)
-            if disk.is_disk_mounted(l_disk):
-                return False
-            return True
-
-        def is_dir_unmounted():
-            cmd = 'umount %s' % self.dir
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.is_dir_mounted(self.dir):
-                return False
-            return True
-
-        self.log.info("checking if disk is mounted.")
-        if disk.is_disk_mounted(l_disk):
-            self.log.info("%s is mounted, unmounting it ....", l_disk)
-            if wait.wait_for(is_disk_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % l_disk)
-            else:
-                self.err_mesg.append("%s unmount failed", l_disk)
-        else:
-            self.log.info("disk %s not mounted." % l_disk)
-        self.log.info("checking if dir %s is mounted." % self.dir)
-        if disk.is_dir_mounted(self.dir):
-            self.log.info("%s is mounted, unmounting it ....", self.dir)
-            if wait.wait_for(is_dir_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % self.dir)
-            else:
-                self.err_mesg.append("failed to unount %s", self.dir)
-        else:
-            self.log.info("dir %s not mounted." % self.dir)
-        self.log.info("checking if fs exists in {}" .format(l_disk))
-        if disk.fs_exists(l_disk):
-            self.log.info("found fs on %s, removing it....", l_disk)
-            if wait.wait_for(is_fs_deleted, timeout=10):
-                self.log.info("fs removed successfully..")
-            else:
-                self.err_mesg.append("failed to delete fs on %s", l_disk)
-        else:
-            self.log.info("No fs detected on %s" % self.disk)
-
     def test(self):
         """
         Execute 'fio' with appropriate parameters.
@@ -425,14 +300,21 @@ class FioTest(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if os.path.exists(self.fio_file):
-            os.remove(self.fio_file)
-        if self.fs_create:
-            self.delete_fs(self.target)
-        if self.lv_create:
-            self.delete_lv()
-        if self.raid_create:
-            self.delete_raid()
-        dmesg.clear_dmesg()
+        try:
+            if os.path.exists(self.fio_file):
+                os.remove(self.fio_file)
+        except Exception as e:
+            self.log.warning("Failed to remove fio file: %s", e)
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)
+
+        try:
+            dmesg.clear_dmesg()
+        except Exception as e:
+            self.log.warning("Failed to clear dmesg: %s", e)
+
         if self.err_mesg:
             self.log.warn("test failed with errors: %s" % self.err_mesg)

--- a/io/disk/fs_mark.py
+++ b/io/disk/fs_mark.py
@@ -23,20 +23,19 @@
 fs_mark: Benchmark synchronous/async file creation
 """
 
-import time
 import os
 from avocado import Test
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import disk
 from avocado.utils import dmesg
-from avocado.utils import wait
 from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils import process, distro
 from avocado.utils.partition import Partition
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class FSMark(Test):
@@ -177,134 +176,11 @@ class FSMark(Test):
         cleanup the disk and directory before test starts on it
         """
         self.log.info("Pre_cleaning of disk and directories...")
-        disk_list = ['/dev/mapper/avocado_vg-avocado_lv', self.raid_name,
-                     self.disk]
-        for disk in disk_list:
-            self.delete_fs(disk)
-        self.log.info("checking ...lv/vg existence...")
-        if lv_utils.lv_check(self.vgname, self.lvname):
-            self.log.info("found lv existence... deleting it")
-            self.delete_lv()
-        elif lv_utils.vg_check(self.vgname):
-            self.log.info("found vg existence ... deleting it")
-            lv_utils.vg_remove(self.vgname)
-        self.log.info("checking for softwareraid existence...")
-        if self.sw_raid.exists():
-            self.log.info("found softwareraid existence... deleting it")
-            self.delete_raid()
-        else:
-            self.log.info("No softwareraid detected ")
-        self.log.info("\n End of pre_cleanup")
-
-    def delete_raid(self):
-        """
-        it checks for existing of raid and deletes it if exists
-        """
-        self.log.info("deleting Sraid %s" % self.raid_name)
-
-        def is_raid_deleted():
-            self.sw_raid.stop()
-            self.sw_raid.clear_superblock()
-            self.log.info("checking for raid metadata")
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if self.sw_raid.exists():
-                return False
-            return True
-        self.log.info("checking lvm_metadata on %s" % self.raid_name)
-        cmd = 'blkid -o value -s TYPE %s' % self.raid_name
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.raid_name
-            process.system(cmd, shell=True, ignore_status=True)
-        if wait.wait_for(is_raid_deleted, timeout=10):
-            self.log.info("software raid  %s deleted" % self.raid_name)
-        else:
-            self.err_mesg.append("failed to delete sraid %s" % self.raid_name)
-
-    def delete_lv(self):
-        """
-        checks if lv/vg exists and delete them along with its metadata
-        if exists.
-        """
-        def is_lv_deleted():
-            lv_utils.lv_remove(self.vgname, self.lvname)
-            time.sleep(5)
-            lv_utils.vg_remove(self.vgname)
-            if lv_utils.lv_check(self.vgname, self.lvname):
-                return False
-            return True
-        if wait.wait_for(is_lv_deleted, timeout=10):
-            self.log.info("lv %s deleted" % self.lvname)
-        else:
-            self.err_mesg.append("failed to delete lv %s" % self.lvname)
-        # checking and deleting if lvm_meta_data exists after lv removed
-        cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.lv_disk
-            process.system(cmd, shell=True, ignore_status=True)
-
-    def delete_fs(self, l_disk):
-        """
-        checks for disk/dir mount, unmount if mounted and checks for
-        filesystem existence and wipe it off after dir/disk unmount.
-
-        :param l_disk: disk name for which you want to check the mount status
-        :return: None
-        """
-        def is_fs_deleted():
-            cmd = "wipefs -af %s" % l_disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.fs_exists(l_disk):
-                return False
-            return True
-
-        def is_disk_unmounted():
-            cmd = "umount %s" % l_disk
-            cmd1 = 'umount /dev/mapper/avocado_vg-avocado_lv'
-            process.system(cmd, shell=True, ignore_status=True)
-            process.system(cmd1, shell=True, ignore_status=True)
-            if disk.is_disk_mounted(l_disk):
-                return False
-            return True
-
-        def is_dir_unmounted():
-            cmd = 'umount %s' % self.dir
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.is_dir_mounted(self.dir):
-                return False
-            return True
-
-        self.log.info("checking if disk is mounted.")
-        if disk.is_disk_mounted(l_disk):
-            self.log.info("%s is mounted, unmounting it ....", l_disk)
-            if wait.wait_for(is_disk_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % l_disk)
-            else:
-                self.err_mesg.append("%s unmount failed", l_disk)
-        else:
-            self.log.info("disk %s not mounted." % l_disk)
-        self.log.info("checking if dir %s is mounted." % self.dir)
-        if disk.is_dir_mounted(self.dir):
-            self.log.info("%s is mounted, unmounting it ....", self.dir)
-            if wait.wait_for(is_dir_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % self.dir)
-            else:
-                self.err_mesg.append("failed to unount %s", self.dir)
-        else:
-            self.log.info("dir %s not mounted." % self.dir)
-        self.log.info("checking if fs exists in {}" .format(l_disk))
-        if disk.fs_exists(l_disk):
-            self.log.info("found fs on %s, removing it....", l_disk)
-            if wait.wait_for(is_fs_deleted, timeout=10):
-                self.log.info("fs removed successfully..")
-            else:
-                self.err_mesg.append(f'failed to delete fs on {l_disk}')
-        else:
-            self.log.info(f'No fs detected on {self.disk}')
+        try:
+            cleanup_disks([self.disk], logger=self.log)
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
         self.log.info("Running dd...")
 
     def test(self):
@@ -319,14 +195,15 @@ class FSMark(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        # if self.link:
-        #    os.unlink(self.link)
-        if self.fs_create:
-            self.delete_fs(self.target)
-        if self.lv_create:
-            self.delete_lv()
-        if self.raid_create:
-            self.delete_raid()
-        dmesg.clear_dmesg()
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)
+        try:
+            dmesg.clear_dmesg()
+        except Exception as e:
+            self.log.warning("Failed to clear dmesg: %s", e)
+
         if self.err_mesg:
             self.warn("test failed due to following errors %s" % self.err_mesg)

--- a/io/disk/iozone.py
+++ b/io/disk/iozone.py
@@ -38,6 +38,7 @@ from avocado.utils import data_structures
 from avocado.utils import astring
 from avocado.utils.partition import PartitionError
 from avocado.utils.software_manager.manager import SoftwareManager
+from avocado.utils.disk import cleanup_disks
 
 
 _LABELS = ['file_size', 'record_size', 'write', 'rewrite', 'read', 'reread',
@@ -494,10 +495,6 @@ class IOZone(Test):
                                                l_disk.split(), '1.2')
         self.sraid.create()
 
-    def delete_raid(self):
-        self.sraid.stop()
-        self.sraid.clear_superblock()
-
     def create_lv(self, l_disk):
         vgname = 'avocado_vg'
         lvname = 'avocado_lv'
@@ -505,12 +502,6 @@ class IOZone(Test):
         lv_utils.vg_create(vgname, l_disk, force=True)
         lv_utils.lv_create(vgname, lvname, lv_size)
         return '/dev/%s/%s' % (vgname, lvname)
-
-    def delete_lv(self):
-        vgname = 'avocado_vg'
-        lvname = 'avocado_lv'
-        lv_utils.lv_remove(vgname, lvname)
-        lv_utils.vg_remove(vgname)
 
     def create_fs(self, l_disk, mountpoint, fstype):
         self.part_obj = Partition(l_disk, mountpoint=mountpoint)
@@ -521,12 +512,6 @@ class IOZone(Test):
         except PartitionError:
             self.fail("Mounting disk %s on directory %s failed"
                       % (l_disk, mountpoint))
-
-    def delete_fs(self, l_disk):
-        self.part_obj.unmount()
-        delete_fs = "dd if=/dev/zero bs=512 count=512 of=%s" % l_disk
-        if process.system(delete_fs, shell=True, ignore_status=True):
-            self.fail("Failed to delete filesystem on %s" % l_disk)
 
     @staticmethod
     def __get_section_name(desc):
@@ -663,10 +648,8 @@ class IOZone(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if self.disk is not None:
-            if self.fs_create:
-                self.delete_fs(self.disk)
-            if self.lv_create:
-                self.delete_lv()
-            if self.raid_create:
-                self.delete_raid()
+        if hasattr(self, 'disk') and self.disk is not None:
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)

--- a/io/disk/ltp_fs.py
+++ b/io/disk/ltp_fs.py
@@ -25,11 +25,9 @@ LTP Filesystem tests
 
 import shutil
 import os
-import time
 from avocado import Test
 from avocado.utils import disk
 from avocado.utils import dmesg
-from avocado.utils import wait
 from avocado.utils import lv_utils
 from avocado.utils import softwareraid
 from avocado.utils import build, distro
@@ -37,6 +35,7 @@ from avocado.utils import process, archive
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class LtpFs(Test):
@@ -210,135 +209,11 @@ class LtpFs(Test):
         cleanup the disk and directory before test starts on it
         """
         self.log.info("Pre_cleaning of disk and directories...")
-        disk_list = ['/dev/mapper/avocado_vg-avocado_lv', self.raid_name,
-                     self.disk]
-        for disk in disk_list:
-            self.delete_fs(disk)
-        self.log.info("checking ...lv/vg existence...")
-        if lv_utils.lv_check(self.vgname, self.lvname):
-            self.log.info("found lv existence... deleting it")
-            self.delete_lv()
-        elif lv_utils.vg_check(self.vgname):
-            self.log.info("found vg existence ... deleting it")
-            lv_utils.vg_remove(self.vgname)
-        self.log.info("checking for softwareraid existence...")
-        if self.sw_raid.exists():
-            self.log.info("found softwareraid existence... deleting it")
-            self.delete_raid()
-        else:
-            self.log.info("No softwareraid detected ")
-        self.log.info("\n End of pre_cleanup")
-
-    def delete_raid(self):
-        """
-        it checks for existing of raid and deletes it if exists
-        """
-        self.log.info("deleting Sraid %s" % self.raid_name)
-
-        def is_raid_deleted():
-            self.sw_raid.stop()
-            self.sw_raid.clear_superblock()
-            self.log.info("checking for raid metadata")
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if self.sw_raid.exists():
-                return False
-            return True
-        self.log.info("checking lvm_metadata on %s" % self.raid_name)
-        cmd = 'blkid -o value -s TYPE %s' % self.raid_name
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.raid_name
-            process.system(cmd, shell=True, ignore_status=True)
-        if wait.wait_for(is_raid_deleted, timeout=10):
-            self.log.info("software raid  %s deleted" % self.raid_name)
-        else:
-            self.err_mesg.extend(["failed to delete swraid %s" %
-                                  self.raid_name])
-
-    def delete_lv(self):
-        """
-        checks if lv/vg exists and delete them along with its metadata
-        if exists.
-        """
-        def is_lv_deleted():
-            lv_utils.lv_remove(self.vgname, self.lvname)
-            time.sleep(5)
-            lv_utils.vg_remove(self.vgname)
-            if lv_utils.lv_check(self.vgname, self.lvname):
-                return False
-            return True
-        if wait.wait_for(is_lv_deleted, timeout=10):
-            self.log.info("lv %s deleted", self.lvname)
-        else:
-            self.err_mesg.extend(["failed to delete lv %s" % self.lvname])
-        # checking and deleting if lvm_meta_data exists after lv removed
-        cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.lv_disk
-            process.system(cmd, shell=True, ignore_status=True)
-
-    def delete_fs(self, l_disk):
-        """
-        checks for disk/dir mount, unmount if mounted and checks for
-        filesystem existence and wipe it off after dir/disk unmount.
-
-        :param l_disk: disk name for which you want to check the mount status
-        :return: None
-        """
-        def is_fs_deleted():
-            cmd = "wipefs -af %s" % l_disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.fs_exists(l_disk):
-                return False
-            return True
-
-        def is_disk_unmounted():
-            cmd = "umount %s" % l_disk
-            cmd1 = 'umount /dev/mapper/avocado_vg-avocado_lv'
-            process.system(cmd, shell=True, ignore_status=True)
-            process.system(cmd1, shell=True, ignore_status=True)
-            if disk.is_disk_mounted(l_disk):
-                return False
-            return True
-
-        def is_dir_unmounted():
-            cmd = 'umount %s' % self.dir
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.is_dir_mounted(self.dir):
-                return False
-            return True
-
-        self.log.info("checking if disk is mounted.")
-        if disk.is_disk_mounted(l_disk):
-            self.log.info("%s is mounted, unmounting it ....", l_disk)
-            if wait.wait_for(is_disk_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % l_disk)
-            else:
-                self.err_mesg.extend(["%s unmount failed", l_disk])
-        else:
-            self.log.info("disk %s not mounted." % l_disk)
-        self.log.info("checking if dir %s is mounted." % self.dir)
-        if disk.is_dir_mounted(self.dir):
-            self.log.info("%s is mounted, unmounting it ....", self.dir)
-            if wait.wait_for(is_dir_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % self.dir)
-            else:
-                self.err_mesg.extend(["failed to unount %s", self.dir])
-        else:
-            self.log.info("dir %s not mounted." % self.dir)
-        self.log.info("checking if fs exists in {}" .format(l_disk))
-        if disk.fs_exists(l_disk):
-            self.log.info("found fs on %s, removing it....", l_disk)
-            if wait.wait_for(is_fs_deleted, timeout=10):
-                self.log.info("fs removed successfully..")
-            else:
-                self.err_mesg.extend([f"failed to delete fs on {l_disk}"])
-        else:
-            self.log.info("No fs detected on %s" % self.disk)
+        try:
+            cleanup_disks([self.disk], logger=self.log)
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
 
     def test_fs_run(self):
         '''
@@ -398,13 +273,16 @@ class LtpFs(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if self.fs_create:
-            self.delete_fs(self.target)
-        if self.lv_create:
-            self.delete_lv()
-        if self.raid_create:
-            self.delete_raid()
-        dmesg.clear_dmesg()
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)
+        try:
+            dmesg.clear_dmesg()
+        except Exception as e:
+            self.log.warning("Failed to clear dmesg: %s", e)
+
         if self.err_mesg:
             self.log.warning("test failed due to following errors %s" %
                              self.err_mesg)

--- a/io/disk/ltp_fsstress.py
+++ b/io/disk/ltp_fsstress.py
@@ -22,19 +22,18 @@ LTP fsstress test
 """
 
 import os
-import time
 from avocado import Test
 from avocado.utils import build
 from avocado.utils import disk
 from avocado.utils import dmesg
 from avocado.utils import lv_utils
-from avocado.utils import wait
 from avocado.utils import softwareraid
 from avocado.utils import distro
 from avocado.utils import process, archive
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class LtpFs(Test):
@@ -185,134 +184,11 @@ class LtpFs(Test):
         cleanup the disk and directory before test starts on it
         """
         self.log.info("Pre_cleaning of disk and directories...")
-        disk_list = ['/dev/mapper/avocado_vg-avocado_lv', self.raid_name,
-                     self.disk]
-        for disk in disk_list:
-            self.delete_fs(disk)
-        self.log.info("checking ...lv/vg existence...")
-        if lv_utils.lv_check(self.vgname, self.lvname):
-            self.log.info("found lv existence... deleting it")
-            self.delete_lv()
-        elif lv_utils.vg_check(self.vgname):
-            self.log.info("found vg existence ... deleting it")
-            lv_utils.vg_remove(self.vgname)
-        self.log.info("checking for softwareraid existence...")
-        if self.sw_raid.exists():
-            self.log.info("found softwareraid existence... deleting it")
-            self.delete_raid()
-        else:
-            self.log.info("No softwareraid detected ")
-        self.log.info("\n End of pre_cleanup")
-
-    def delete_raid(self):
-        """
-        it checks for existing of raid and deletes it if exists
-        """
-        self.log.info("deleting Sraid %s" % self.raid_name)
-
-        def is_raid_deleted():
-            self.sw_raid.stop()
-            self.sw_raid.clear_superblock()
-            self.log.info("checking for raid metadata")
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if self.sw_raid.exists():
-                return False
-            return True
-        self.log.info("checking lvm_metadata on %s" % self.raid_name)
-        cmd = 'blkid -o value -s TYPE %s' % self.raid_name
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.raid_name
-            process.system(cmd, shell=True, ignore_status=True)
-        if wait.wait_for(is_raid_deleted, timeout=10):
-            self.log.info("software raid  %s deleted" % self.raid_name)
-        else:
-            self.err_mesg.extend(['failed to delete sraid %s' % self.raid_name])
-
-    def delete_lv(self):
-        """
-        checks if lv/vg exists and delete them along with its metadata
-        if exists.
-        """
-        def is_lv_deleted():
-            lv_utils.lv_remove(self.vgname, self.lvname)
-            time.sleep(5)
-            lv_utils.vg_remove(self.vgname)
-            if lv_utils.lv_check(self.vgname, self.lvname):
-                return False
-            return True
-        if wait.wait_for(is_lv_deleted, timeout=10):
-            self.log.info("lv %s deleted", self.lvname)
-        else:
-            self.err_mesg.extend(['failed to delete lv %s' % self.lvname])
-        # checking and deleting if lvm_meta_data exists after lv removed
-        cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.lv_disk
-            process.system(cmd, shell=True, ignore_status=True)
-
-    def delete_fs(self, l_disk):
-        """
-        checks for disk/dir mount, unmount if mounted and checks for
-        filesystem existence and wipe it off after dir/disk unmount.
-
-        :param l_disk: disk name for which you want to check the mount status
-        :return: None
-        """
-        def is_fs_deleted():
-            cmd = "wipefs -af %s" % l_disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.fs_exists(l_disk):
-                return False
-            return True
-
-        def is_disk_unmounted():
-            cmd = "umount %s" % l_disk
-            cmd1 = 'umount /dev/mapper/avocado_vg-avocado_lv'
-            process.system(cmd, shell=True, ignore_status=True)
-            process.system(cmd1, shell=True, ignore_status=True)
-            if disk.is_disk_mounted(l_disk):
-                return False
-            return True
-
-        def is_dir_unmounted():
-            cmd = 'umount %s' % self.dir
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.is_dir_mounted(self.dir):
-                return False
-            return True
-
-        self.log.info("checking if disk is mounted.")
-        if disk.is_disk_mounted(l_disk):
-            self.log.info("%s is mounted, unmounting it ....", l_disk)
-            if wait.wait_for(is_disk_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % l_disk)
-            else:
-                self.err_mesg.extend(['%s unmount failed', l_disk])
-        else:
-            self.log.info("disk %s not mounted." % l_disk)
-        self.log.info("checking if dir %s is mounted." % self.dir)
-        if disk.is_dir_mounted(self.dir):
-            self.log.info("%s is mounted, unmounting it ....", self.dir)
-            if wait.wait_for(is_dir_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % self.dir)
-            else:
-                self.err_mesg.extend(['failed to unount %s', self.dir])
-        else:
-            self.log.info("dir %s not mounted." % self.dir)
-        self.log.info("checking if fs exists in {}" .format(l_disk))
-        if disk.fs_exists(l_disk):
-            self.log.info("found fs on %s, removing it....", l_disk)
-            if wait.wait_for(is_fs_deleted, timeout=10):
-                self.log.info("fs removed successfully..")
-            else:
-                self.err_mesg.extend([f'failed to delete fs on {l_disk}'])
-        else:
-            self.log.info(f'No fs detected on {self.disk}')
+        try:
+            cleanup_disks([self.disk], logger=self.log)
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
 
     def test_fsstress_run(self):
         '''
@@ -334,12 +210,16 @@ class LtpFs(Test):
         '''
         Cleanup of disk used to perform this test
         '''
-        if self.fs_create:
-            self.delete_fs(self.target)
-        if self.lv_create:
-            self.delete_lv()
-        if self.raid_create:
-            self.delete_raid()
-        dmesg.clear_dmesg()
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)
+
+        try:
+            dmesg.clear_dmesg()
+        except Exception as e:
+            self.log.warning("Failed to clear dmesg: %s", e)
+
         if self.err_mesg:
             self.log.warning("test failed due to following errors %s" % self.err_mesg)

--- a/io/disk/lvsetup.py
+++ b/io/disk/lvsetup.py
@@ -37,6 +37,7 @@ from avocado.utils import lv_utils
 from avocado.utils import distro
 from avocado.utils import disk
 from avocado.utils.disk import DiskError
+from avocado.utils.disk import cleanup_disks
 
 
 class Lvsetup(Test):
@@ -216,3 +217,9 @@ class Lvsetup(Test):
         self.delete_lv()
         if not self.disks:
             disk.delete_loop_device(self.device)
+
+        if hasattr(self, 'disks') and self.disks:
+            try:
+                cleanup_disks(self.disks, logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disks, e)

--- a/io/disk/parallel_dd.py
+++ b/io/disk/parallel_dd.py
@@ -31,6 +31,7 @@ import json
 from avocado import Test
 from avocado.utils import process, distro, disk
 from avocado.utils import partition as partition_lib
+from avocado.utils.disk import cleanup_disks
 
 
 class ParallelDd(Test):
@@ -212,9 +213,15 @@ class ParallelDd(Test):
 
     def tearDown(self):
         """
-        Formatting the disk.
+        Cleanup disk used in test
         """
         try:
             self.fsys.unmount()
         except process.CmdError:
             pass
+
+        if hasattr(self, 'disk') and self.disk:
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)

--- a/io/disk/softwareraid.py
+++ b/io/disk/softwareraid.py
@@ -29,6 +29,7 @@ from avocado import Test
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import disk
 from avocado.utils import softwareraid
+from avocado.utils.disk import cleanup_disks
 
 
 class SoftwareRaid(Test):
@@ -97,3 +98,9 @@ class SoftwareRaid(Test):
         if hasattr(self, "sraid"):
             self.sraid.stop()
             self.sraid.clear_superblock()
+
+        if hasattr(self, 'disks') and self.disks:
+            try:
+                cleanup_disks(self.disks, logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disks, e)

--- a/io/disk/tiobench.py
+++ b/io/disk/tiobench.py
@@ -25,9 +25,7 @@ to measure file system performance.
 """
 
 import os
-import time
 from avocado import Test
-from avocado.utils import wait
 from avocado.utils import archive
 from avocado.utils import build
 from avocado.utils import disk
@@ -38,6 +36,7 @@ from avocado.utils import process, distro
 from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils.partition import Partition
 from avocado.utils.partition import PartitionError
+from avocado.utils.disk import cleanup_disks
 
 
 class Tiobench(Test):
@@ -169,134 +168,11 @@ class Tiobench(Test):
         cleanup the disk and directory before test starts on it
         """
         self.log.info("Pre_cleaning of disk and directories...")
-        disk_list = ['/dev/mapper/avocado_vg-avocado_lv', self.raid_name,
-                     self.disk]
-        for disk in disk_list:
-            self.delete_fs(disk)
-        self.log.info("checking ...lv/vg existence...")
-        if lv_utils.lv_check(self.vgname, self.lvname):
-            self.log.info("found lv existence... deleting it")
-            self.delete_lv()
-        elif lv_utils.vg_check(self.vgname):
-            self.log.info("found vg existence ... deleting it")
-            lv_utils.vg_remove(self.vgname)
-        self.log.info("checking for softwareraid existence...")
-        if self.sw_raid.exists():
-            self.log.info("found softwareraid existence... deleting it")
-            self.delete_raid()
-        else:
-            self.log.info("No softwareraid detected ")
-        self.log.info("\n End of pre_cleanup")
-
-    def delete_raid(self):
-        """
-        it checks for existing of raid and deletes it if exists
-        """
-        self.log.info("deleting Sraid %s" % self.raid_name)
-
-        def is_raid_deleted():
-            self.sw_raid.stop()
-            self.sw_raid.clear_superblock()
-            self.log.info("checking for raid metadata")
-            cmd = "wipefs -af %s" % self.disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if self.sw_raid.exists():
-                return False
-            return True
-        self.log.info("checking lvm_metadata on %s" % self.raid_name)
-        cmd = 'blkid -o value -s TYPE %s' % self.raid_name
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.raid_name
-            process.system(cmd, shell=True, ignore_status=True)
-        if wait.wait_for(is_raid_deleted, timeout=10):
-            self.log.info("software raid  %s deleted" % self.raid_name)
-        else:
-            self.err_mesg.append("failed to delete sraid %s" % self.raid_name)
-
-    def delete_lv(self):
-        """
-        checks if lv/vg exists and delete them along with its metadata
-        if exists.
-        """
-        def is_lv_deleted():
-            lv_utils.lv_remove(self.vgname, self.lvname)
-            time.sleep(5)
-            lv_utils.vg_remove(self.vgname)
-            if lv_utils.lv_check(self.vgname, self.lvname):
-                return False
-            return True
-        if wait.wait_for(is_lv_deleted, timeout=10):
-            self.log.info("lv %s deleted" % self.lvname)
-        else:
-            self.err_mesg.append("failed to delete lv %s" % self.lvname)
-        # checking and deleting if lvm_meta_data exists after lv removed
-        cmd = 'blkid -o value -s TYPE %s' % self.lv_disk
-        out = process.system_output(cmd, shell=True,
-                                    ignore_status=True).decode("utf-8")
-        if out == 'LVM2_member':
-            cmd = "wipefs -af %s" % self.lv_disk
-            process.system(cmd, shell=True, ignore_status=True)
-
-    def delete_fs(self, l_disk):
-        """
-        checks for disk/dir mount, unmount if mounted and checks for
-        filesystem existence and wipe it off after dir/disk unmount.
-
-        :param l_disk: disk name for which you want to check the mount status
-        :return: None
-        """
-        def is_fs_deleted():
-            cmd = "wipefs -af %s" % l_disk
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.fs_exists(l_disk):
-                return False
-            return True
-
-        def is_disk_unmounted():
-            cmd = "umount %s" % l_disk
-            cmd1 = 'umount /dev/mapper/avocado_vg-avocado_lv'
-            process.system(cmd, shell=True, ignore_status=True)
-            process.system(cmd1, shell=True, ignore_status=True)
-            if disk.is_disk_mounted(l_disk):
-                return False
-            return True
-
-        def is_dir_unmounted():
-            cmd = 'umount %s' % self.dir
-            process.system(cmd, shell=True, ignore_status=True)
-            if disk.is_dir_mounted(self.dir):
-                return False
-            return True
-
-        self.log.info("checking if disk is mounted.")
-        if disk.is_disk_mounted(l_disk):
-            self.log.info("%s is mounted, unmounting it ....", l_disk)
-            if wait.wait_for(is_disk_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % l_disk)
-            else:
-                self.err_mesg.append("%s unmount failed", l_disk)
-        else:
-            self.log.info("disk %s not mounted." % l_disk)
-        self.log.info("checking if dir %s is mounted." % self.dir)
-        if disk.is_dir_mounted(self.dir):
-            self.log.info("%s is mounted, unmounting it ....", self.dir)
-            if wait.wait_for(is_dir_unmounted, timeout=10):
-                self.log.info("%s unmounted successfully" % self.dir)
-            else:
-                self.err_mesg.append("failed to unount %s", self.dir)
-        else:
-            self.log.info("dir %s not mounted." % self.dir)
-        self.log.info("checking if fs exists in {}" .format(l_disk))
-        if disk.fs_exists(l_disk):
-            self.log.info("found fs on %s, removing it....", l_disk)
-            if wait.wait_for(is_fs_deleted, timeout=10):
-                self.log.info("fs removed successfully..")
-            else:
-                self.err_mesg.append(f'failed to delete fs on {l_disk}')
-        else:
-            self.log.info(f'No fs detected on {self.disk}')
+        try:
+            cleanup_disks([self.disk], logger=self.log)
+            self.log.info("Pre-cleanup completed successfully")
+        except Exception as e:
+            self.cancel("Pre-cleanup failed, cannot run on dirty disk: %s" % e)
 
     def test(self):
         """
@@ -326,12 +202,16 @@ class Tiobench(Test):
         """
         Cleanup of disk used to perform this test
         """
-        if self.fs_create:
-            self.delete_fs(self.target)
-        if self.lv_create:
-            self.delete_lv()
-        if self.raid_create:
-            self.delete_raid()
-        dmesg.clear_dmesg()
+        if getattr(self, 'disk', None):
+            try:
+                cleanup_disks([self.disk], logger=self.log, mode="full")
+            except Exception as e:
+                self.log.error("Disk cleanup failed for %s: %s", self.disk, e)
+
+        try:
+            dmesg.clear_dmesg()
+        except Exception as e:
+            self.log.warning("Failed to clear dmesg: %s", e)
+
         if self.err_mesg:
             self.warn("test failed due to following errors %s" % self.err_mesg)


### PR DESCRIPTION
Added new disk_cleanup.py module providing comprehensive disk cleanup functionality for storage test teardown. This module handles:
- Multipath device normalization
- LVM/RAID dependency graph building
- Filesystem unmounting and swap disabling
- LVM volume group and logical volume removal
- RAID array cleanup with member device handling
- Partition table removal and metadata wiping
- Disk zeroing for complete cleanup

Refactor 13 test files to use the new cleanup_disks() function:
- ltp_fsstress.py, tiobench.py, fiotest.py, lvsetup.py
- softwareraid.py, dbench.py, iozone.py, parallel_dd.py
- disk_info.py, bonnie.py, ltp_fs.py, disktest.py, fs_mark.py

Benefits:
- Consistent cleanup across all disk I/O tests
- Reduced code duplication (DRY principle)
- Better handling of complex storage configurations
- Improved test reliability and cleanup robustness