### PR TITLE
pb/swraid rebuild_sync_lvm extend

### DIFF
--- a/io/driver/driver_parameter_block_device.py
+++ b/io/driver/driver_parameter_block_device.py
@@ -41,7 +41,8 @@ class Moduleparameter(Test):
         self.mpath_enabled = self.params.get('multipath_enabled',
                                              default=False)
         self.disk = self.params.get('disk', default=None)
-        self.load_unload_sleep_time = 30
+        self.load_unload_sleep_time = self.params.get('load_unload_sleep_time',
+                                                      default=30)
         self.error_modules = []
         self.uname = linux_modules.platform.uname()[2]
         if not self.module:

--- a/io/driver/driver_parameter_block_device.py.data/driver_parameter_block_device_vscsi.yaml
+++ b/io/driver/driver_parameter_block_device.py.data/driver_parameter_block_device_vscsi.yaml
@@ -1,0 +1,52 @@
+module: 'ibmvscsi'
+multipath_enabled: False
+disk:
+load_unload_sleep_time: 60
+
+Test: !mux
+
+    client_reserve:
+        module_param_name: "client_reserve"
+        value: !mux
+            client_reserve_0:
+                module_param_value: "0"
+            client_reserve_1:
+                module_param_value: "1"
+
+    fast_fail:
+        module_param_name: "fast_fail"
+        value: !mux
+            fast_fail_0:
+                module_param_value: "0"
+            fast_fail_1:
+                module_param_value: "1"
+
+    init_timeout:
+        module_param_name: "init_timeout"
+        value: !mux
+            init_timeout_0:
+                module_param_value: "0"
+            init_timeout_60:
+                module_param_value: "60"
+            init_timeout_300:
+                module_param_value: "300"
+
+    max_channel:
+        module_param_name: "max_channel"
+        value: !mux
+            max_channel_0:
+                module_param_value: "0"
+            max_channel_1:
+                module_param_value: "1"
+            max_channel_16:
+                module_param_value: "16"
+
+    max_id:
+        module_param_name: "max_id"
+        value: !mux
+            max_id_0:
+                module_param_value: "0"
+            max_id_64:
+                module_param_value: "64"
+            max_id_256:
+                module_param_value: "256"


### PR DESCRIPTION
Add comprehensive test for Software RAID rebuild, synchronization, and LVM extend operations.