### PR TITLE
[avocado-misc][perf]: update perf_bin path in yaml configs

### DIFF
--- a/perf/perf_basic.py.data/perf_basic.yaml
+++ b/perf/perf_basic.py.data/perf_basic.yaml
@@ -1,1 +1,1 @@
-perf_bin: '/tmp/perf'
+perf_bin: '/usr/local/perf'

--- a/perf/perf_duplicate_probe.py.data/perf_duplicate_probe.yaml
+++ b/perf/perf_duplicate_probe.py.data/perf_duplicate_probe.yaml
@@ -1,1 +1,1 @@
-perf_bin: '/tmp/perf'
+perf_bin: '/usr/local/perf'

--- a/perf/perf_events_crash_test.py.data/perf_events_crash_test.yaml
+++ b/perf/perf_events_crash_test.py.data/perf_events_crash_test.yaml
@@ -1,1 +1,1 @@
-perf_bin: '/tmp/perf'
+perf_bin: '/usr/local/perf'

--- a/perf/perf_events_test.py.data/perf_events_test.yaml
+++ b/perf/perf_events_test.py.data/perf_events_test.yaml
@@ -1,1 +1,1 @@
-perf_bin: '/tmp/perf'
+perf_bin: '/usr/local/perf'

--- a/perf/perf_script_bug.py.data/perf_script_bug.yaml
+++ b/perf/perf_script_bug.py.data/perf_script_bug.yaml
@@ -1,1 +1,1 @@
-perf_bin: '/tmp/perf'
+perf_bin: '/usr/local/perf'

--- a/perf/perftool_test.py.data/perftool_test.yaml
+++ b/perf/perftool_test.py.data/perftool_test.yaml
@@ -1,1 +1,1 @@
-perf_bin: '/tmp/perf'
+perf_bin: '/usr/local/perf'


### PR DESCRIPTION
The perf test data yaml files set perf_bin to /tmp/perf, a transient location that does not match where the built perf binary is installed. Point perf_bin to /usr/local/bin/perf so the tests consistently use the locally built/installed perf binary.

Affected tests: perf_basic, perf_duplicate_probe, perf_events_crash_test, perf_events_test, perf_script_bug, perftool_test.
