### PR TITLE
Adding numa to ltp-mem.yaml

### DIFF
--- a/generic/ltp.py.data/ltp-mem.yaml
+++ b/generic/ltp.py.data/ltp-mem.yaml
@@ -10,3 +10,5 @@ general: !mux
         thp-page-cache:
             args: '-f mm'
             tmpfs_mount_dir: '/mnt/thp/'
+        numa:
+            args: '-f numa'


### PR DESCRIPTION
Added numa to ltp-mem.yaml to run numa LTP tests along with mem tests.


Logs:

https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Fetching asset from ltp.py:LTP.test
Fetching asset from ltp.py:LTP.test
JOB ID     : 8598e440d5899200e12c1671992ea7dad918b422
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2026-06-20T13.43-8598e44/job.log
 (1/4) ltp.py:LTP.test;run-general-kirk-mm-f469: STARTED
 (1/4) ltp.py:LTP.test;run-general-kirk-mm-f469:  PASS (4343.58 s)
 (2/4) ltp.py:LTP.test;run-general-kirk-hugetlb-5c53: STARTED
 (2/4) ltp.py:LTP.test;run-general-kirk-hugetlb-5c53:  PASS (43.01 s)
 (3/4) ltp.py:LTP.test;run-general-kirk-thp-page-cache-2827: STARTED
 (3/4) ltp.py:LTP.test;run-general-kirk-thp-page-cache-2827:  PASS (4463.56 s)
 (4/4) ltp.py:LTP.test;run-general-kirk-numa-0919: STARTED
 (4/4) ltp.py:LTP.test;run-general-kirk-numa-0919:  PASS (3692.15 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2026-06-20T13.43-8598e44/results.html
JOB TIME   : 12686.27 s