### PR TITLE
will-it-scale: Add step optimization patch for large systems

### DIFF
--- a/kernel/will-it-scale.py
+++ b/kernel/will-it-scale.py
@@ -223,7 +223,7 @@ class WillItScaleTest(Test):
         """
         self.distro_rel = distro.detect()
         smm = SoftwareManager()
-        deps = ['gcc', 'make']
+        deps = ['gcc', 'make', 'patch']
         if self.distro_rel.name.lower() in ['fedora', 'redhat', 'rhel']:
             deps.extend(['hwloc-devel'])
         for package in deps:
@@ -243,6 +243,19 @@ class WillItScaleTest(Test):
         archive.extract(tarball, self.workdir)
         self.sourcedir = os.path.join(self.workdir, 'will-it-scale-master')
         os.chdir(self.sourcedir)
+
+        # Apply step optimization patch for large systems
+        # This reduces test time from 24 hours to ~1 hour on 256-core systems
+        step_patch = self.get_data('step_optimization.patch')
+        if os.path.exists(step_patch):
+            self.log.info("Applying step optimization patch for large systems...")
+            patch_cmd = 'patch -p1 < %s' % step_patch
+            result = process.run(patch_cmd, shell=True, ignore_status=True)
+            if result.exit_status == 0:
+                self.log.info("Step optimization patch applied successfully")
+            else:
+                self.log.warning("Step optimization patch failed, continuing with default step=1")
+
         # Modify the makefile to point to installed libhwloc
         if 'suse' in self.distro_rel.name.lower():
             makefile_patch = 'patch -p1 < %s' % self.get_data('makefile.patch')

--- a/kernel/will-it-scale.py.data/step_optimization.patch
+++ b/kernel/will-it-scale.py.data/step_optimization.patch
@@ -1,0 +1,22 @@
+--- a/runtest.py
++++ b/runtest.py
+@@ -87,7 +87,18 @@ if arch == 'ppc64':
+ print('tasks,processes,processes_idle,threads,threads_idle,linear')
+ print('0,0,100,0,100,0')
+ 
+-step = 1
++# Dynamic step calculation based on number of cores
++# Target: ~1 hour per test for large systems
++if nr_cores <= 16:
++    step = 1       # Small systems: test every core
++elif nr_cores <= 32:
++    step = 2       # 32 cores: detailed testing
++elif nr_cores <= 64:
++    step = 4       # 64 cores: balanced testing
++elif nr_cores <= 128:
++    step = 8       # 128 cores: ~1 hour per test
++else:
++    step = 25      # 256+ cores: ~1 hour per test
+ # if step=5, this is: [5, 10, 15, ... nr_cores]
+ data_points = list(range(step, nr_cores+step, step))
+ # this makes it [ 1, 5, 10, ... ]


### PR DESCRIPTION
Add automatic application of step_optimization.patch to reduce test execution time on large systems. This patch dynamically adjusts the step value in runtest.py based on CPU count, significantly reducing test duration while maintaining meaningful scalability data.

Key improvements:
- Reduces test time from 24 hours to ~1 hour on 256-core systems
- Maintains detailed testing (step=1) on small systems (≤16 cores)
- Uses progressive step values: 2 (32 cores), 4 (64 cores), 8 (128 cores), 25 (256+ cores)
- Includes graceful fallback if patch application fails
- Applied automatically for all systems during setUp()

The patch modifies will-it-scale's runtest.py to use dynamic step calculation instead of hardcoded step=1, making the test suite practical for large-scale systems while preserving granular data on smaller systems.

Files modified:
- kernel/will-it-scale.py: Added patch application logic

Files added:
- kernel/will-it-scale.py.data/step_optimization.patch