### PR TITLE
[avocado-misc] Perf: Use the built perf binary

### DIFF
--- a/perf/perf_bench.py
+++ b/perf/perf_bench.py
@@ -14,10 +14,10 @@
 # Copyright: 2019 IBM
 # Author: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>
 
-import platform
+import os
 from avocado import Test
-from avocado.utils import distro, process, dmesg
-from avocado.utils.software_manager.manager import SoftwareManager
+from avocado.utils import process, dmesg
+from avocado.utils.software_manager.distro_packages import ensure_tool
 
 
 class perf_bench(Test):
@@ -33,22 +33,22 @@ class perf_bench(Test):
         '''
 
         # Check for basic utilities
-        smm = SoftwareManager()
-        detected_distro = distro.detect()
-        self.distro_name = detected_distro.name
-
-        deps = ['gcc', 'make']
-        if 'Ubuntu' in self.distro_name:
-            deps.extend(['linux-tools-common', 'linux-tools-%s' %
-                         platform.uname()[2]])
-        elif self.distro_name in ['rhel', 'SuSE', 'fedora', 'centos']:
-            deps.extend(['perf'])
-        else:
-            self.cancel("Install the package for perf supported \
-                         by %s" % detected_distro.name)
-        for package in deps:
-            if not smm.check_installed(package) and not smm.install(package):
-                self.cancel('%s is needed for the test to be run' % package)
+        perf_path = self.params.get('perf_bin', default='')
+        distro_pkg_map = {
+            "Ubuntu": [f"linux-tools-{os.uname()[2]}", "linux-tools-common"],
+            "debian": ["linux-perf"],
+            "centos": ["perf"],
+            "fedora": ["perf"],
+            "rhel": ["perf"],
+            "SuSE": ["perf"],
+        }
+        try:
+            perf_version = ensure_tool("perf", custom_path=perf_path,
+                                       distro_pkg_map=distro_pkg_map)
+            self.log.info(f"Perf version: {perf_version}")
+            self.perf_bin = perf_path if perf_path else "perf"
+        except RuntimeError as e:
+            self.cancel(str(e))
 
         # Getting the parameters from yaml file
         self.optname = self.params.get('name', default='all')
@@ -77,6 +77,6 @@ class perf_bench(Test):
 
     def test_bench(self):
         # perf bench command
-        bench_cmd = "perf bench %s %s" % (self.optname, self.option)
+        bench_cmd = "%s bench %s %s" % (self.perf_bin, self.optname, self.option)
         self.run_cmd(bench_cmd)
         self.verify_dmesg()

--- a/perf/perf_bench.py.data/perf_bench.yaml
+++ b/perf/perf_bench.py.data/perf_bench.yaml
@@ -1,0 +1,1 @@
+perf_bin: '/usr/local/perf'

--- a/trace/perf_uprobe.py
+++ b/trace/perf_uprobe.py
@@ -15,12 +15,11 @@
 # Author: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>
 
 import os
-import platform
 import shutil
 import tempfile
 from avocado import Test
 from avocado.utils import build, distro, process, genio
-from avocado.utils.software_manager.manager import SoftwareManager
+from avocado.utils.software_manager.distro_packages import ensure_tool
 
 
 class PerfUprobe(Test):
@@ -39,25 +38,24 @@ class PerfUprobe(Test):
         # Check for basic utilities
 
         self.temp_file = tempfile.NamedTemporaryFile().name
-        smm = SoftwareManager()
         self.detected_distro = distro.detect()
         self.distro_name = self.detected_distro.name
-        deps = ['gcc', 'make']
-        if 'Ubuntu' in self.distro_name:
-            deps.extend(['linux-tools-common', 'linux-tools-%s' %
-                         platform.uname()[2]])
-        elif self.distro_name in ['SuSE', 'fedora', 'centos']:
-            deps.extend(['perf'])
-        elif self.distro_name == 'rhel' and int(self.detected_distro.version) < 9:
-            deps.extend(['perf'])
-        elif self.distro_name == 'rhel' and int(self.detected_distro.version) >= 9:
-            deps.extend(['perf', 'perf-debuginfo'])
-        else:
-            self.cancel("Install the package for perf supported\
-                      by %s" % self.detected_distro.name)
-        for package in deps:
-            if not smm.check_installed(package) and not smm.install(package):
-                self.cancel('%s is needed for the test to be run' % package)
+        perf_path = self.params.get('perf_bin', default='')
+        distro_pkg_map = {
+            "Ubuntu": [f"linux-tools-{os.uname()[2]}", "linux-tools-common", "gcc", "make"],
+            "debian": ["linux-perf", "gcc", "make"],
+            "centos": ["perf", "gcc", "make"],
+            "fedora": ["perf", "gcc", "make"],
+            "rhel": ["perf", "gcc", "make"],
+            "SuSE": ["perf", "gcc", "make"],
+        }
+        try:
+            perf_version = ensure_tool("perf", custom_path=perf_path,
+                                       distro_pkg_map=distro_pkg_map)
+            self.log.info(f"Perf version: {perf_version}")
+            self.perf_bin = perf_path if perf_path else "perf"
+        except RuntimeError as e:
+            self.cancel(str(e))
 
         shutil.copyfile(self.get_data('uprobe.c'),
                         os.path.join(self.teststmpdir, 'uprobe.c'))
@@ -67,25 +65,28 @@ class PerfUprobe(Test):
 
         build.make(self.teststmpdir)
         os.chdir(self.teststmpdir)
-        self.cmdProbe = "perf probe -x"
-        self.recProbe = "perf record -o %s -e probe_uprobe_test:doit" % self.temp_file
-        self.report = "perf report --input=%s" % self.temp_file
+        self.cmdProbe = "%s probe -x" % self.perf_bin
+        self.recProbe = "%s record -o %s -e probe_uprobe_test:doit" % (
+            self.perf_bin, self.temp_file)
+        self.report = "%s report --input=%s" % (self.perf_bin, self.temp_file)
 
     def cmd_verify(self, cmd):
         return process.run(cmd, shell=True, ignore_status=True)
 
     def test_uprobe(self):
-        output = self.cmd_verify('%s /usr/bin/perf main' % self.cmdProbe)
+        output = self.cmd_verify('%s ./uprobe_test main' % self.cmdProbe)
         if 'Added new event' not in output.stderr.decode("utf-8"):
-            self.fail("perf: probe of perf main failed")
-        output = self.cmd_verify('perf probe -l')
-        if 'probe_perf:main' not in output.stdout.decode("utf-8"):
-            self.fail("perf: probe of 'perf main' not found in list")
+            self.fail("perf: probe of uprobe_test main failed")
+        output = self.cmd_verify('%s probe -l' % self.perf_bin)
+        if 'probe_uprobe_test:main' not in output.stdout.decode("utf-8"):
+            self.fail("perf: probe of 'main' not found in list")
         sysfsfile = '/sys/kernel/debug/tracing/uprobe_events'
-        if 'probe_perf' not in genio.read_file(sysfsfile).rstrip('\t\r\n\0'):
+        if 'probe_uprobe_test' not in genio.read_file(
+                sysfsfile).rstrip('\t\r\n\0'):
             self.fail("perf: sysfs file didn't reflect uprobe events")
-        output = self.cmd_verify('perf record -o %s -e probe_perf:main -- '
-                                 'perf list' % self.temp_file)
+        output = self.cmd_verify('%s record -o %s -e probe_uprobe_test:main '
+                                 '-- ./uprobe_test'
+                                 % (self.perf_bin, self.temp_file))
         if 'samples' not in output.stderr.decode("utf-8"):
             self.fail("perf: perf.data file not created")
         self.cmd_verify(self.report)
@@ -122,6 +123,6 @@ class PerfUprobe(Test):
         self.cmd_verify(self.report)
 
     def tearDown(self):
-        self.cmd_verify('perf probe -d \\*')
+        self.cmd_verify('%s probe -d \\*' % self.perf_bin)
         if os.path.isfile(self.temp_file):
             process.run('rm -f %s' % self.temp_file)

--- a/trace/perf_uprobe.py.data/perf_uprobe.yaml
+++ b/trace/perf_uprobe.py.data/perf_uprobe.yaml
@@ -1,0 +1,1 @@
+perf_bin: '/usr/local/perf'


### PR DESCRIPTION
Introduced support for specifying a custom perf binary path in misc tests.
Updated perf test scripts to call ensure_tool() from distro_packages for dependency handling when a custom binary path is provided.
Added corresponding .data/ YAML files for test configuration.
Integrated perf tests into the avocado-misc-tests CI pipeline to ensure consistency and reproducibility across environments.

perf_bench.py
perf_uprobe.py 
Include similar changes  as per the PR: https://github.com/avocado-framework-tests/avocado-misc-tests/pull/3087/
https://github.com/avocado-framework-tests/avocado-misc-tests/pull/3202