### PR TITLE
kernel/kselftest: prevent bpf flow from falling into else block

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -219,7 +219,7 @@ class kselftest(Test):
         kself_args = self.params.get("kself_args", default='')
         if self.comp == "bpf":
             self.bpf()
-        if self.comp == "cpufreq":
+        elif self.comp == "cpufreq":
             self.cpufreq()
         else:
             if self.subtest == "ksm_tests":


### PR DESCRIPTION
The test dispatch in kselftest.test() used two consecutive if checks
followed by an else attached to the second condition.

Because of that, when comp == "bpf", bpf() was executed first, but
the second if for cpufreq evaluated false and control dropped into
the else block, which then executed the generic selftest path as well.

Change the second condition to elif so the dispatch becomes mutually
exclusive:
- bpf runs only bpf()
- cpufreq runs only cpufreq()
- all other cases use the generic path

This fixes unintended fallthrough after the bpf execution path.

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>