### PR TITLE
memory/stressng: optimize execution for maxconfig system [ system with memory 64TB ]

### DIFF
--- a/memory/stressng_mem.py
+++ b/memory/stressng_mem.py
@@ -18,6 +18,7 @@ import os
 from avocado import Test
 from avocado.utils import process
 from avocado.utils import memory
+from avocado.utils import cpu
 from avocado.utils import build
 from avocado.utils import archive
 from avocado.utils import dmesg
@@ -73,26 +74,31 @@ class Stressngmem(Test):
                         trace_lines = [line]
                         i += 1
 
-                        # Continue collecting lines that are part of the call trace
-                        # Call trace lines typically start with spaces or specific patterns
+                        # Continue collecting lines that are part of the
+                        # call trace. Lines typically start with spaces
+                        # or specific patterns.
                         while i < len(lines):
                             next_line = lines[i].rstrip("\n")
 
-                            # Check if still part of call trace (indented or contains function names)
+                            # Check if still part of call trace
+                            # (indented or contains function names)
                             if (next_line.strip().startswith('[') or
-                                next_line.strip().startswith('?') or
-                                '0x' in next_line or
-                                '+0x' in next_line or
-                                next_line.strip().startswith('---[') or
-                                (len(next_line) > 0 and next_line[0] == ' ' and
-                                 any(c in next_line for c in ['[', ']', '+']))):
+                                    next_line.strip().startswith('?') or
+                                    '0x' in next_line or
+                                    '+0x' in next_line or
+                                    next_line.strip().startswith('---[') or
+                                    (len(next_line) > 0 and
+                                     next_line[0] == ' ' and
+                                     any(c in next_line
+                                         for c in ['[', ']', '+']))):
 
                                 # Check if this line should be ignored
                                 line_should_ignore = False
                                 for ignore_pattern in ignore_patterns:
                                     if ignore_pattern in next_line:
                                         line_should_ignore = True
-                                        should_ignore = True  # Mark entire trace as ignored
+                                        # Mark entire trace as ignored
+                                        should_ignore = True
                                         break
 
                                 if not line_should_ignore:
@@ -117,11 +123,107 @@ class Stressngmem(Test):
         return call_traces
 
     def process_looping(self, list_of_stressors):
-        loop_count = 0
-        while loop_count < len(list_of_stressors):
-            return_code = self.execute_stressor(list_of_stressors[loop_count])
-            loop_count = loop_count + 1
-        return return_code
+        for stressor in list_of_stressors:
+            return_code = self.execute_stressor(stressor)
+            if return_code == 0:
+                self.passed_stressors.append(stressor)
+            else:
+                self.failed_stressors.append((stressor, return_code))
+
+    def calculate_workers_for_memory(self, stressor):
+        """
+        Calculate optimal worker count for memory-intensive stressors
+        on max config systems.
+
+        For systems >4TB, scales workers based on memory size rather
+        than CPU count to achieve better memory utilization
+        (target: 50-70% memory usage).
+
+        :param stressor: Name of the stressor
+        :return: Number of workers, or None to let stress-ng
+                 auto-scale to CPU count
+        """
+        if self.stressor_flag == "vrt" and self.is_max_config:
+            optimal_workers = int(
+                self.total_memory_in_GiB / self.mem_per_worker)
+            max_workers = self.online_cpus * 2
+            calculated_workers = min(optimal_workers, max_workers)
+            self.log.info(
+                "Max config memory-based worker calculation for %s:",
+                stressor)
+            self.log.info("  Total memory: %s GiB", self.total_memory_in_GiB)
+            self.log.info("  Target per worker: %s GiB", self.mem_per_worker)
+            self.log.info("  Optimal workers: %s", optimal_workers)
+            self.log.info("  CPU count: %s (max workers cap: %s)",
+                          self.online_cpus, max_workers)
+            self.log.info("  Using %s workers (vs %s CPUs with auto-scale)",
+                          calculated_workers, self.online_cpus)
+            return calculated_workers if calculated_workers > 0 else None
+        return None
+
+    def get_memory_option_for_stressor(self, stressor, workers):
+        """
+        Get memory size option for stressor to target specified memory
+        utilization.
+        Uses stress-ng's percentage-based sizing (e.g., --vm-bytes 70%)
+
+        :param stressor: Name of the stressor
+        :param workers: Number of workers, or None if stress-ng is auto-scaling
+        :return: String with memory option or empty string
+        """
+        if not self.is_max_config or workers is None:
+            return ""
+
+        target_percent = self.memory_target_percent
+        if stressor in ['vm', 'mmap']:
+            options = {
+                'vm': f'--vm-bytes {target_percent}%',
+                'mmap': f'--mmap-bytes {target_percent}%',
+            }
+            return options.get(stressor, "")
+        if stressor in ['malloc', 'bigheap', 'brk']:
+            # Calculate total target memory in bytes
+            total_memory_bytes = (
+                self.total_memory_in_GiB * 1024 * 1024 * 1024)
+            target_memory_bytes = int(
+                total_memory_bytes * (target_percent / 100.0))
+            per_worker_bytes = target_memory_bytes // workers
+            per_worker_gb = per_worker_bytes / (1024 * 1024 * 1024)
+            self.log.info(
+                "  Calculated per-worker memory for %s: %.2f GB "
+                "(%d workers x %.2f GB = %.2f GB total, %d%% of %d GB)",
+                stressor, per_worker_gb, workers, per_worker_gb,
+                workers * per_worker_gb, target_percent,
+                self.total_memory_in_GiB
+            )
+
+            if stressor == 'malloc':
+                alloc_size_mb = 512
+                alloc_size_bytes = alloc_size_mb * 1024 * 1024
+                allocations_needed = int(per_worker_bytes / alloc_size_bytes)
+                allocations_per_worker = allocations_needed * 100
+                allocations_per_worker = min(allocations_per_worker, 2000)
+                allocations_per_worker = max(100, allocations_per_worker)
+                self.log.info(
+                    "  malloc strategy: %d MB allocation size, "
+                    "%d max allocations per worker (100x multiplier)",
+                    alloc_size_mb, allocations_per_worker
+                )
+                malloc_opt = (
+                    '--malloc-bytes %s --malloc-max %s --malloc-touch'
+                    % (alloc_size_bytes, allocations_per_worker))
+                return malloc_opt
+            bigheap_growth_bytes = 32 * 1024 * 1024
+            options = {
+                'bigheap': ('--bigheap-bytes %s --bigheap-growth %s'
+                            % (per_worker_bytes, bigheap_growth_bytes)),
+                'brk': f'--brk-bytes {per_worker_bytes}',
+            }
+            return options.get(stressor, "")
+        if stressor == 'mincore':
+            return '--mincore-random'
+
+        return ""
 
     def execute_stressor(self, stressor):
         if self.stressor_flag == "crt":
@@ -130,14 +232,34 @@ class Stressngmem(Test):
             run_time = self.variable_time
 
         end_time = ((run_time)*(15/10))
+        workers = self.calculate_workers_for_memory(stressor)
+        memory_option = self.get_memory_option_for_stressor(stressor, workers)
+        workers_arg = workers if workers is not None else 0
+
+        # Apply CPU load cap only for VRT stressors on max config systems
+        cpu_load_option = ""
+        if (self.stressor_flag == "vrt" and self.is_max_config and
+                self.max_cpu_load is not None):
+            cpu_load_option = "--cpu-load %s" % self.max_cpu_load
+            self.log.info("  CPU load cap (max config VRT): %s%%",
+                          self.max_cpu_load)
+
+        if workers is not None:
+            workers_label = workers
+        else:
+            workers_label = "auto-scale (%s CPUs)" % self.online_cpus
         self.log.info(
-            "Running stress-ng : %s stressor for %s seconds",
-            stressor, run_time)
+            "Running stress-ng : %s stressor for %s seconds with"
+            " %s workers", stressor, run_time, workers_label)
+        if memory_option:
+            self.log.info("  Memory target: %s", memory_option)
 
         # Use "timeout" command to launch stress-ng, in order catch it;
         # should it go into la-la land
-        cmd = "timeout -s 9 %s stress-ng --aggressive --verify \
-                --timeout %s --%s 0" % (end_time, run_time, stressor)
+        cmd = ("timeout -s 9 %s stress-ng --aggressive --verify"
+               " --timeout %s --%s %s %s %s"
+               % (end_time, run_time, stressor,
+                  workers_arg, memory_option, cpu_load_option))
         return_code = process.system(cmd, ignore_status=True)
         self.log.info("Return code is %s", return_code)
 
@@ -161,8 +283,18 @@ class Stressngmem(Test):
         self.log.info("Total Memory on the system : %s GiB",
                       self.total_memory_in_GiB)
 
+        self.is_max_config = self.total_memory_in_GiB > 4096
         extra_time = (self.time_per_gig * self.total_memory_in_GiB)
-        self.variable_time = (self.base_time + extra_time)
+        calculated_time = (self.base_time + extra_time)
+        if self.max_vrt_time is not None:
+            self.variable_time = min(calculated_time, self.max_vrt_time)
+            if calculated_time > self.max_vrt_time:
+                self.log.info("Max config system detected (%s GiB > 4TB)",
+                              self.total_memory_in_GiB)
+                self.log.info("VRT runtime capped from %s to %s seconds",
+                              calculated_time, self.variable_time)
+        else:
+            self.variable_time = calculated_time
         self.log.info("Time limit set for constant_run_time stressors is %s "
                       "seconds per stressor.", self.base_time)
         self.log.info("Time limit set for variable_run_time stressors is %s "
@@ -179,11 +311,21 @@ class Stressngmem(Test):
                               "mmap"]
 
         self.had_error = 0
-        self.skip_teardown_dmesg_check = False  # Flag to skip dmesg check in tearDown
+        self.is_max_config = False
+        self.skip_teardown_dmesg_check = False
+        self.passed_stressors = []
+        self.failed_stressors = []
         self.base_time = self.params.get("base_time", default=300)
         self.time_per_gig = self.params.get("time_per_gig", default=10)
-        self.url = self.params.get("url", default="https://github.com/"
-                                   "ColinIanKing/stress-ng/archive/master.zip")
+        self.max_vrt_time = self.params.get("max_vrt_time", default=7200)
+        self.mem_per_worker = self.params.get("mem_per_worker", default=20)
+        self.memory_target_percent = self.params.get(
+            "memory_target_percent", default=70)
+        self.max_cpu_load = self.params.get("max_cpu_load", default=None)
+        self.online_cpus = cpu.online_count()
+        self.url = self.params.get(
+            "url", default="https://github.com/"
+            "ColinIanKing/stress-ng/archive/V0.21.04.zip")
         self.crt_stressors = self.params.get(
             "crt_stressors", default=crt_stressors_list)
         self.vrt_stressors = self.params.get(
@@ -197,7 +339,8 @@ class Stressngmem(Test):
         tarball = self.fetch_asset(
             'stressng.zip', locations=self.url, expire='7d')
         archive.extract(tarball, self.workdir)
-        sourcedir = os.path.join(self.workdir, 'stress-ng-master')
+        version = os.path.splitext(os.path.basename(self.url))[0].lstrip('Vv')
+        sourcedir = os.path.join(self.workdir, 'stress-ng-' + version)
         os.chdir(sourcedir)
         result = build.run_make(sourcedir, process_kwargs={
                                 'ignore_status': True})
@@ -226,23 +369,43 @@ class Stressngmem(Test):
 
         # Loop through each constant_run_time stressors
         self.stressor_flag = "crt"
-        return_code = self.process_looping(self.crt_stressors)
+        self.process_looping(self.crt_stressors)
 
         # Loop through each variable_run_time stressors
         self.stressor_flag = "vrt"
-        return_code = self.process_looping(self.vrt_stressors)
+        self.process_looping(self.vrt_stressors)
 
+        self.log.info("=====================================================")
+        self.log.info("==> Test Summary:")
+        self.log.info("=====================================================")
+        self.log.info("Total stressors executed: %s",
+                      len(self.passed_stressors) + len(self.failed_stressors))
+        self.log.info("Passed: %s", len(self.passed_stressors))
+        self.log.info("Failed: %s", len(self.failed_stressors))
+        self.log.info("=====================================================")
+        if self.passed_stressors:
+            self.log.info("==> Passed Stressors (%s):",
+                          len(self.passed_stressors))
+            for stressor in self.passed_stressors:
+                self.log.info("  ✓ %s", stressor)
+        if self.failed_stressors:
+            self.log.info("==> Failed Stressors (%s):",
+                          len(self.failed_stressors))
+            for stressor, code in self.failed_stressors:
+                self.log.info("  ✗ %s (return code: %s)", stressor, code)
         self.log.info("=====================================================")
         if self.had_error == 0:
             self.log.info("==> stress-ng memory test passed!")
         else:
-            self.fail("==> stress-ng memory test failed; most recent error \
-                    was %s" % return_code)
+            failed_info = ', '.join(
+                "%s(rc=%s)" % (s, rc) for s, rc in self.failed_stressors)
+            self.fail("stress-ng memory test failed: %s" % failed_info)
         self.log.info("=====================================================")
 
     def test_vm_class_sequential(self):
         """
-        Test VM and memory-related stressors sequentially with specific options.
+        Test VM and memory-related stressors sequentially with specific
+        options.
         Runs stressors in sequence for exactly 1 hour total.
 
         Command breakdown:
@@ -269,7 +432,8 @@ class Stressngmem(Test):
         # Set flag to skip dmesg check in tearDown. We check it here instead
         self.skip_teardown_dmesg_check = True
 
-        # List of all stressors to run sequentially (60 stressors × 60s = 3600s = 60 minutes)
+        # List of all stressors to run sequentially
+        # (60 stressors x 60s = 3600s = 60 minutes)
         stressors = [
             "tlb-shootdown", "fault", "userfaultfd", "fork", "exec", "memfd",
             "numa", "pkey", "remap", "rmap", "shm", "switch", "tmpfs",
@@ -288,7 +452,8 @@ class Stressngmem(Test):
         ]
 
         # Base command with common options
-        base_cmd = "stress-ng --no-oom-adjust --oomable --seq 0 -t 60s --perf -v --verify"
+        base_cmd = ("stress-ng --no-oom-adjust --oomable --seq 0"
+                    " -t 60s --perf -v --verify")
 
         # Build the full command with all stressors
         stressor_args = []
@@ -304,7 +469,8 @@ class Stressngmem(Test):
         cmd_with_timeout = "timeout -s 9 %s %s" % (timeout_seconds, full_cmd)
 
         self.log.info("Running VM class sequential test...")
-        return_code = process.system(cmd_with_timeout, ignore_status=True, shell=True)
+        return_code = process.system(cmd_with_timeout,
+                                     ignore_status=True, shell=True)
 
         self.log.info("=====================================================")
         self.log.info("VM class sequential test completed")
@@ -333,7 +499,8 @@ class Stressngmem(Test):
 
         # First, collect non-call-trace errors
         for error_pattern in error_patterns:
-            contents = self.read_line_with_matching_pattern(filename, error_pattern)
+            contents = self.read_line_with_matching_pattern(
+                filename, error_pattern)
             if contents:
                 for line in contents:
                     # Check if this line should be ignored
@@ -353,9 +520,11 @@ class Stressngmem(Test):
 
         # Log unique dmesg errors if found (only once each)
         if errors_in_dmesg or call_traces:
-            self.log.error("=====================================================")
+            self.log.error(
+                "=====================================================")
             self.log.error("Errors found in dmesg (OOM errors excluded):")
-            self.log.error("=====================================================")
+            self.log.error(
+                "=====================================================")
 
             if errors_in_dmesg:
                 self.log.error("\n--- Non-Call-Trace Errors ---")
@@ -363,12 +532,14 @@ class Stressngmem(Test):
                     self.log.error("%s", error)
 
             if call_traces:
-                self.log.error("\n--- Call Traces (%d unique) ---" % len(call_traces))
+                self.log.error("\n--- Call Traces (%d unique) ---",
+                               len(call_traces))
                 for i, trace in enumerate(call_traces, 1):
                     self.log.error("\nCall Trace #%d:", i)
                     self.log.error("%s", trace)
 
-            self.log.error("\n=====================================================")
+            self.log.error(
+                "\n=====================================================")
 
         # Check return code and dmesg errors
         total_errors = len(errors_in_dmesg) + len(call_traces)
@@ -377,23 +548,37 @@ class Stressngmem(Test):
             self.fail("VM class sequential test timed out after 90 minutes!")
         elif total_errors > 0:
             # Real errors found in dmesg (non-OOM)
-            self.fail("VM class sequential test completed but %d error(s) found in dmesg: %d non-trace errors, %d call traces (see log above)" %
-                      (total_errors, len(errors_in_dmesg), len(call_traces)))
+            self.fail(
+                "VM class sequential test completed but %d error(s)"
+                " found in dmesg: %d non-trace errors, %d call traces"
+                " (see log above)"
+                % (total_errors, len(errors_in_dmesg), len(call_traces)))
         elif return_code != 0:
-            # Non-zero return code but no dmesg errors (likely OOM-related failures)
-            self.log.info("=====================================================")
-            self.log.info("stress-ng returned exit code %s, but no non-OOM errors found in dmesg", return_code)
-            self.log.info("This is expected behavior during aggressive memory stress testing")
+            # Non-zero return code but no dmesg errors
+            # (likely OOM-related failures)
+            self.log.info(
+                "=====================================================")
+            self.log.info(
+                "stress-ng returned exit code %s, but no non-OOM"
+                " errors found in dmesg", return_code)
+            self.log.info(
+                "This is expected behavior during aggressive memory"
+                " stress testing")
             self.log.info("==> VM class sequential test passed!")
-            self.log.info("=====================================================")
+            self.log.info(
+                "=====================================================")
         else:
             self.log.info("==> VM class sequential test passed!")
-            self.log.info("=====================================================")
+            self.log.info(
+                "=====================================================")
 
     def tearDown(self):
         # Skip dmesg check if test already handled it
-        if hasattr(self, 'skip_teardown_dmesg_check') and self.skip_teardown_dmesg_check:
-            self.log.info("Skipping tearDown dmesg check (already checked in test method)")
+        if (hasattr(self, 'skip_teardown_dmesg_check') and
+                self.skip_teardown_dmesg_check):
+            self.log.info(
+                "Skipping tearDown dmesg check"
+                " (already checked in test method)")
             return
 
         errors_in_dmesg = []

--- a/memory/stressng_mem.py.data/README
+++ b/memory/stressng_mem.py.data/README
@@ -49,3 +49,34 @@ Method descriptions:
       runtime stressors & the variable runtime stressors.
     - The calculations required for these estimates are explained above in
       the "How is the estimated execution time calculated?" section.
+
+Additional Parameters (Max Config Support):
+--------------------------------------------
+    --max_vrt_time (default: 7200):
+        - Caps the variable runtime (in seconds) for VRT stressors.
+        - Prevents excessively long runs on large memory systems (> 4 TiB).
+        - Set to null to disable the cap.
+
+    --mem_per_worker (default: 20):
+        - Target GiB of memory per worker on max config systems (> 4 TiB).
+        - Worker count is scaled as: workers = total_GiB / mem_per_worker
+          capped at online_cpus * 2.
+
+    --memory_target_percent (default: 70):
+        - Target memory utilisation (%) for VRT stressors on max config
+          systems. Passed to stress-ng via --vm-bytes, --mmap-bytes, or
+          calculated per-worker for malloc/bigheap/brk stressors.
+
+    --max_cpu_load (default: null):
+        - Optional CPU load cap (%) for VRT stressors on max config systems.
+        - Passed to stress-ng as --cpu-load <N>. Omit or set null to disable.
+
+Max Config Behaviour (systems with > 4 TiB RAM):
+--------------------------------------------------
+    - is_max_config is set to True automatically when total RAM > 4096 GiB.
+    - VRT stressor runtime is capped at max_vrt_time seconds.
+    - Worker count for VRT stressors is scaled by memory rather than CPU
+      count, targeting the specified memory_target_percent utilisation.
+    - Use stressng_mem_maxconfig.yaml for a ready-made configuration tuned
+      for large memory systems.
+

--- a/memory/stressng_mem.py.data/stressng_mem.yaml
+++ b/memory/stressng_mem.py.data/stressng_mem.yaml
@@ -1,8 +1,8 @@
-url: "https://github.com/ColinIanKing/stress-ng/archive/master.zip"
-base_time: 300 
+url: "https://github.com/ColinIanKing/stress-ng/archive/V0.21.04.zip"
+base_time: 300
 time_per_gig: 10
-crt_stressors: ["bsearch", "context", "hsearch", "lsearch", "matrix", "memcpy", 
-                "null", "pipe", "qsort", "stack", "str", "stream", "tsearch", "vm-rw", 
-                "wcs", "zero", "mlock", "mmapfork", "mmapmany", "mremap", "shm-sysv", 
+crt_stressors: ["bsearch", "context", "hsearch", "lsearch", "matrix", "memcpy",
+                "null", "pipe", "qsort", "stack", "str", "stream", "tsearch", "vm-rw",
+                "wcs", "zero", "mlock", "mmapfork", "mmapmany", "mremap", "shm-sysv",
                 "vm-splice"]
 vrt_stressors: ["malloc", "mincore", "vm", "bigheap", "brk", "mmap"]

--- a/memory/stressng_mem.py.data/stressng_mem_maxconfig.yaml
+++ b/memory/stressng_mem.py.data/stressng_mem_maxconfig.yaml
@@ -1,0 +1,14 @@
+# Configuration for large memory systems (> 4 TiB).
+# See README for parameter descriptions.
+url: "https://github.com/ColinIanKing/stress-ng/archive/V0.21.04.zip"
+base_time: 300
+time_per_gig: 10
+max_vrt_time: 7200
+mem_per_worker: 20
+memory_target_percent: 70
+max_cpu_load: 80
+crt_stressors: ["bsearch", "context", "hsearch", "lsearch", "matrix", "memcpy",
+                "null", "pipe", "qsort", "stack", "str", "stream", "tsearch",
+                "vm-rw", "wcs", "zero", "mlock", "mmapfork", "mmapmany",
+                "mremap", "shm-sysv", "vm-splice"]
+vrt_stressors: ["malloc", "mincore", "vm", "bigheap", "brk", "mmap"]


### PR DESCRIPTION
Add worker scaling and memory options for systems with >4TB RAM to
target 70% memory utilization across VRT stressors. Cap VRT runtime
at max_vrt_time to prevent unbounded runs on large memory systems.
Fix process_looping() to track per-stressor pass/fail and report all
failed stressors with return codes instead of the last exit code only.