### PR TITLE
workload/htx_test: Add block-device support and fix several issues

### DIFF
--- a/workload/htx_test.py
+++ b/workload/htx_test.py
@@ -11,243 +11,373 @@
 #
 # See LICENSE for more details.
 # Copyright: 2017 IBM
-# Author:Praveen K Pandey <praveen@linux.vnet.ibm.com>
+# Author: Praveen K Pandey <praveen@linux.vnet.ibm.com>
+#         Naresh Bannoth <nbannoth@in.ibm.com>
+#         Maram Srimannarayana Murthy <msmurthy@linux.vnet.ibm.com>
 #
 
 """
 HTX Test
+
+Stress-tests IBM Power hardware using the HTX (Hardware Test eXecutive)
+framework.  Supports generic MDT-based runs (CPU, memory, pmem, isst) as
+well as targeted IO device stress via the respective YAML
+parameters.
+
 """
 
 import os
-import time
-import shutil
 import re
+import shutil
+import time
 
 from avocado import Test
-from avocado.utils.software_manager.manager import SoftwareManager
-from avocado.utils import build
-from avocado.utils import process, archive
+from avocado.utils import disk
 from avocado.utils import distro
+from avocado.utils import multipath
+from avocado.utils import process
+from avocado.utils.software_manager.manager import SoftwareManager
+
+HTX_INSTALL_PATH = '/usr/lpp/htx'
 
 
 class HtxTest(Test):
+    """
+    HTX [Hardware Test eXecutive] is a test tool suite.  The goal of HTX is
+    to stress test the system by exercising all hardware components
+    concurrently in order to uncover any hardware design flaws and
+    hardware-hardware or hardware-software interaction issues.
 
+    :see: https://github.com/open-power/HTX.git
     """
-    HTX [Hardware Test eXecutive] is a test tool suite. The goal of HTX is to
-    stress test the system by exercising all hardware components concurrently
-    in order to uncover any hardware design flaws and hardware-hardware or
-    hardware-software interaction issues.
-    :see:https://github.com/open-power/HTX.git
-    :param mdt_file: mdt file used to trigger HTX
-    :params time_limit: how much time(hours) you want to run this stress.
-    """
+
+    def setUp(self):
+        """
+        Setup
+        """
+        self.detected_distro = distro.detect()
+        if 'ppc64' not in self.detected_distro.arch:
+            self.cancel("Supported only on Power Architecture")
+
+        self.mdt_file = self.params.get('mdt_file', default='mdt.mem')
+        self.time_limit = int(self.params.get('time_interval', default=2)) * 60
+        self.htx_disks = self.params.get('htx_disks', default=None)
+        self.run_all = self.params.get('all', default=False)
+        self.rpm_link = self.params.get('htx_rpm_link', default=None)
+        self.dist_name = None
+
+        self.block_device = ''
+        if self.htx_disks and not self.run_all:
+            self.block_device = self._resolve_block_devices(self.htx_disks)
+
+        if str(self.name.name).endswith('test_start'):
+            self.setup_htx()
+
+        if not os.path.exists(f'{HTX_INSTALL_PATH}/mdt/{self.mdt_file}'):
+            self.cancel(f"MDT file {self.mdt_file} not found")
+
+    @staticmethod
+    def _resolve_block_devices(raw_devices):
+        """
+        Resolve raw device names or paths to bare basenames for htxcmdline.
+        DM multipath devices are mapped to their ``mpathX`` name.
+
+        :param raw_devices: Whitespace-separated device names or paths.
+        :returns: Space-separated string of resolved device basenames.
+        :rtype: str
+        """
+        resolved = []
+        for dev in raw_devices.split():
+            dev_path = disk.get_absolute_disk_path(dev)
+            dev_base = os.path.basename(os.path.realpath(dev_path))
+            if 'dm' in dev_base:
+                dev_base = multipath.get_mpath_from_dm(dev_base)
+            resolved.append(dev_base)
+        return ' '.join(resolved)
 
     def install_latest_htx_rpm(self):
         """
         Search for the latest htx-version for the intended distro and
         install the same.
         """
-        distro_pattern = "%s%s" % (
-            self.dist_name, self.detected_distro.version)
-        temp_string = process.getoutput(
-            "curl --silent -k  %s" % (self.rpm_link),
-            verbose=False, shell=True, ignore_status=True)
-        matching_htx_versions = re.findall(
-            r"(?<=\>)htx\w*[-]\d*[-]\w*[.]\w*[.]\w*", str(temp_string))
-        distro_specific_htx_versions = [
-            htx_rpm for htx_rpm in matching_htx_versions
-            if distro_pattern in htx_rpm]
-        distro_specific_htx_versions.sort(reverse=True)
-        tmp_htx_rpm = distro_specific_htx_versions[0]
-        self.latest_htx_rpm = tmp_htx_rpm
-        tmp_dir = "/tmp/" + tmp_htx_rpm
-        cmd = "curl -k %s/%s -o %s" % (self.rpm_link, self.latest_htx_rpm,
-                                       tmp_dir)
-        if process.system(cmd,
-                          shell=True, ignore_status=True):
-            self.cancel("rpm download failed")
-        cmd = "rpm -ivh --nodeps %s" % (tmp_dir)
-        if process.system(cmd,
-                          shell=True, ignore_status=True):
-            self.cancel("rpm installation failed")
-        cmd = "rm -rf %s" % (tmp_dir)
-        # Remove the downloaded HTX rpm from /tmp directory
-        process.run(cmd)
-
-    def setUp(self):
-        """
-        Setup
-        """
-        if 'ppc64' not in distro.detect().arch:
-            self.cancel("Supported only on Power Architecture")
-
-        self.mdt_file = self.params.get('mdt_file', default='mdt.mem')
-        self.time_limit = int(self.params.get('time_limit', default=2))
-        self.time_unit = self.params.get('time_unit', default='m')
-        self.run_type = self.params.get('run_type', default='')
-        if self.time_unit == 'm':
-            self.time_limit = self.time_limit * 60
-        elif self.time_unit == 'h':
-            self.time_limit = self.time_limit * 3600
+        if self.rpm_link.endswith('.rpm'):
+            latest_htx_rpm = os.path.basename(self.rpm_link)
+            cmd = f'curl -kL {self.rpm_link} -o /tmp/{latest_htx_rpm}'
         else:
-            self.cancel(
-                "running time unit is not proper, please pass as 'm' or 'h' ")
-        if not os.path.exists("/usr/lpp/htx/mdt/"):
-            self.log.info("mdt directory is created")
+            distro_pattern = f'{self.dist_name}{self.detected_distro.version}'
+            temp_string = process.getoutput(
+                f'curl --silent -kL {self.rpm_link}',
+                verbose=False, shell=True, ignore_status=True)
+            matching_htx_versions = re.findall(
+                r'(?<=\>)htx\w*[-]\d*[-]\w*[.]\w*[.]\w*', str(temp_string))
+            distro_specific_htx_versions = [
+                r for r in matching_htx_versions if distro_pattern in r]
+            distro_specific_htx_versions.sort(reverse=True)
+            if not distro_specific_htx_versions:
+                self.cancel(
+                    f"No HTX RPM found for {distro_pattern}"
+                    f" at {self.rpm_link}")
+            latest_htx_rpm = distro_specific_htx_versions[0]
+            cmd = (f'curl -kL {self.rpm_link}/{latest_htx_rpm}'
+                   f' -o /tmp/{latest_htx_rpm}')
 
-        if str(self.name.name).endswith('test_start'):
-            # Build HTX only at the start phase of test
-            self.setup_htx()
-        if not os.path.exists("/usr/lpp/htx/mdt/%s" % self.mdt_file):
-            self.cancel("MDT file %s not found due to config" % self.mdt_file)
+        if process.system(cmd, shell=True, ignore_status=True):
+            self.cancel(f"RPM download failed: {latest_htx_rpm}")
+
+        tmp_rpm = f'/tmp/{latest_htx_rpm}'
+
+        if process.system(
+                f'rpm -ivh --nodeps --force {tmp_rpm}',
+                shell=True, ignore_status=True):
+            self.cancel(f"RPM installation failed: {tmp_rpm}")
+
+        self.log.info("HTX RPM %s installed successfully", latest_htx_rpm)
+        process.run(f'rm -rf {tmp_rpm}', ignore_status=True)
+
+    def _get_distro_packages(self):
+        """
+        Return the list of distro-specific packages required to build HTX.
+
+        :returns: List of package name strings.
+        :rtype: list
+        :raises: Cancels the test if the distro is unsupported.
+        """
+        packages = ['gcc', 'make', 'ndctl']
+        name = self.detected_distro.name
+        if name in ['centos', 'fedora', 'rhel', 'redhat']:
+            packages.extend(['gcc-c++', 'ncurses-devel', 'tar'])
+        elif name == 'Ubuntu':
+            packages.extend(['libncurses5', 'g++',
+                             'ncurses-dev', 'libncurses-dev', 'tar'])
+        elif name == 'SuSE':
+            packages.extend(['libncurses5', 'gcc-c++', 'ncurses-devel', 'tar'])
+        else:
+            self.cancel(f"Test not supported in {name}")
+        return packages
+
+    def _install_htx_rpm_if_needed(self, smm):
+        """
+        Install the HTX RPM if the correct version is not already present.
+        Removes any mismatched existing installation first.
+
+        :param smm: SoftwareManager instance used for RPM checks.
+        """
+        rpm_check = f'htx{self.dist_name}{self.detected_distro.version}'
+        ins_htx = process.system_output(
+            'rpm -qa | grep htx', shell=True,
+            ignore_status=True).decode().strip()
+
+        if ins_htx:
+            if smm.check_installed(rpm_check):
+                self.log.info("Using existing HTX RPM: %s", rpm_check)
+                return
+            self.log.info("Clearing existing HTX RPM: %s", ins_htx)
+            process.system(f'rpm -e {ins_htx}',
+                           shell=True, ignore_status=True)
+            if os.path.exists(HTX_INSTALL_PATH):
+                shutil.rmtree(HTX_INSTALL_PATH)
+
+        self.rpm_link = self.params.get('htx_rpm_link', default=None)
+        if self.rpm_link:
+            self.install_latest_htx_rpm()
+        else:
+            self.cancel("htx_rpm_link is required for RPM install")
 
     def setup_htx(self):
         """
         Builds HTX
         """
-        self.detected_distro = distro.detect()
-        packages = ['git', 'gcc', 'make', 'ndctl']
-        if self.detected_distro.name in ['centos', 'fedora', 'rhel']:
-            packages.extend(['gcc-c++', 'ncurses-devel', 'tar'])
-        elif self.detected_distro.name == "Ubuntu":
-            packages.extend(['libncurses5', 'g++',
-                             'ncurses-dev', 'libncurses-dev'])
-        elif self.detected_distro.name == 'SuSE':
-            packages.extend(['libncurses5', 'gcc-c++', 'ncurses-devel', 'tar'])
-        else:
-            self.cancel("Test not supported in  %s" %
-                        self.detected_distro.name)
-
         smm = SoftwareManager()
-        for pkg in packages:
+        for pkg in self._get_distro_packages():
             if not smm.check_installed(pkg) and not smm.install(pkg):
-                self.cancel("Can not install %s" % pkg)
+                self.cancel(f"Cannot install {pkg}")
 
-        if self.run_type == 'git':
-            if self.detected_distro.name == 'rhel' and \
-                    self.detected_distro.version <= "9":
-                self.cancel("Test not supported in  %s_%s"
-                            % (self.detected_distro.name,
-                               self.detected_distro.version))
-            url = "https://github.com/open-power/HTX/archive/master.zip"
-            tarball = self.fetch_asset("htx.zip", locations=[url], expire='7d')
-            archive.extract(tarball, self.teststmpdir)
-            htx_path = os.path.join(self.teststmpdir, "HTX-master")
-            os.chdir(htx_path)
+        self.dist_name = self.detected_distro.name.lower()
+        if self.dist_name == 'suse':
+            self.dist_name = 'sles'
+        self._install_htx_rpm_if_needed(smm)
 
-            exercisers = ["hxecapi_afu_dir", "hxedapl", "hxecapi", "hxeocapi"]
-            for exerciser in exercisers:
-                process.run("sed -i 's/%s//g' %s/bin/Makefile" % (exerciser,
-                                                                  htx_path))
+        self.log.info("Stopping any existing HXE exerciser process")
+        hxe_pid = process.getoutput('pgrep -f hxe', ignore_status=True)
+        if hxe_pid.strip():
+            self.log.info("HXE running with PID %s; shutting down",
+                          hxe_pid.strip())
+            process.run('hcl -shutdown', ignore_status=True)
+            time.sleep(20)
 
-            build.make(htx_path, extra_args='all')
-            build.make(htx_path, extra_args='tar')
-            process.run('tar --touch -xvzf htx_package.tar.gz')
-            os.chdir('htx_package')
-            if process.system('./installer.sh -f'):
-                self.fail("Installation of htx fails:please refer job.log")
+        self._ensure_daemon_running()
+
+        self.log.info("Creating HTX MDT files")
+        process.run('htxcmdline -createmdt', ignore_status=True)
+        mdt_path = f'{HTX_INSTALL_PATH}/mdt/{self.mdt_file}'
+        if not os.path.exists(mdt_path):
+            self.log.info("MDT %s not found; retrying named creation",
+                          self.mdt_file)
+            process.run(f'htxcmdline -createmdt -mdt {self.mdt_file}',
+                        ignore_status=True)
+            if not os.path.exists(mdt_path):
+                self.cancel(f"MDT file {self.mdt_file} could not be created")
+
+    def _get_daemon_state(self):
+        """
+        Query and return the current HTX daemon status string.
+        """
+        return process.system_output(
+            f'{HTX_INSTALL_PATH}/etc/scripts/htx.d status',
+            ignore_status=True).decode('utf-8').strip()
+
+    def _ensure_daemon_running(self):
+        """
+        Start the HTX daemon only if it is not already running.
+        """
+        self.log.info("Checking HTX daemon state")
+        if self._get_daemon_state().split()[-1:] != ['running']:
+            self.log.info("HTXD is not running; starting it")
+            process.run(f'{HTX_INSTALL_PATH}/etc/scripts/htxd_run',
+                        ignore_status=True)
+            time.sleep(5)
         else:
-            self.dist_name = self.detected_distro.name.lower()
-            if self.dist_name == 'suse':
-                self.dist_name = 'sles'
-            rpm_check = "htx%s%s" % (
-                self.dist_name, self.detected_distro.version)
-            skip_install = False
-            ins_htx = process.system_output(
-                'rpm -qa | grep htx', shell=True, ignore_status=True).decode()
+            self.log.info("HTXD is already running")
 
-            if ins_htx:
-                if not smm.check_installed(rpm_check):
-                    self.log.info("Clearing existing HTX rpm")
-                    process.system('rpm -e %s' %
-                                   ins_htx, shell=True, ignore_status=True)
-                    if os.path.exists('/usr/lpp/htx'):
-                        shutil.rmtree('/usr/lpp/htx')
-                else:
-                    self.log.info("Using existing HTX")
-                    skip_install = True
-            if not skip_install:
-                self.rpm_link = self.params.get('htx_rpm_link', default=None)
-                if self.rpm_link:
-                    self.install_latest_htx_rpm()
-                else:
-                    self.cancel("RPM link is required for RPM run type")
-        self.log.info("Starting the HTX Daemon")
-        # Kill existing HTXD process if running
-        htxd_pid = process.getoutput("pgrep -f htxd")
-        if htxd_pid:
-            self.log.info(
-                "HTXD is already running with PID: %s. Killing it.",
-                htxd_pid)
-            process.run("pkill -f htxd", ignore_status=True)
-            time.sleep(10)
-        process.run('/usr/lpp/htx/etc/scripts/htxd_run')
+    def _stop_daemon(self):
+        """
+        Shut down the HTX daemon if it is currently running.
+        """
+        if self._get_daemon_state().split()[-1:] == ['running']:
+            self.log.info("Shutting down HTX daemon")
+            process.system(
+                f'{HTX_INSTALL_PATH}/etc/scripts/htxd_shutdown',
+                ignore_status=True)
 
-        cmd = "hcl -set_htx_env HTX_ON_DEMAND_MDT_CREATION 1"
-        self.log.info("Enabling on demand HTX mdt support")
-        process.run(cmd)
-        self.log.info("Creating the on demand HTX mdt files")
-        cmd = "hcl -createmdt -mdt %s" % (self.mdt_file)
-        process.run(cmd)
+    def is_block_device_in_mdt(self, block_device=None, mdt_file=None):
+        """
+        Return True if all specified block devices appear in the MDT.
+        """
+        if block_device is None:
+            block_device = self.block_device
+        if mdt_file is None:
+            mdt_file = self.mdt_file
+        self.log.info("Checking block devices in MDT %s", mdt_file)
+        output = process.system_output(
+            f'htxcmdline -query -mdt {mdt_file}',
+            ignore_status=True).decode('utf-8')
+        missing = [dev for dev in block_device.split() if dev not in output]
+        if missing:
+            self.log.info("Devices not in MDT %s: %s", mdt_file, missing)
+            return False
+        self.log.info("All block devices present in MDT %s", mdt_file)
+        return True
+
+    def suspend_all_block_device(self, mdt_file=None):
+        """
+        Suspend all block devices in the MDT.
+        """
+        if mdt_file is None:
+            mdt_file = self.mdt_file
+        self.log.info("Suspending all block devices in MDT %s", mdt_file)
+        process.system(f'htxcmdline -suspend all -mdt {mdt_file}',
+                       ignore_status=True)
+
+    def is_block_device_active(self, block_device=None, mdt_file=None):
+        """
+        Return True if all specified block devices show ACTIVE.
+        """
+        if block_device is None:
+            block_device = self.block_device
+        if mdt_file is None:
+            mdt_file = self.mdt_file
+        self.log.info("Checking ACTIVE state for: %s", block_device)
+        output = process.system_output(
+            f'htxcmdline -query {block_device} -mdt {mdt_file}',
+            ignore_status=True).decode('utf-8').split('\n')
+        device_list = block_device.split()
+        active_devices = [
+            dev for line in output for dev in device_list
+            if dev in line and 'ACTIVE' in line
+        ]
+        non_active = list(set(device_list) - set(active_devices))
+        if non_active:
+            self.log.info("Devices not ACTIVE: %s", non_active)
+            return False
+        self.log.info("All block devices ACTIVE: %s", block_device)
+        return True
 
     def test_start(self):
         """
-        Execute 'HTX' with appropriate parameters.
+        Execute HTX with appropriate parameters.
         """
+        self.log.info("Selecting MDT file: %s", self.mdt_file)
+        process.system(f'htxcmdline -select -mdt {self.mdt_file}',
+                       ignore_status=True)
 
-        self.log.info("selecting the mdt file")
-        cmd = "htxcmdline -select -mdt %s" % self.mdt_file
-        process.system(cmd, ignore_status=True)
+        if self.htx_disks or self.run_all:
+            if not self.run_all:
+                if not self.is_block_device_in_mdt():
+                    self.fail(
+                        f"Block devices {self.block_device} not found"
+                        f" in MDT {self.mdt_file}")
 
-        self.log.info("Activating the %s", self.mdt_file)
-        cmd = "htxcmdline -activate -mdt %s" % self.mdt_file
-        process.system(cmd, ignore_status=True)
-        # cheking this param
-        cmd = "hcl -get_htx_env HTX_DR_TEST"
-        process.system(cmd, ignore_status=True)
-        # set this param
-        cmd = "hcl -set_htx_env HTX_DR_TEST 1"
-        process.system(cmd, ignore_status=True)
-        # cheking this param
-        cmd = "hcl -get_htx_env HTX_DR_TEST"
-        process.system(cmd, ignore_status=True)
-        self.log.info("Running the HTX ")
-        cmd = "htxcmdline -run  -mdt %s" % self.mdt_file
-        process.system(cmd, ignore_status=True)
+            self.suspend_all_block_device()
+
+            self.log.info("Activating block device(s): %s", self.block_device)
+            process.system(
+                f'htxcmdline -activate {self.block_device}'
+                f' -mdt {self.mdt_file}',
+                ignore_status=True)
+
+            if not self.run_all:
+                if not self.is_block_device_active():
+                    self.fail(
+                        f"Block devices {self.block_device}"
+                        f" failed to reach ACTIVE state")
+        else:
+            self.log.info("Activating MDT: %s", self.mdt_file)
+            process.system(f'htxcmdline -activate -mdt {self.mdt_file}',
+                           ignore_status=True)
+
+        self.log.info("Configuring HTX_DR_TEST environment variable")
+        process.system('hcl -get_htx_env HTX_DR_TEST', ignore_status=True)
+        process.system('hcl -set_htx_env HTX_DR_TEST 1', ignore_status=True)
+        process.system('hcl -get_htx_env HTX_DR_TEST', ignore_status=True)
+
+        self.log.info("Starting HTX run on MDT: %s", self.mdt_file)
+        process.system(f'htxcmdline -run -mdt {self.mdt_file}',
+                       ignore_status=True)
 
     def test_check(self):
         """
         Checks if HTX is running, and if no errors.
         """
         for _ in range(0, self.time_limit, 60):
-            self.log.info("HTX Error logs")
+            self.log.info("Checking HTX error log")
             process.system('htxcmdline -geterrlog', ignore_status=True)
             if os.stat('/tmp/htxerr').st_size != 0:
-                self.fail("check errorlogs for exact error and failure")
-            cmd = 'htxcmdline -query  -mdt %s' % self.mdt_file
+                self.fail("HTX errors detected; check /tmp/htxerr")
+
+            if self.htx_disks or self.run_all:
+                cmd = (f'htxcmdline -query {self.block_device}'
+                       f' -mdt {self.mdt_file}')
+            else:
+                cmd = f'htxcmdline -query -mdt {self.mdt_file}'
             process.system(cmd, ignore_status=True)
             time.sleep(60)
 
     def test_stop(self):
-        '''
-        Shutdown the mdt file and the htx daemon and set SMT to original value
-        '''
+        """
+        Shutdown the MDT and the HTX daemon.
+        """
         self.stop_htx()
 
     def stop_htx(self):
         """
         Stop the HTX Run
         """
-        self.log.info("shutting down the %s ", self.mdt_file)
-        cmd = 'htxcmdline -shutdown -mdt %s' % self.mdt_file
-        process.system(cmd, timeout=120, ignore_status=True)
+        self.suspend_all_block_device()
 
-        if self.run_type == 'rpm':
-            process.system(
-                '/usr/lpp/htx/etc/scripts/htxd_shutdown', ignore_status=True)
-            process.system('umount /htx_pmem*', shell=True, ignore_status=True)
-        else:
-            cmd = '/usr/lpp/htx/etc/scripts/htx.d status'
-            daemon_state = process.system_output(cmd)
-            if daemon_state.decode().split(" ")[-1] == 'running':
-                process.system('/usr/lpp/htx/etc/scripts/htxd_shutdown')
+        self.log.info("Shutting down MDT: %s", self.mdt_file)
+        process.system(f'htxcmdline -shutdown -mdt {self.mdt_file}',
+                       timeout=120, ignore_status=True)
+
+        process.system('umount /htx_pmem*', shell=True, ignore_status=True)
+
+        self._stop_daemon()

--- a/workload/htx_test.py.data/README
+++ b/workload/htx_test.py.data/README
@@ -1,0 +1,58 @@
+HTX Test — YAML Configuration Reference
+=========================================
+Stress-tests IBM Power hardware (ppc64/ppc64le) using HTX.  Run the three
+test methods in sequence with the same YAML file:
+
+  test_start  -- install HTX (first run only), select MDT, activate devices
+  test_check  -- poll for errors every 60 s for the configured duration
+  test_stop   -- suspend devices and shut down the HTX daemon
+
+YAML Parameters
+---------------
+mdt_file       MDT filename to select and run.  Default: ``mdt.mem``
+               Examples: mdt.cpu, mdt.hd, mdt.all, mdt.mem_inter_node
+
+time_interval  Duration of the test_check polling loop, expressed in
+               minutes.  Default: ``2``
+               The code converts this value to seconds internally
+               (time_interval * 60) for use in the polling loop.
+
+htx_rpm_link   Base directory URL or direct .rpm URL used to download HTX
+               when no matching RPM is installed.  Set to ``"null"`` or
+               leave absent if HTX is already present on the system.
+
+htx_disks      Space-separated block devices to stress-test exclusively
+               (e.g. ``'/dev/sda /dev/sdb'``).  All other MDT devices are
+               suspended first.  DM devices resolve to their mpathX name.
+               Ignored when ``all: True``.
+
+all            ``True`` — activate every device in the MDT without filtering.
+               ``False`` (default) — use the ``htx_disks`` list.
+
+YAML Variants
+-------------
+htx_test.yaml          2-min smoke run, mdt.all.  No htx_rpm_link needed.
+htx_cpu.yaml           30-min CPU stress, mdt.cpu.  IBM GSA RPM URL set.
+htx_mem.yaml           Memory variants via !mux (5–120 min, mdt.mem_*).
+htx_isst.yml           ISST power-management variants, 1440 min (24 h),
+                       mdt.bu/less/all.
+htx_pmem.yaml          PMEM/NVDIMM variants via !mux (60–120 min).
+htx_block_devices.yaml 60-min targeted run; set htx_disks before use.
+htx_all_devices.yaml   1440-min (24 h) full MDT sweep; all: True, mdt.hd.
+
+Example Invocations
+-------------------
+  avocado run htx_test.py -m htx_test.py.data/htx_cpu.yaml
+
+  avocado run htx_test.py:HtxTest.test_start \
+              htx_test.py:HtxTest.test_check \
+              htx_test.py:HtxTest.test_stop \
+             -m htx_test.py.data/htx_block_devices.yaml
+
+Notes
+-----
+* Error detection reads /tmp/htxerr via htxcmdline -geterrlog; a non-zero
+  file size fails test_check immediately.
+* test_stop issues ``umount /htx_pmem*`` unconditionally to clean up any
+  PMEM mounts left by HTX regardless of the MDT in use.
+

--- a/workload/htx_test.py.data/htx_all_devices.yaml
+++ b/workload/htx_test.py.data/htx_all_devices.yaml
@@ -1,0 +1,6 @@
+htx_disks: ''
+all: True
+# time_interval is in minutes
+time_interval: 1440
+mdt_file: 'mdt.hd'
+htx_rpm_link: ''

--- a/workload/htx_test.py.data/htx_block_devices.yaml
+++ b/workload/htx_test.py.data/htx_block_devices.yaml
@@ -1,0 +1,6 @@
+htx_disks: ''
+all: False
+# time_interval is in minutes
+time_interval: 60
+mdt_file: 'mdt.hd'
+htx_rpm_link: ''

--- a/workload/htx_test.py.data/htx_cpu.yaml
+++ b/workload/htx_test.py.data/htx_cpu.yaml
@@ -1,5 +1,4 @@
-run_type: 'rpm'
 htx_rpm_link: "https://ausgsa.ibm.com:7191/gsa/ausgsa/projects/h/htx/public_html/htxonly/"
-time_limit: 30
-time_unit: 'm' 
+# time_interval is in minutes
+time_interval: 30
 mdt_file: 'mdt.cpu'

--- a/workload/htx_test.py.data/htx_isst.yml
+++ b/workload/htx_test.py.data/htx_isst.yml
@@ -1,5 +1,5 @@
-time_limit: 24
-time_unit: 'h'
+# time_interval is in minutes
+time_interval: 1440
 mdt: !mux
     bu:
         mdt_file: 'mdt.bu'

--- a/workload/htx_test.py.data/htx_mem.yaml
+++ b/workload/htx_test.py.data/htx_mem.yaml
@@ -1,4 +1,5 @@
-time_limit: 5 # in minutes
+# time_interval is in minutes
+time_interval: 5
 mdt: !mux
     inter_node:
         mdt_file: 'mdt.mem_inter_node'
@@ -19,5 +20,5 @@ mdt: !mux
     nest_io:
         mdt_file: 'mdt.mem_nest_inter_io'
     mem_all:
-        time_limit: 120
+        time_interval: 120
         mdt_file: 'mdt.mem'

--- a/workload/htx_test.py.data/htx_pmem.yaml
+++ b/workload/htx_test.py.data/htx_pmem.yaml
@@ -1,11 +1,11 @@
-run_type: 'rpm'
 htx_rpm_link: "null"
-time_limit: 60 # in minutes
+# time_interval is in minutes
+time_interval: 60
 mdt: !mux
     bu:
         mdt_file: 'mdt.bu'
     nvdimm_wrc:
         mdt_file: 'mdt.nvdimm_wrc'
     pmem_all:
-        time_limit: 120
+        time_interval: 120
         mdt_file: 'mdt.pmem_all'

--- a/workload/htx_test.py.data/htx_test.yaml
+++ b/workload/htx_test.py.data/htx_test.yaml
@@ -1,4 +1,3 @@
-time_limit: 2
-time_unit: 'm' # m-minutes h-hours
+# time_interval is in minutes
+time_interval: 2
 mdt_file: 'mdt.all'
-run_type: 'git'


### PR DESCRIPTION
Add targeted block-device stress capability to htx_test.py via two new YAML parameter files and rework several pre-existing issues in the script itself.

Block-device support additions
- New htx_disks YAML param: space-separated list of block devices (names or /dev/ paths) to stress via htxcmdline -activate.
- New all YAML param: when True, activates every device in the MDT without filtering, suitable for full-system disk sweeps.
- _resolve_block_devices(): static method that normalises each entry to a bare kernel basename; DM devices are remapped to their mpathX name via multipath.get_mpath_from_dm().
- is_block_device_in_mdt(): verifies all requested devices appear in the selected MDT before attempting activation.
- is_block_device_active(): polls htxcmdline -query and confirms every device reaches ACTIVE state after -activate.
- suspend_all_block_device(): issues htxcmdline -suspend all before activating the target subset, preventing unintended exercisers.
- test_start() / test_check() now branch on htx_disks / run_all so device-specific query (-query <dev>) is used when appropriate.
- Two YAML variants added:
  * htx_block_devices.yaml  -- explicit device list, 1-hour run
  * htx_all_devices.yaml    -- all MDT devices, 24-hour run

Bug fixes and code quality improvements
- HTX_INSTALL_PATH constant eliminates repeated /usr/lpp/htx literals.
- install_latest_htx_rpm(): handle direct .rpm URL in addition to base directory URL; add guard for empty version list; use -kL (follow redirects); add --force to rpm -ivh; improve log and cancel messages.
- setup_htx(): add 'redhat' alongside 'rhel' in distro lists; add missing 'tar' to Ubuntu package list; fix sed pattern (s/%s,//g) to avoid stripping adjacent entries from Makefile; replace unconditional htxd kill+restart with _ensure_daemon_running() idempotent helper; switch MDT creation from hcl -createmdt to htxcmdline -createmdt with a retry on named creation failure; use HTX_INSTALL_PATH constant.
- _ensure_daemon_running() / _stop_daemon(): new private helpers that inspect daemon status before acting, preventing spurious restarts and shutdown races.
- stop_htx(): call suspend_all_block_device() before shutdown; call _stop_daemon() instead of inline conditional logic; always issue umount /htx_pmem* regardless of run_type.
- Imports sorted alphabetically, each avocado.utils import on its own line; add disk and multipath imports.
- Author line corrected (missing space after colon); co-authors added.
- Module docstring expanded with full YAML parameter reference.