### PR TITLE
sosreport.py: Fix NUMA plugin detection

### DIFF
--- a/ras/sosreport.py
+++ b/ras/sosreport.py
@@ -64,7 +64,7 @@ class Sosreport(Test):
                 match = re.match(r"^(\w+)\s+(.*)$", plugins.strip())
                 if match:
                     matched_plugin = match.group(1)
-            break
+                    break
 
         return matched_plugin
 


### PR DESCRIPTION
Fix get_sos_plugin() to iterate through the complete plugin list instead of stopping after the first entry. This ensures the supported NUMA plugin is detected correctly when it is not listed first.