### PR TITLE
[avocado-misc-tests/memory]: Fix failure in page_table test

### DIFF
--- a/memory/page_table.py
+++ b/memory/page_table.py
@@ -49,7 +49,9 @@ class PageTable(Test):
         self.url = self.params.get('url', default=None)
         git.get_repo(self.url, destination_dir=self.teststmpdir)
         os.chdir(self.teststmpdir)
-        build.make(self.teststmpdir)
+        # GCC >= 14 defaults to -std=gnu23, under which this repo's
+        # old-style K&R declarations fail to build.
+        build.make(self.teststmpdir, extra_args='CFLAGS=-std=gnu17')
 
     def test_detect_5lvl(self):
         '''


### PR DESCRIPTION
memory/page_table: Fix build failure with GCC 14+

1. GCC 14 and later default to -std=gnu23, under which the legacy4K&R-style declarations used by pg-table_tests no longer compile.
2. Pass CFLAGS=-std=gnu17 during the build to maintain compatibility6with newer compiler versions.