### PR TITLE
Added new component kexec.

### DIFF
--- a/kernel/kselftest.py.data/kselftest_CI.yaml
+++ b/kernel/kselftest.py.data/kselftest_CI.yaml
@@ -1,23 +1,25 @@
 component: !mux
-    sched:
-        comp: 'sched'
-    mm:
-        comp: 'mm'
-    mm_powerpc:
-        comp: 'powerpc/mm'
-    cpu_hotplug:
-        comp: 'cpu-hotplug'
-    memory_hotplug:
-        comp: 'memory-hotplug'
-    vDSO:
-        comp: 'vDSO'
-    static_keys:
-        comp: 'static_keys'
-    signal:
-        comp: 'signal'
-    zram:
-        comp: "zram"
+  sched:
+    comp: "sched"
+  mm:
+    comp: "mm"
+  mm_powerpc:
+    comp: "powerpc/mm"
+  cpu_hotplug:
+    comp: "cpu-hotplug"
+  memory_hotplug:
+    comp: "memory-hotplug"
+  vDSO:
+    comp: "vDSO"
+  static_keys:
+    comp: "static_keys"
+  signal:
+    comp: "signal"
+  zram:
+    comp: "zram"
+  kexec:
+    comp: "kexec"
 run_type: !mux
-    upstream:
-        type: 'upstream'
-        location: "https://github.com/torvalds/linux/archive/master.zip"
+  upstream:
+    type: "upstream"
+    location: "https://github.com/torvalds/linux/archive/master.zip"

--- a/kernel/kselftest.py.data/kselftest_CR.yaml
+++ b/kernel/kselftest.py.data/kselftest_CR.yaml
@@ -1,20 +1,22 @@
 component: !mux
-    sched:
-      comp: 'sched'
-    mm:
-        comp: 'mm'
-    mm_powerpc:
-        comp: 'powerpc/mm'
-    cpu_hotplug:
-        comp: 'cpu-hotplug'
-    memory_hotplug:
-        comp: 'memory-hotplug'
-    vDSO:
-        comp: 'vDSO'
-    signal:
-        comp: 'signal'
-    zram:
-        comp: "zram"
+  sched:
+    comp: "sched"
+  mm:
+    comp: "mm"
+  mm_powerpc:
+    comp: "powerpc/mm"
+  cpu_hotplug:
+    comp: "cpu-hotplug"
+  memory_hotplug:
+    comp: "memory-hotplug"
+  vDSO:
+    comp: "vDSO"
+  signal:
+    comp: "signal"
+  zram:
+    comp: "zram"
+  kexec:
+    comp: "kexec"
 run_type: !mux
-    distro:
-        type: 'distro'
+  distro:
+    type: "distro"


### PR DESCRIPTION
Added new component and indentation.

root# avocado run --max-parallel-tasks=1 kselftest.py -m kselftest.py.data/kselftest_CR.yaml
Fetching asset from kselftest.py:kselftest.test
JOB ID     : afae5550d326f99166539e1b0822e8ba6c65242c
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2026-07-26T06.29-afae555/job.log

 (9/9) kselftest.py:kselftest.test;run-component-kexec-run_type-distro-0d8a: STARTED
 (9/9) kselftest.py:kselftest.test;run-component-kexec-run_type-distro-0d8a: PASS (34.64 s)
 
 ------
 
 root# avocado run --max-parallel-tasks=1 kselftest.py -m kselftest.py.data/kselftest_CI.yaml
Fetching asset from kselftest.py:kselftest.test
JOB ID     : e525a0b455b5e7622c9763a98f0fd2d051858d5a
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2026-07-26T06.14-e525a0b/job.log

 (10/10) kselftest.py:kselftest.test;run-component-kexec-run_type-upstream-ba5a: STARTED
 (10/10) kselftest.py:kselftest.test;run-component-kexec-run_type-upstream-ba5a: PASS (23.53 s)