### PR TITLE
Add test for Linux kernel mremap selftest with PMD alignment validation

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -239,6 +239,8 @@ class kselftest(Test):
         else:
             if self.subtest == "ksm_tests":
                 self.ksmtest()
+            elif self.subtest == "mremap_test":
+                self.mremaptest()
             else:
                 if self.subtest:
                     test_comp = self.comp + "/" + self.subtest
@@ -324,6 +326,101 @@ class kselftest(Test):
         else:
             self.cancel("Invalid ksm_tests build path:- {}"
                         .format(ksm_test_dir))
+
+    def mremaptest(self):
+        """
+        Run mremap test and validate performance for the PMD-source aligned and 4MB cases.
+        Asserts that the src+dst PMD-aligned case is the fastest.
+        """
+        mremap_test_dir = os.path.join(self.sourcedir, "mm")
+        mremap_test_bin = os.path.join(mremap_test_dir, "mremap_test")
+        if not os.path.exists(mremap_test_bin):
+            self.cancel("mremap_test binary not found at: %s" % mremap_test_bin)
+        self.log.info("Running mremap_test from %s", mremap_test_dir)
+        os.chdir(mremap_test_dir)
+        try:
+            self.result = process.run('./mremap_test',
+                                      ignore_status=True,
+                                      sudo=True)
+        except process.CmdError as details:
+            self.fail("Command ./mremap_test failed: %s" % details)
+        output = self.result.stdout.decode('utf-8')
+        self.log.info("Test output:\n%s", output)
+        times = self.parse_mremap_times(output)
+        if not times:
+            self.log.warning("No 4MB PMD-source timing lines found in output")
+            if self.result.exit_status != 0:
+                self.fail("mremap_test failed with exit code: %d" % self.result.exit_status)
+            return
+        pmd_src_and_dest = {desc: ns for desc, ns in times.items()
+                            if 'Destination PMD-aligned' in desc}
+        pmd_src_only = {desc: ns for desc, ns in times.items()
+                        if 'Destination PMD-aligned' not in desc}
+        self.log.info("=" * 80)
+        self.log.info("4MB mremap cases with Source PMD-aligned:")
+        for desc, ns in sorted(times.items()):
+            self.log.info("  %s: %d ns", desc, ns)
+        self.log.info("=" * 80)
+        if not pmd_src_and_dest:
+            self.log.warning("'Source PMD-aligned, Destination PMD-aligned' 4MB case not found")
+            if self.result.exit_status != 0:
+                self.fail("mremap_test failed with exit code: %d" % self.result.exit_status)
+            return
+        time_pmd_both = min(pmd_src_and_dest.values())
+        failures = []
+        for desc, ns in pmd_src_only.items():
+            if ns < time_pmd_both:
+                msg = ("FAIL: '%s' (%d ns) is faster than "
+                       "'Source PMD-aligned, Destination PMD-aligned' (%d ns)"
+                       % (desc, ns, time_pmd_both))
+                self.log.error(msg)
+                failures.append(msg)
+        if failures:
+            self.log.error("=" * 80)
+            self.log.error("PERFORMANCE VALIDATION FAILED:")
+            self.log.error("For 4MB PMD-source mremap, the PMD+PMD case must be fastest!")
+            for failure in failures:
+                self.log.error("  - %s", failure)
+            self.log.error("=" * 80)
+            self.fail("Source+Dest PMD-aligned 4MB mremap is not the fastest. "
+                      "See failures above.")
+        else:
+            self.log.info("=" * 80)
+            self.log.info("SUCCESS: Source+Dest PMD-aligned 4MB mremap is fastest!")
+            self.log.info("  PMD+PMD time : %d ns", time_pmd_both)
+            if pmd_src_only:
+                min_src_only = min(pmd_src_only.values())
+                self.log.info("  Non-PMD-dest min time : %d ns", min_src_only)
+                if time_pmd_both > 0:
+                    self.log.info("  Performance improvement: %.2fx faster",
+                                  min_src_only / time_pmd_both)
+                else:
+                    self.log.warning("Cannot calculate improvement: PMD+PMD time is zero")
+            self.log.info("=" * 80)
+
+    def parse_mremap_times(self, output):
+        """
+        Parse mremap_test output and return timings for the
+        '4MB mremap - Source PMD-aligned' cases.
+        Returns dict: test description -> time_ns
+        """
+        times = {}
+        lines = output.split('\n')
+        for i, line in enumerate(lines):
+            if '4MB mremap - Source PMD-aligned' not in line:
+                continue
+            tap_match = re.search(r'^ok\s+\d+\s+(.+)', line)
+            if not tap_match:
+                continue
+            test_desc = tap_match.group(1).strip()
+            for next_line in lines[i + 1:i + 4]:
+                time_match = re.search(r'mremap time:\s+(\d+)ns', next_line)
+                if time_match:
+                    time_ns = int(time_match.group(1))
+                    times[test_desc] = time_ns
+                    self.log.info("Found: %s = %d ns", test_desc, time_ns)
+                    break
+        return times
 
     def bpf(self):
         """

--- a/kernel/kselftest.py.data/kselftest_CI.yaml
+++ b/kernel/kselftest.py.data/kselftest_CI.yaml
@@ -3,6 +3,9 @@ component: !mux
     comp: "sched"
   mm:
     comp: "mm"
+  mm_mremap_test:
+    comp: "mm"
+    subtest: "mremap_test"
   mm_powerpc:
     comp: "powerpc/mm"
   cpu_hotplug:

--- a/kernel/kselftest.py.data/kselftest_CR.yaml
+++ b/kernel/kselftest.py.data/kselftest_CR.yaml
@@ -3,6 +3,9 @@ component: !mux
     comp: "sched"
   mm:
     comp: "mm"
+  mm_mremap_test:
+    comp: "mm"
+    subtest: "mremap_test"
   mm_powerpc:
     comp: "powerpc/mm"
   cpu_hotplug:


### PR DESCRIPTION
Test validates the performance optimization where both source and destination PMD-aligned mremap operations should be faster than other alignment combinations