### PR TITLE
add HNV DLPAR loop test

### DIFF
--- a/io/net/sriov_device_test.py
+++ b/io/net/sriov_device_test.py
@@ -494,6 +494,23 @@ class NetworkSriovDevice(Test):
                     self.fail(
                         "still list logical device after remove operation")
 
+    def test_hnv_dlpar_loop(self):
+        '''
+        test to add and remove migratable HNV device in a loop.
+        Reuses test_add_migratable_sriov and test_remove_migratable_sriov
+        logic. Loop count is driven by num_of_dlpar from YAML.
+        '''
+        if not self.migratable:
+            self.cancel("Test unsupported for non-migratable (HNV) devices")
+        num_of_dlpar = int(self.params.get('num_of_dlpar', default=1))
+        for iteration in range(num_of_dlpar):
+            self.log.info("HNV DLPAR iteration %d of %d",
+                          iteration + 1, num_of_dlpar)
+            self.test_add_migratable_sriov()
+            self.test_remove_migratable_sriov()
+            self.log.info("HNV DLPAR iteration %d completed",
+                          iteration + 1)
+
     def tearDown(self):
         if hasattr(self, 'session'):
             self.session.quit()

--- a/io/net/sriov_device_test.py.data/migratable_sriov_veth.yaml
+++ b/io/net/sriov_device_test.py.data/migratable_sriov_veth.yaml
@@ -8,3 +8,4 @@ peer_ips: ""
 mac_id: ""
 migratable: True
 backup_veth_vnetwork: ""
+num_of_dlpar: 

--- a/io/net/sriov_device_test.py.data/migratable_sriov_vnic.yaml
+++ b/io/net/sriov_device_test.py.data/migratable_sriov_vnic.yaml
@@ -13,3 +13,4 @@ max_capacity: ""
 capacity: ""
 vios_name: ""
 failover_priority: ""
+num_of_dlpar: 


### PR DESCRIPTION
Add test_hnv_dlpar_loop() which drives migratable SR-IOV (HNV) device add and remove in a configurable loop by calling the existing test_add_migratable_sriov() and test_remove_migratable_sriov() helpers. The loop count is read from the YAML key num_of_dlpar (default: 1)