### PR TITLE
fs/xfstests: add btrfs adv auto configs and update xfs 64k mount opts

### DIFF
--- a/fs/xfstests.py.data/btrfs/4k_adv_auto.yaml
+++ b/fs/xfstests.py.data/btrfs/4k_adv_auto.yaml
@@ -4,14 +4,14 @@ disk_mnt: '/mnt/loop-device'
 
 loop_type: !mux
     type: 'loop'
-    loop_size: '12GiB'
+    loop_size: '5GiB'
     # Option to provide disk for loop device creation,
     # Uses '/' by default for file creation
     disk: "null"
 
 fs_type: !mux
-    fs_xfs_64k_adv_auto:
-        fs: 'xfs'
+    fs_btrfs_4k_adv_auto:
+        fs: 'btrfs'
         args: '-R xunit -L 10 -g auto'
-        mkfs_opt: '-f -m inobtcount=1,bigtime=1,rmapbt=1 -b size=65536'
-        mount_opt: '-o usrquota,grpquota,prjquota'
+        mkfs_opt: '-f -s 4096 -O quota,block-group-tree'
+        mount_opt: ''

--- a/fs/xfstests.py.data/btrfs/64k_adv_auto.yaml
+++ b/fs/xfstests.py.data/btrfs/64k_adv_auto.yaml
@@ -4,14 +4,14 @@ disk_mnt: '/mnt/loop-device'
 
 loop_type: !mux
     type: 'loop'
-    loop_size: '12GiB'
+    loop_size: '5GiB'
     # Option to provide disk for loop device creation,
     # Uses '/' by default for file creation
     disk: "null"
 
 fs_type: !mux
-    fs_xfs_64k_adv_auto:
-        fs: 'xfs'
+    fs_btrfs_64k_adv_auto:
+        fs: 'btrfs'
         args: '-R xunit -L 10 -g auto'
-        mkfs_opt: '-f -m inobtcount=1,bigtime=1,rmapbt=1 -b size=65536'
-        mount_opt: '-o usrquota,grpquota,prjquota'
+        mkfs_opt: '-f -s 65536 -n 65536 -O quota,block-group-tree'
+        mount_opt: ''


### PR DESCRIPTION
Add two new xfstests parameter files for btrfs filesystem testing:

- btrfs/4k_adv_auto.yaml: Runs 'auto' group tests on btrfs with 4K sector size (-s 4096) and quota/block-group-tree features enabled.
- btrfs/64k_adv_auto.yaml: Runs 'auto' group tests on btrfs with 64K sector/nodesize (-s 65536 -n 65536) and quota/block-group-tree features enabled.

Also update xfs 64k_adv_auto.yaml to enable usrquota, grpquota, and prjquota mount options.