### PR TITLE
fs/xfstests: Fix mkfs fstype injection for mkfs_opt containing '-t' substring

### DIFF
--- a/fs/xfstests.py
+++ b/fs/xfstests.py
@@ -369,19 +369,20 @@ class Xfstests(Test):
             f.writelines(new_lines)
 
         self.log.info("Final local.config content:\n%s", ''.join(new_lines))
+        mkfs_args = f'-t {self.fs_to_test} {self.mkfs_opt}'.strip()
 
         # Create logdev filesystems
         for dev in self.log_devices:
-            partition.Partition(dev).mkfs(fstype=self.fs_to_test, args=self.mkfs_opt)
+            partition.Partition(dev).mkfs(fstype=self.fs_to_test, args=mkfs_args)
 
         # Create mkfs on test and scratch devices
         for i, dev in enumerate(self.devices):
             dev_obj = partition.Partition(dev)
             if self.logdev_opt:
                 dev_obj.mkfs(fstype=self.fs_to_test,
-                             args=f'{self.mkfs_opt} {self.logdev_opt}={self.log_devices[i]}')
+                             args=f'{mkfs_args} {self.logdev_opt}={self.log_devices[i]}')
             else:
-                dev_obj.mkfs(fstype=self.fs_to_test, args=self.mkfs_opt)
+                dev_obj.mkfs(fstype=self.fs_to_test, args=mkfs_args)
 
         # Clone & build xfstests
         git.get_repo('https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git',


### PR DESCRIPTION
avocado's partition.mkfs() checks 'if "-t" not in args' to decide whether to inject '-t <fstype>'. This check fails when mkfs_opt contains an option value with '-t' as a substring, e.g. '-O quota,block-group-tree' (group-tree contains '-t').

Result: mkfs is called without '-t btrfs', falling through to mkfs.ext2 and failing.

Fix by explicitly prepending '-t <fstype>' to mkfs_args before passing to partition.mkfs(), ensuring the check always finds it.
Affects all btrfs yamls using -O block-group-tree.

Before fix
```
# avocado run xfstests.py -m xfstests.py.data/btrfs/4k_adv_auto.yaml
JOB ID     : a2717dc0e3c9a0ccaeca277aa4349ba9ddb1c447
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2026-08-03T17.33-a2717dc/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_btrfs_4k_adv_auto-loop_type-0f11: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_btrfs_4k_adv_auto-loop_type-0f11: ERROR: Partition(/dev/loop0): Failed to mkfs: Command 'yes | mkfs -s 4096 -O quota,block-group-tree -f /dev/loop0' failed.\nstdout: b''\nstderr: b"mkfs.ext2: invalid option -- 'f'\nUsage: mkfs.ext2 [-c|-l filename] [-b block-size] [-C cluster-size]\n\t[-i bytes-pe... (0.56 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2026-08-03T17.33-a2717dc/results.html
JOB TIME   : 15.61 s
```
After fix
```
# avocado run xfstests.py -m xfstests.py.data/btrfs/4k_adv_auto.yaml
JOB ID     : bb79a9c57238712007e76dce11343cf3b5b9bcae
JOB LOG    : /home/avocado-fvt-wrapper/results/job-2026-08-03T17.53-bb79a9c/job.log
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_btrfs_4k_adv_auto-loop_type-0f11: STARTED
 (1/1) xfstests.py:Xfstests.test;run-fs_type-fs_btrfs_4k_adv_auto-loop_type-0f11: PASS (19.97 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /home/avocado-fvt-wrapper/results/job-2026-08-03T17.53-bb79a9c/results.html
JOB TIME   : 31.28 s
```