### PR TITLE
Spyre: Resolving warnings in podman stop

### DIFF
--- a/accelerator/spyre/spyre_Embedding_test.py
+++ b/accelerator/spyre/spyre_Embedding_test.py
@@ -414,13 +414,12 @@ class SpyreEmbeddingTest(Test):
 
                 self.log.info("Stopping container as user '%s': %s",
                               self.user, self.container_id)
-                try:
-                    self.podman.stop(self.container_id, user=self.user)
-                except Exception as stop_ex:
-                    self.log.warning(
-                        "Failed to stop via podman utility: %s", stop_ex)
-                    stop_cmd = f"su - {self.user} -c 'podman stop {self.container_id}'"
-                    process.run(stop_cmd, shell=True)
+                stop_cmd = (
+                    f"su - {self.user} -c 'podman stop -t 10 {self.container_id}'"
+                    if self.user
+                    else f"podman stop -t 10 {self.container_id}"
+                )
+                process.run(stop_cmd, shell=True)
 
                 self.log.info("Removing container as user '%s': %s",
                               self.user, self.container_id)

--- a/accelerator/spyre/spyre_Entity_Extraction_test.py
+++ b/accelerator/spyre/spyre_Entity_Extraction_test.py
@@ -416,13 +416,12 @@ class EntityExtractionTest(Test):
 
                 self.log.info("Stopping container as user '%s': %s",
                               self.user, self.container_id)
-                try:
-                    self.podman.stop(self.container_id, user=self.user)
-                except Exception as stop_ex:
-                    self.log.warning(
-                        "Failed to stop via podman utility: %s", stop_ex)
-                    stop_cmd = f"su - {self.user} -c 'podman stop {self.container_id}'"
-                    process.run(stop_cmd, shell=True)
+                stop_cmd = (
+                    f"su - {self.user} -c 'podman stop -t 10 {self.container_id}'"
+                    if self.user
+                    else f"podman stop -t 10 {self.container_id}"
+                )
+                process.run(stop_cmd, shell=True)
 
                 self.log.info("Removing container as user '%s': %s",
                               self.user, self.container_id)

--- a/accelerator/spyre/spyre_RAG_usecase_test.py
+++ b/accelerator/spyre/spyre_RAG_usecase_test.py
@@ -402,13 +402,12 @@ class SpyreRAGTest(Test):
 
                 self.log.info("Stopping container as user '%s': %s",
                               self.user, self.container_id)
-                try:
-                    self.podman.stop(self.container_id, user=self.user)
-                except Exception as stop_ex:
-                    self.log.warning(
-                        "Failed to stop via podman utility: %s", stop_ex)
-                    stop_cmd = f"su - {self.user} -c 'podman stop {self.container_id}'"
-                    process.run(stop_cmd, shell=True)
+                stop_cmd = (
+                    f"su - {self.user} -c 'podman stop -t 10 {self.container_id}'"
+                    if self.user
+                    else f"podman stop -t 10 {self.container_id}"
+                )
+                process.run(stop_cmd, shell=True)
 
                 self.log.info("Removing container as user '%s': %s",
                               self.user, self.container_id)

--- a/accelerator/spyre/spyre_Reranker_test.py
+++ b/accelerator/spyre/spyre_Reranker_test.py
@@ -414,13 +414,12 @@ class SpyreRerankerTest(Test):
 
                 self.log.info("Stopping container as user '%s': %s",
                               self.user, self.container_id)
-                try:
-                    self.podman.stop(self.container_id, user=self.user)
-                except Exception as stop_ex:
-                    self.log.warning(
-                        "Failed to stop via podman utility: %s", stop_ex)
-                    stop_cmd = f"su - {self.user} -c 'podman stop {self.container_id}'"
-                    process.run(stop_cmd, shell=True)
+                stop_cmd = (
+                    f"su - {self.user} -c 'podman stop -t 10 {self.container_id}'"
+                    if self.user
+                    else f"podman stop -t 10 {self.container_id}"
+                )
+                process.run(stop_cmd, shell=True)
 
                 self.log.info("Removing container as user '%s': %s",
                               self.user, self.container_id)

--- a/accelerator/spyre/spyre_Senlib_test.py
+++ b/accelerator/spyre/spyre_Senlib_test.py
@@ -485,7 +485,8 @@ class SenlibTests(Test):
                     self.log.warning("Failed to save final logs: %s", log_ex)
 
                 self.log.info("Stopping container: %s", self.container_id)
-                self.podman.stop(self.container_id)
+                process.run(f"podman stop -t 10 {self.container_id}",
+                            shell=True)
 
                 self.log.info("Removing container: %s", self.container_id)
                 self.podman.remove(self.container_id, force=True)

--- a/accelerator/spyre/spyre_Serviceability_test.py
+++ b/accelerator/spyre/spyre_Serviceability_test.py
@@ -804,14 +804,12 @@ class SpyreServiceabilityTest(Test):
 
                 self.log.info("Stopping container '%s': %s",
                               self.container_user, self.container_id)
-                try:
-                    self.podman.stop(self.container_id,
-                                     user=self.container_user)
-                except Exception as stop_ex:
-                    self.log.warning(
-                        "Failed to stop via podman utility: %s", stop_ex)
-                    stop_cmd = f"su - {self.container_user} -c 'podman stop {self.container_id}'"
-                    process.run(stop_cmd, shell=True)
+                stop_cmd = (
+                    f"su - {self.container_user} -c 'podman stop -t 10 {self.container_id}'"
+                    if self.container_user
+                    else f"podman stop -t 10 {self.container_id}"
+                )
+                process.run(stop_cmd, shell=True)
 
                 self.log.info("Removing container '%s': %s",
                               self.container_user, self.container_id)


### PR DESCRIPTION
Adding a timeout of 10 seconds to podman stop
to avoid spurious WARN on teardown