### PR TITLE
cpu/ebizzy.py fix: update ebizzy download link to use HTTPS

### DIFF
--- a/cpu/ebizzy.py.data/ebizzy.yaml
+++ b/cpu/ebizzy.py.data/ebizzy.yaml
@@ -1,4 +1,4 @@
-ebizy_url: 'http://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz'
+ebizy_url: 'https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz'
 iterations: 10
 perfstat: -a
 taskset: '0'


### PR DESCRIPTION
Fixed the wget issue where we are using the link to download the ebizzy workload, which failed to download the file.
Ex: http://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz

Now I have added the link below:
Ex: https://sourceforge.net/projects/ebizzy/files/ebizzy/0.3/ebizzy-0.3.tar.gz