### PR TITLE
security/kernel-lockdown-tests.py: fix debugfs test for RHEL 9 / Linu…

### DIFF
--- a/security/kernel-lockdown-tests.py
+++ b/security/kernel-lockdown-tests.py
@@ -102,15 +102,18 @@ class kernelLockdown(Test):
         output = process.system_output('mount', ignore_status=True).decode()
         if 'debugfs' not in output:
             self.cancel("Skip this test as 'debugfs' not mounted.")
+        # Linux 5.16+: xive was restructured into a directory with store-eoi
+        # inside (commits baed14de, d7bc1e37). RHEL 9 (5.14-based) never
+        # received that backport, so xive remains a flat file there.
         dbg_file = "/sys/kernel/debug/powerpc/xive/store-eoi"
-        if os.path.exists(dbg_file):
-            try:
-                genio.read_file(dbg_file)
-            except PermissionError as err:
-                if 'Operation not permitted' not in str(err):
-                    self.fail("Access to %s permitted." % dbg_file)
-        else:
-            self.cancel("%s file not exist." % dbg_file)
+        dbg_file = dbg_file if os.path.isfile(dbg_file) else "/sys/kernel/debug/powerpc/xive"
+        if not os.path.isfile(dbg_file):
+            self.cancel(f"{dbg_file} file does not exist.")
+        try:
+            genio.read_file(dbg_file)
+        except PermissionError as err:
+            if 'Operation not permitted' not in str(err):
+                self.fail(f"Access to {dbg_file} permitted.")
 
     def test_lockdown_ioctl(self):
         # Clear dmesg log


### PR DESCRIPTION
…x 5.14.

This path only exists on Linux 5.16+ where two upstream commits restructured the XIVE debugfs layout:

  baed14de powerpc/xive: Change the debugfs file 'xive' into a directory
  d7bc1e37 powerpc/xive: Add a debugfs toggle for StoreEOI

  https://lore.kernel.org/r/20211105102636.1016378-9-clg@kaod.org

RHEL 9 is based on Linux 5.14 and never received these backports. On RHEL 9, /sys/kernel/debug/powerpc/xive remains a flat file, so the test always CANCELed with "store-eoi file not exist".


---- Result ----

Before:
 (4/5) kernel-lockdown-tests.py:kernelLockdown.test_lockdown_debugfs: STARTED
 (4/5) kernel-lockdown-tests.py:kernelLockdown.test_lockdown_debugfs: CANCEL: /sys/kernel/debug/powerpc/xive/store-eoi file not exist. (0.25 s)
 
 After:
 
 (4/5) kernel-lockdown-tests.py:kernelLockdown.test_lockdown_debugfs: STARTED
 (4/5) kernel-lockdown-tests.py:kernelLockdown.test_lockdown_debugfs: PASS (0.26 s)