### PR TITLE
io/pci/pci_hotplug: Adding support for pcie_lockdown feature

### DIFF
--- a/io/pci/pci_hotplug.py.data/pci_hotplug_lockdown.yaml
+++ b/io/pci/pci_hotplug.py.data/pci_hotplug_lockdown.yaml
@@ -1,0 +1,7 @@
+pci_devices: ""
+count: 10
+#This option is for nvme splitter adapter, Value: nvme_splitter
+adapter_type: ""
+peer_ip:
+lockdown_mode: ""
+lockdown_enable:


### PR DESCRIPTION
This test adds pcie_lockdown support for pci_hotplug by:
- adding lockdown_enable and lockdown_mode parameters
- setting lockdown mode (none/integrity/confidentiality) before pci_hotplug operations
- adding a lockdown YAML template for configuration