### PR TITLE
fixing HMCIPAddr not found via lsrsrc IBM.MCP command issue

### DIFF
--- a/io/net/sriov_device_test.py
+++ b/io/net/sriov_device_test.py
@@ -19,6 +19,7 @@
 Tests for Sriov logical device
 '''
 
+import re
 import netifaces
 from avocado import Test
 from avocado.utils import process
@@ -46,6 +47,10 @@ class NetworkSriovDevice(Test):
             if not smm.check_installed(pkg) and not smm.install(pkg):
                 self.cancel('%s is needed for the test to be run' % pkg)
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
+        if not self.hmc_ip:
+            self.log.info("HMCIPAddr not found via lsrsrc IBM.MCP, "
+                          "falling back to lssrc -ls mcproxy for hostname")
+            self.hmc_ip = self.get_hmc_from_mcproxy()
         if not self.hmc_ip:
             self.cancel("HMC IP not got")
         self.hmc_pwd = self.params.get("hmc_pwd", default=None)
@@ -149,6 +154,24 @@ class NetworkSriovDevice(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_hmc_from_mcproxy():
+        '''
+        Fallback: parse 'lssrc -ls mcproxy' for the HMC hostname when
+        'lsrsrc IBM.MCP HMCIPAddr' returns no IP address.
+        Looks for a line of the form:
+            Hostname: ://example.com
+        and returns the hostname string, or '' if not found.
+        '''
+        for line in process.system_output('lssrc -ls mcproxy',
+                                          ignore_status=True, shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
+            match = re.match(r'\s*Hostname:\s*(\S+)', line)
+            if match:
+                return match.group(1)
         return ''
 
     @staticmethod

--- a/io/net/virt-net/lpm.py
+++ b/io/net/virt-net/lpm.py
@@ -18,6 +18,7 @@
 Tests for Live Partition Mobility
 '''
 
+import re
 import time
 from avocado import Test
 from avocado.utils import process
@@ -50,6 +51,10 @@ class LPM(Test):
         self.rsct_service_start()
 
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
+        if not self.hmc_ip:
+            self.log.info("HMCIPAddr not found via lsrsrc IBM.MCP, "
+                          "falling back to lssrc -ls mcproxy for hostname")
+            self.hmc_ip = self.get_hmc_from_mcproxy()
         if not self.hmc_ip:
             self.cancel("HMC IP not got from lsrsrc command")
         self.hmc_user = self.params.get("hmc_username", default='hscroot')
@@ -142,6 +147,24 @@ class LPM(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_hmc_from_mcproxy():
+        '''
+        Fallback: parse 'lssrc -ls mcproxy' for the HMC hostname when
+        'lsrsrc IBM.MCP HMCIPAddr' returns no IP address.
+        Looks for a line of the form:
+            Hostname: ://example.com
+        and returns the hostname string, or '' if not found.
+        '''
+        for line in process.system_output('lssrc -ls mcproxy',
+                                          ignore_status=True, shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
+            match = re.match(r'\s*Hostname:\s*(\S+)', line)
+            if match:
+                return match.group(1)
         return ''
 
     @staticmethod

--- a/io/net/virt-net/network_virtualization.py
+++ b/io/net/virt-net/network_virtualization.py
@@ -65,6 +65,10 @@ class NetworkVirtualization(Test):
         self.hmc_ip = wait.wait_for(
             lambda: self.get_mcp_component("HMCIPAddr"), timeout=30)
         if not self.hmc_ip:
+            self.log.info("HMCIPAddr not found via lsrsrc IBM.MCP, "
+                          "falling back to lssrc -ls mcproxy for hostname")
+            self.hmc_ip = self.get_hmc_from_mcproxy()
+        if not self.hmc_ip:
             self.cancel("HMC IP not got")
         self.hmc_pwd = self.params.get("hmc_pwd", default=None)
         self.hmc_username = self.params.get("hmc_username", default=None)
@@ -184,6 +188,24 @@ class NetworkVirtualization(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_hmc_from_mcproxy():
+        '''
+        Fallback: parse 'lssrc -ls mcproxy' for the HMC hostname when
+        'lsrsrc IBM.MCP HMCIPAddr' returns no IP address.
+        Looks for a line of the form:
+            Hostname: ://example.com
+        and returns the hostname string, or '' if not found.
+        '''
+        for line in process.system_output('lssrc -ls mcproxy',
+                                          ignore_status=True, shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
+            match = re.match(r'\s*Hostname:\s*(\S+)', line)
+            if match:
+                return match.group(1)
         return ''
 
     @staticmethod


### PR DESCRIPTION
In few distro, lsrsrc IBM.MCP command is failing to fetch the HMCIPAddr and hence not able to establish the connection with HMC and tests were failing
this script adds the alternative way of finding the HMCIP using "lssrc -ls mcproxy" command. And now it is working fine