### PR TITLE
lsrsrc IBM.MCP command failing to fetch the HMCIP, fixing the same

### DIFF
--- a/io/disk/vfc-tests/vfc_dlpar.py
+++ b/io/disk/vfc-tests/vfc_dlpar.py
@@ -18,6 +18,7 @@
 Tests for Virtual FC
 '''
 
+import re
 import time
 from avocado import Test
 from avocado.utils import process
@@ -47,6 +48,10 @@ class VirtualFC(Test):
         self.install_packages()
         self.rsct_service_start()
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
+        if not self.hmc_ip:
+            self.log.info("HMCIPAddr not found via lsrsrc IBM.MCP, "
+                          "falling back to lssrc -ls mcproxy for hostname")
+            self.hmc_ip = self.get_hmc_from_mcproxy()
         if not self.hmc_ip:
             self.cancel("HMC IP not got")
         self.hmc_pwd = self.params.get("hmc_pwd", '*', default=None)
@@ -99,6 +104,24 @@ class VirtualFC(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_hmc_from_mcproxy():
+        '''
+        Fallback: parse 'lssrc -ls mcproxy' for the HMC hostname when
+        'lsrsrc IBM.MCP HMCIPAddr' returns no IP address.
+        Looks for a line of the form:
+            Hostname: ://example.com
+        and returns the hostname string, or '' if not found.
+        '''
+        for line in process.system_output('lssrc -ls mcproxy',
+                                          ignore_status=True, shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
+            match = re.match(r'\s*Hostname:\s*(\S+)', line)
+            if match:
+                return match.group(1)
         return ''
 
     @staticmethod

--- a/io/disk/vfc-tests/virtual_fc.py
+++ b/io/disk/vfc-tests/virtual_fc.py
@@ -18,6 +18,7 @@
 Tests for Virtual FC
 '''
 
+import re
 import time
 from avocado import Test
 from avocado.utils import process
@@ -49,6 +50,10 @@ class VirtualFC(Test):
         self.install_packages()
         self.rsct_service_start()
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
+        if not self.hmc_ip:
+            self.log.info("HMCIPAddr not found via lsrsrc IBM.MCP, "
+                          "falling back to lssrc -ls mcproxy for hostname")
+            self.hmc_ip = self.get_hmc_from_mcproxy()
         if not self.hmc_ip:
             self.cancel("HMC IP not got")
         self.vioses = self.params.get("vioses", default=None)
@@ -110,6 +115,24 @@ class VirtualFC(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_hmc_from_mcproxy():
+        '''
+        Fallback: parse 'lssrc -ls mcproxy' for the HMC hostname when
+        'lsrsrc IBM.MCP HMCIPAddr' returns no IP address.
+        Looks for a line of the form:
+            Hostname: ://example.com
+        and returns the hostname string, or '' if not found.
+        '''
+        for line in process.system_output('lssrc -ls mcproxy',
+                                          ignore_status=True, shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
+            match = re.match(r'\s*Hostname:\s*(\S+)', line)
+            if match:
+                return match.group(1)
         return ''
 
     @staticmethod

--- a/io/pci/dlpar.py
+++ b/io/pci/dlpar.py
@@ -18,6 +18,7 @@
 """
 DLPAR operations
 """
+import re
 import time
 import os
 
@@ -51,6 +52,10 @@ class DlparPci(Test):
         self.install_packages()
         self.rsct_service_start()
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
+        if not self.hmc_ip:
+            self.log.info("HMCIPAddr not found via lsrsrc IBM.MCP, "
+                          "falling back to lssrc -ls mcproxy for hostname")
+            self.hmc_ip = self.get_hmc_from_mcproxy()
         if not self.hmc_ip:
             self.cancel("HMC IP not got")
         self.hmc_user = self.params.get("hmc_username", default='*******')
@@ -155,6 +160,24 @@ class DlparPci(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_hmc_from_mcproxy():
+        '''
+        Fallback: parse 'lssrc -ls mcproxy' for the HMC hostname when
+        'lsrsrc IBM.MCP HMCIPAddr' returns no IP address.
+        Looks for a line of the form:
+            Hostname: ://example.com
+        and returns the hostname string, or '' if not found.
+        '''
+        for line in process.system_output('lssrc -ls mcproxy',
+                                          ignore_status=True, shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
+            match = re.match(r'\s*Hostname:\s*(\S+)', line)
+            if match:
+                return match.group(1)
         return ''
 
     @staticmethod

--- a/perf/perf_hv_gpci_interface.py
+++ b/perf/perf_hv_gpci_interface.py
@@ -14,6 +14,7 @@
 # Copyright: 2024 IBM
 # Author: Tejas Manhas <Tejas.Manhas1@ibm.com>
 import os
+import re
 from avocado import Test
 from avocado.utils import distro, process, genio, cpu, dmesg
 from avocado.utils.software_manager.manager import SoftwareManager
@@ -47,6 +48,10 @@ class perf_hv_gpci_interface(Test):
                 self.cancel('%s is needed for the test to be run' % package)
         self.expected_files = self.params.get("access_files", default=None)
         self.hmc_ip = self.get_mcp_component("HMCIPAddr")
+        if not self.hmc_ip:
+            self.log.info("HMCIPAddr not found via lsrsrc IBM.MCP, "
+                          "falling back to lssrc -ls mcproxy for hostname")
+            self.hmc_ip = self.get_hmc_from_mcproxy()
         if not self.hmc_ip:
             self.cancel("HMC IP not got")
         self.hmc_username = self.params.get("hmc_username", '*', default=None)
@@ -89,6 +94,24 @@ class perf_hv_gpci_interface(Test):
                                                     .splitlines():
             if component in line:
                 return line.split()[-1].strip('{}\"')
+        return ''
+
+    @staticmethod
+    def get_hmc_from_mcproxy():
+        '''
+        Fallback: parse 'lssrc -ls mcproxy' for the HMC hostname when
+        'lsrsrc IBM.MCP HMCIPAddr' returns no IP address.
+        Looks for a line of the form:
+            Hostname: ://example.com
+        and returns the hostname string, or '' if not found.
+        '''
+        for line in process.system_output('lssrc -ls mcproxy',
+                                          ignore_status=True, shell=True,
+                                          sudo=True).decode("utf-8") \
+                                                    .splitlines():
+            match = re.match(r'\s*Hostname:\s*(\S+)', line)
+            if match:
+                return match.group(1)
         return ''
 
     @staticmethod


### PR DESCRIPTION
In few distro, lsrsrc IBM.MCP command is failing to fetch the HMCIPAddr and hence not able to establish the connection with HMC and tests were failing this script adds the alternative way of finding the HMCIP using "lssrc -ls mcproxy" command. And now it is working fine