### PR TITLE
kselftest: add filesystems selftests from tools/testing/selftests/filesystems

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -22,7 +22,7 @@ import shutil
 from avocado import Test
 from avocado.utils import build, process
 from avocado.utils import distro
-from avocado.utils import archive, git
+from avocado.utils import archive, git, linux_modules
 from avocado.utils.software_manager.manager import SoftwareManager
 
 
@@ -58,6 +58,7 @@ class kselftest(Test):
         self.kexec_symlink_created = False
         self.kexec_kernel_version = None
         self.subtest = self.params.get('subtest', default='')
+        self._overlay_loaded = False
         if self.comp == "mm" and self.subtest == "ksm_tests":
             self.test_type = self.params.get('test_type', default='-H')
             self.Size_flag = self.params.get('Size', default='-s')
@@ -108,7 +109,7 @@ class kselftest(Test):
             if self.detected_distro.name == 'rhel' and self.distro_ver >= 9:
                 packages_remove = ['libhugetlbfs-devel']
                 deps = list(set(deps)-set(packages_remove))
-                deps.extend(['fuse3-devel'])
+                deps.extend(['fuse3-devel', 'libasan'])
             else:
                 deps.extend(['fuse-devel'])
 
@@ -156,8 +157,12 @@ class kselftest(Test):
                     break
             self.sourcedir = os.path.join(self.buldir, self.testdir)
             if (self.comp != "cpufreq" and self.comp != "bpf"):
-                process.system("make headers -C %s" % self.buldir, shell=True,
-                               sudo=True)
+                if self.comp.startswith('filesystems'):
+                    process.system("make headers_install -C %s" % self.buldir,
+                                   shell=True, sudo=True, ignore_status=True)
+                else:
+                    process.system("make headers -C %s" % self.buldir,
+                                   shell=True, sudo=True)
                 # Only run 'make install' if no specific component is selected
                 # Component-specific builds will be done later in the build phase
                 if not self.comp:
@@ -204,13 +209,35 @@ class kselftest(Test):
             process.system("sed -i 's/^.*cmsg_time.sh/#&/g' %s" % make_path,
                            shell=True, sudo=True)
         if (self.comp != "cpufreq" and self.comp != "bpf"):
-            # Run make headers before building
-            process.system("make headers -C %s" % self.buldir, shell=True,
-                           sudo=True)
-            if self.comp:
-                build_str = '-C %s' % self.comp
-            if build.make(self.sourcedir, extra_args='%s' % build_str):
-                self.fail("Compilation failed, Please check the build logs !!")
+            if self.comp.startswith('filesystems'):
+                if self.comp == 'filesystems/mount-notify':
+                    if (linux_modules.check_kernel_config('CONFIG_FANOTIFY')
+                            == linux_modules.ModuleConfig.NOT_SET):
+                        self.cancel("mount-notify requires CONFIG_FANOTIFY=y "
+                                    "in the running kernel")
+                if self.comp == 'filesystems/binderfs':
+                    for mod, cfg in [('binder_linux', 'CONFIG_ANDROID_BINDER_IPC'),
+                                     ('binderfs', 'CONFIG_ANDROID_BINDERFS')]:
+                        status = linux_modules.check_kernel_config(cfg)
+                        if status == linux_modules.ModuleConfig.NOT_SET:
+                            self.cancel("binderfs requires %s in the running kernel" % cfg)
+                        if status == linux_modules.ModuleConfig.MODULE:
+                            if not linux_modules.module_is_loaded(mod):
+                                if not linux_modules.load_module(mod):
+                                    self.cancel("Failed to load module %s %s" % (mod, cfg))
+                if self.comp == 'filesystems/overlayfs':
+                    result = process.run("lsmod | grep -w overlay",
+                                         shell=True, ignore_status=True)
+                    if result.exit_status != 0:
+                        process.system("modprobe overlay", shell=True, sudo=True)
+                        self._overlay_loaded = True
+            else:
+                # Run make headers before building
+                process.system("make headers -C %s" % self.buldir, shell=True,
+                               sudo=True)
+                build_str = '-C %s' % self.comp if self.comp else ''
+                if build.make(self.sourcedir, extra_args='%s' % build_str):
+                    self.fail("Compilation failed, Please check the build logs !!")
         # Fix for kexec test: Create vmlinuz symlink if only vmlinux exists
         # This handles SUSE systems that use vmlinux instead of vmlinuz
         if self.comp == "kexec":
@@ -250,7 +277,7 @@ class kselftest(Test):
                     self.sourcedir, kself_args, test_comp)
                 self.result = process.run(
                     make_cmd, shell=True, ignore_status=True)
-        log_output = self.result.stdout.decode('utf-8')
+        log_output = (self.result.stdout + self.result.stderr).decode('utf-8')
         results_path = os.path.join(self.outputdir, 'raw_output')
         with open(results_path, 'w') as r_file:
             r_file.write(log_output)
@@ -267,6 +294,10 @@ class kselftest(Test):
                     # Match both overall test failures and individual test failures
                     self.find_match(r'not ok (.*) selftests:(.*)', line)
                     self.find_match(r'# not ok \d+ .* # exit=\d+', line)
+        if self.result.exit_status != 0 and not self.error:
+            self.fail("make run_tests exited with status %d (build or runtime "
+                      "error — check raw_output for details)"
+                      % self.result.exit_status)
 
         if self.error:
             # Build the summary message
@@ -450,5 +481,8 @@ class kselftest(Test):
                                shell=True, sudo=True, ignore_status=True)
             else:
                 self.log.warning(f"Symlink {vmlinuz_path} no longer exists or is not a symlink, skipping removal")
+        if getattr(self, '_overlay_loaded', False):
+            process.system("rmmod overlay", shell=True, sudo=True,
+                           ignore_status=True)
         if os.path.exists(self.workdir):
             shutil.rmtree(self.workdir)

--- a/kernel/kselftest.py.data/kselftest_CI.yaml
+++ b/kernel/kselftest.py.data/kselftest_CI.yaml
@@ -22,6 +22,44 @@ component: !mux
     comp: "zram"
   kexec:
     comp: "kexec"
+  filesystem:
+    comp: 'filesystems'
+  filesystem_binderfs:
+    comp: 'filesystems/binderfs'
+  filesystem_empty_mntns:
+    comp: 'filesystems/empty_mntns'
+  filesystem_epoll:
+    comp: 'filesystems/epoll'
+  filesystem_eventfd:
+    comp: 'filesystems/eventfd'
+  filesystem_failfs:
+    comp: 'filesystems/failfs'
+  filesystem_fat:
+    comp: 'filesystems/fat'
+  filesystem_fscontext_ns:
+    comp: 'filesystems/fscontext_ns'
+  filesystem_fsmount_ns:
+    comp: 'filesystems/fsmount_ns'
+  filesystem_fuse:
+    comp: 'filesystems/fuse'
+  filesystem_mntns_cleanup:
+    comp: 'filesystems/mntns_cleanup'
+  filesystem_mount-notify:
+    comp: 'filesystems/mount-notify'
+  filesystem_move_mount:
+    comp: 'filesystems/move_mount'
+  filesystem_nsfs:
+    comp: 'filesystems/nsfs'
+  filesystem_open_tree_ns:
+    comp: 'filesystems/open_tree_ns'
+  filesystem_openat2:
+    comp: 'filesystems/openat2'
+  filesystem_overlayfs:
+    comp: 'filesystems/overlayfs'
+  filesystem_statmount:
+    comp: 'filesystems/statmount'
+  filesystem_xattr:
+    comp: 'filesystems/xattr'
 run_type: !mux
   upstream:
     type: "upstream"

--- a/kernel/kselftest.py.data/kselftest_CR.yaml
+++ b/kernel/kselftest.py.data/kselftest_CR.yaml
@@ -20,6 +20,20 @@ component: !mux
     comp: "zram"
   kexec:
     comp: "kexec"
+  filesystem:
+    comp: 'filesystems'
+  filesystem_binderfs:
+    comp: 'filesystems/binderfs'
+  filesystem_epoll:
+    comp: 'filesystems/epoll'
+  filesystem_eventfd:
+    comp: 'filesystems/eventfd'
+  filesystem_fat:
+    comp: 'filesystems/fat'
+  filesystem_overlayfs:
+    comp: 'filesystems/overlayfs'
+  filesystem_statmount:
+    comp: 'filesystems/statmount'
 run_type: !mux
   distro:
     type: "distro"


### PR DESCRIPTION
Add support for running Linux filesystem selftests available under tools/testing/selftests/filesystems in the kernel source.

Key changes to kselftest.py:
- Use 'make headers_install' for filesystems as some filesystem selftests require kernel headers to be installed in the system include path to build correctly
- Add libasan to RHEL >= 9 deps (required by filesystems/openat2)
- Add per-subtest kernel config/module guards: 
  CONFIG_FANOTIFY for mount-notify 
  binder configs for binderfs 
  overlay module for overlayfs

kselftest_CI.yaml: add 19 filesystems sub-component entries for upstream
kselftest_CR.yaml: add 6 filesystems entries present on distro kernel sources