### PR TITLE
cpu/cpuidle_wakeup_test: Add cpuidle wakeup latency test

### DIFF
--- a/cpu/cpuidle_wakeup_test.py
+++ b/cpu/cpuidle_wakeup_test.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2026 IBM
+# Author: Samir Mulani <samir@linux.ibm.com>
+
+import glob
+import os
+import shutil
+
+from avocado import Test
+from avocado.utils import cpu, process
+from avocado.utils.software_manager.manager import SoftwareManager
+
+
+class CpuidleWakeupTest(Test):
+    """
+    Compile cpuidle_wakeup.c and run it across a sweep of sleep intervals
+    using pipe-based wakeup mode.  One plain-text log file per interval is
+    written under cpuidle_wakeup_logs/.
+
+    :avocado: tags=cpu,cpuidle,power,wakeup_latency
+    """
+
+    def setUp(self):
+        """
+        Install gcc/make, compile the bundled C source, validate cpuidle
+        sysfs, and read test parameters from YAML.
+        """
+        smm = SoftwareManager()
+        for pkg in ["gcc", "make"]:
+            if not smm.check_installed(pkg) and not smm.install(pkg):
+                self.cancel(
+                    "'%s' is required but could not be installed" % pkg)
+
+        src_name = "cpuidle_wakeup.c"
+        src_path = self.get_data(src_name)
+        if src_path is None:
+            self.cancel(
+                "Source file '%s' not found in the .data directory" % src_name
+            )
+
+        dst_src = os.path.join(self.workdir, src_name)
+        shutil.copy(src_path, dst_src)
+
+        self.binary = os.path.join(self.workdir, "cpuidle-state-test")
+        ret = process.run(
+            "gcc -O2 -pthread -o %s %s" % (self.binary, dst_src),
+            ignore_status=True,
+        )
+        if ret.exit_status != 0:
+            self.cancel(
+                "Compilation failed:\n%s\n%s"
+                % (ret.stdout_text, ret.stderr_text)
+            )
+        self.log.info("Binary compiled: %s", self.binary)
+
+        cpuidle_root = "/sys/devices/system/cpu/cpu0/cpuidle"
+        if not os.path.isdir(cpuidle_root):
+            self.cancel(
+                "cpuidle sysfs not found at '%s'; "
+                "cpuidle may be disabled on this kernel" % cpuidle_root
+            )
+        state_dirs = glob.glob(os.path.join(cpuidle_root, "state*"))
+        self.nr_idle_states = len(state_dirs)
+        self.log.info("Detected %d cpuidle state(s) on cpu0",
+                      self.nr_idle_states)
+
+        self.wakee_cpu = self.params.get("wakee_cpu", default=10)
+        self.waker_cpu = self.params.get("waker_cpu", default=40)
+        self.test_duration = self.params.get("test_duration_sec", default=10)
+        raw = self.params.get(
+            "sleep_intervals_us",
+            default="3,5,10,20,30,40,50,60,70,80,90",
+        )
+        self.sleep_intervals = [int(x.strip()) for x in str(raw).split(",")]
+
+        online_cpus = cpu.cpu_online_list()
+        for c in [self.wakee_cpu, self.waker_cpu]:
+            if c not in online_cpus:
+                self.cancel(
+                    "CPU %d is not online (online list: %s)" % (c, online_cpus)
+                )
+
+        self.log.info(
+            "Config — wakee_cpu=%d  waker_cpu=%d  duration=%ds  intervals=%s",
+            self.wakee_cpu, self.waker_cpu,
+            self.test_duration, self.sleep_intervals,
+        )
+
+        self.result_dir = os.path.join(self.logdir, "cpuidle_wakeup_logs")
+        os.makedirs(self.result_dir, exist_ok=True)
+        self.log.info("Run logs dir: %s", self.result_dir)
+
+    def test(self):
+        """
+        Run cpuidle-state-test for every sleep interval (pipe-based wakeup).
+        Each run is checked for exit status, wakeup count, and above/below
+        idle residency threshold (default 8%).  Raw output is dumped to a
+        per-interval .log file.  A failed-commands summary is printed at
+        the end.
+        """
+        ABOVE_BELOW_THRESHOLD_PCT = self.params.get(
+            "above_below_threshold_pct", default=8.0
+        )
+
+        any_failure = False
+        failed_cmds = []
+
+        for interval_us in self.sleep_intervals:
+
+            cmd = (
+                "%s -w %d -e %d -d %d -s %d -p"
+                % (self.binary, self.wakee_cpu, self.waker_cpu,
+                   self.test_duration, interval_us)
+            )
+            self.log.info("=" * 60)
+            self.log.info("Running [interval=%d us]: %s", interval_us, cmd)
+            self.log.info("=" * 60)
+
+            result = process.run(
+                cmd, ignore_status=True,
+                timeout=self.test_duration + 30
+            )
+
+            stdout = result.stdout_text.strip()
+            stderr = result.stderr_text.strip()
+
+            if result.exit_status != 0:
+                reason = "exit status %d" % result.exit_status
+                self.log.error("FAIL [interval=%d us]: %s",
+                               interval_us, reason)
+                self._dump_run_log(interval_us, cmd, stdout, stderr,
+                                   result.exit_status, fail_reason=reason)
+                failed_cmds.append((cmd, reason))
+                any_failure = True
+                continue
+
+            wakeup_count = self._parse_wakeup_count(stdout)
+            if wakeup_count == 0:
+                reason = "wakeup_count is 0"
+                self.log.error("FAIL [interval=%d us]: %s",
+                               interval_us, reason)
+                self._dump_run_log(interval_us, cmd, stdout, stderr,
+                                   result.exit_status, fail_reason=reason)
+                failed_cmds.append((cmd, reason))
+                any_failure = True
+                continue
+
+            above_pct, below_pct = self._parse_above_below(stdout)
+            ab_fail_reason = None
+
+            if above_pct > ABOVE_BELOW_THRESHOLD_PCT:
+                ab_fail_reason = (
+                    "Total Above %.2f%% exceeds threshold %.2f%%"
+                    % (above_pct, ABOVE_BELOW_THRESHOLD_PCT)
+                )
+            elif below_pct > ABOVE_BELOW_THRESHOLD_PCT:
+                ab_fail_reason = (
+                    "Total Below %.2f%% exceeds threshold %.2f%%"
+                    % (below_pct, ABOVE_BELOW_THRESHOLD_PCT)
+                )
+
+            if ab_fail_reason:
+                self.log.error(
+                    "FAIL [interval=%d us]: %s", interval_us, ab_fail_reason
+                )
+                self._dump_run_log(interval_us, cmd, stdout, stderr,
+                                   result.exit_status,
+                                   fail_reason=ab_fail_reason)
+                failed_cmds.append((cmd, ab_fail_reason))
+                any_failure = True
+                continue
+
+            self._dump_run_log(interval_us, cmd, stdout, stderr,
+                               result.exit_status)
+            self.log.info(
+                "PASS [interval=%d us] — wakeups=%d  "
+                "above=%.2f%%  below=%.2f%%",
+                interval_us, wakeup_count, above_pct, below_pct,
+            )
+
+        self.log.info("Logs written to: %s", self.result_dir)
+
+        if failed_cmds:
+            self.log.error("")
+            self.log.error("=" * 60)
+            self.log.error("FAILED COMMANDS SUMMARY (%d / %d runs failed):",
+                           len(failed_cmds), len(self.sleep_intervals))
+            self.log.error("=" * 60)
+            for i, (fc, reason) in enumerate(failed_cmds, 1):
+                self.log.error("  [%d] cmd   : %s", i, fc)
+                self.log.error("       reason: %s", reason)
+            self.log.error("=" * 60)
+
+        if any_failure:
+            self.fail(
+                "%d of %d runs failed. See logs in: %s"
+                % (len(failed_cmds), len(self.sleep_intervals),
+                   self.result_dir)
+            )
+
+    def _dump_run_log(self, interval_us, cmd, stdout, stderr,
+                      exit_status, fail_reason=None):
+        """
+        Write raw command output to cpuidle_wakeup_logs/run_<N>us.log.
+        Failed runs are prefixed with STATUS: FAIL and the failure reason.
+        """
+        log_path = os.path.join(self.result_dir, "run_%dus.log" % interval_us)
+        with open(log_path, "w") as fh:
+            if fail_reason:
+                fh.write("STATUS      : FAIL\n")
+                fh.write("FAIL REASON : %s\n" % fail_reason)
+            else:
+                fh.write("STATUS      : PASS\n")
+            fh.write("cmd         : %s\n" % cmd)
+            fh.write("exit_status : %d\n" % exit_status)
+            fh.write("\n")
+            fh.write(stdout)
+            if stderr:
+                fh.write("\n")
+                fh.write(stderr)
+            fh.write("\n")
+        self.log.info("Log written: %s", log_path)
+
+    @staticmethod
+    def _parse_wakeup_count(output):
+        """
+        Parse ``Wakee wakeups: <N>`` from binary stdout.
+        Returns 0 when the line is absent (timer-mode omits it).
+        """
+        for line in output.splitlines():
+            if "Wakee wakeups:" in line:
+                try:
+                    return int(
+                        line.split("Wakee wakeups:")[1].split(",")[0].strip()
+                    )
+                except (IndexError, ValueError):
+                    pass
+        return 0
+
+    @staticmethod
+    def _parse_metric(output, keyword):
+        """
+        Parse a float value (µs) from lines matching *keyword*.
+        Handles lines of the form ``<label> = 5.123 us``.
+        Returns 0.0 when not found.
+        """
+        kw_lower = keyword.lower()
+        for line in output.splitlines():
+            if kw_lower in line.lower():
+                parts = line.split("=")
+                if len(parts) >= 2:
+                    try:
+                        return float(parts[-1].strip().split()[0])
+                    except (IndexError, ValueError):
+                        pass
+        return 0.0
+
+    @staticmethod
+    def _parse_above_below(output):
+        """
+        Parse ``Total Above: N (X.XX% …)`` / ``Total Below: N (X.XX% …)``.
+        Returns (above_pct, below_pct) as floats.
+        """
+        above_pct = below_pct = 0.0
+        for line in output.splitlines():
+            lo = line.lower()
+            if "total above:" in lo:
+                try:
+                    above_pct = float(line.split("(")[1].split("%")[0].strip())
+                except (IndexError, ValueError):
+                    pass
+            elif "total below:" in lo:
+                try:
+                    below_pct = float(line.split("(")[1].split("%")[0].strip())
+                except (IndexError, ValueError):
+                    pass
+        return above_pct, below_pct

--- a/cpu/cpuidle_wakeup_test.py.data/cpuidle_wakeup.c
+++ b/cpu/cpuidle_wakeup_test.py.data/cpuidle_wakeup.c
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * cpuidle_wakeup.c - CPU idle wakeup latency and residency micro-benchmark
+ *
+ * Copyright (C) 2026 IBM Corporation
+ * Author: Aboorva Devarajan
+ *
+ * Creates two threads pinned to user-specified CPUs:
+ *   - wakee: blocks on a pipe read (PIPE_WAKEUP) or nanosleep (TIMER_WAKEUP)
+ *   - waker: periodically writes to the pipe or simply spins (TIMER_WAKEUP)
+ *
+ * Measures:
+ *   - Average wakeup latency (pipe mode only)
+ *   - Actual sleep interval seen by the wakee
+ *   - cpuidle sysfs above/below residency counters for the wakee CPU
+ *
+ * Usage:
+ *   ./cpuidle-state-test -w <wakee_cpu> -e <waker_cpu> \
+ *                        [-d <duration_sec>] [-s <sleep_us>] [-p|-t]
+ *
+ *   -w <cpu>   CPU id for the wakee thread  (required, must be != 0)
+ *   -e <cpu>   CPU id for the waker thread  (required, must be != 0)
+ *   -s <us>    Sleep interval in microseconds (default: 100)
+ *   -d <sec>   Test duration in seconds      (default: 5)
+ *   -p         Pipe-based wakeup mode        (default: timer)
+ *   -t         Timer-based wakeup mode
+ *   -h         Show this help and exit
+ */
+
+#define _GNU_SOURCE
+
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <signal.h>
+#include <assert.h>
+#include <sys/syscall.h>
+#include <dirent.h>
+#include <time.h>
+#include <unistd.h>
+
+#define MAX_IDLE_STATES          10
+#define DEFAULT_WAKEUP_INTERVAL_NS  100000ULL   /* 100 µs */
+#define DEFAULT_TEST_DURATION_SEC   5
+
+#define READ  0
+#define WRITE 1
+
+char pipec;
+static int pipe_fd_wakee[2];
+
+unsigned int stop = 0;
+
+int clockid = CLOCK_REALTIME;
+
+typedef enum { PIPE_WAKEUP, TIMER_WAKEUP } wakeup_mode_t;
+typedef enum { IDLE_STATE_NUMERIC, IDLE_STATE_STRING } idle_state_type_t;
+
+static wakeup_mode_t current_wakeup_mode = TIMER_WAKEUP;
+
+int wakee_cpu_id = 0, waker_cpu_id = 0;
+static pthread_t wakee_tid, waker_tid;
+
+int total_idle_states = 0;
+
+unsigned long wakeup_interval_ns = DEFAULT_WAKEUP_INTERVAL_NS;
+unsigned long test_duration_sec  = DEFAULT_TEST_DURATION_SEC;
+
+const char *cpuidle_path_template =
+    "/sys/devices/system/cpu/cpu%d/cpuidle";
+
+/* ------------------------------------------------------------------ */
+/* Data structures                                                      */
+/* ------------------------------------------------------------------ */
+
+struct idle_state_data {
+    unsigned long long usage;
+    unsigned long long time;
+    unsigned long long above;
+    unsigned long long below;
+};
+
+struct idle_state {
+    int  cpu_id;
+    int  state_index;
+    char state_name[50];
+
+    struct idle_state_data before;
+    struct idle_state_data after;
+};
+
+struct idle_state wakee_idle_states[MAX_IDLE_STATES];
+
+struct wakeup_time {
+    struct timespec begin;
+    struct timespec end;
+};
+
+struct wakeup_time        wakee_wakeup_time;
+unsigned long long        wakee_wakeup_time_total_ns;
+unsigned long long        wakee_sleep_time_total_ns;
+unsigned long long        wakee_wakeup_count;
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                              */
+/* ------------------------------------------------------------------ */
+
+static unsigned long long compute_timediff(struct timespec before,
+                                           struct timespec after)
+{
+    unsigned long long ret_ns;
+    unsigned long long ns_per_sec = 1000UL * 1000 * 1000;
+
+    if (after.tv_sec == before.tv_sec)
+        return after.tv_nsec - before.tv_nsec;
+
+    if (after.tv_sec > before.tv_sec) {
+        ret_ns  = (after.tv_sec - before.tv_sec) * ns_per_sec;
+        ret_ns += after.tv_nsec - before.tv_nsec;
+        return ret_ns;
+    }
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* cpuidle sysfs helpers                                               */
+/* ------------------------------------------------------------------ */
+
+void get_cpu_idle_state(const char *field, int cpu, int state,
+                        void *value, idle_state_type_t type)
+{
+    char filepath[256];
+    FILE *file;
+    char buffer[64];
+
+    snprintf(filepath, sizeof(filepath),
+             "/sys/devices/system/cpu/cpu%d/cpuidle/state%d/%s",
+             cpu, state, field);
+
+    file = fopen(filepath, "r");
+    if (!file) {
+        perror("Error opening file");
+        if (type == IDLE_STATE_NUMERIC)
+            *(unsigned long long *)value = 0;
+        else
+            ((char *)value)[0] = '\0';
+        return;
+    }
+
+    if (fgets(buffer, sizeof(buffer), file)) {
+        if (type == IDLE_STATE_NUMERIC) {
+            *(unsigned long long *)value = strtoull(buffer, NULL, 10);
+        } else {
+            strncpy((char *)value, buffer, 64);
+            ((char *)value)[strcspn((char *)value, "\n")] = '\0';
+        }
+    } else {
+        if (type == IDLE_STATE_NUMERIC)
+            *(unsigned long long *)value = 0;
+        else
+            ((char *)value)[0] = '\0';
+    }
+
+    fclose(file);
+}
+
+unsigned int get_total_idle_states(void)
+{
+    char path[100];
+    int  state_count = 0;
+    DIR *dir;
+    struct dirent *entry;
+
+    snprintf(path, sizeof(path), cpuidle_path_template, 0);
+    dir = opendir(path);
+    if (!dir)
+        return 0;
+
+    while ((entry = readdir(dir))) {
+        if (entry->d_name[0] != '.')
+            state_count++;
+    }
+    closedir(dir);
+    return state_count;
+}
+
+static void initialize_wakee_idle_states(void)
+{
+    int i;
+
+    for (i = 0; i < total_idle_states; i++) {
+        wakee_idle_states[i].cpu_id      = wakee_cpu_id;
+        wakee_idle_states[i].state_index = i;
+        get_cpu_idle_state("name", wakee_cpu_id, i,
+                           wakee_idle_states[i].state_name,
+                           IDLE_STATE_STRING);
+    }
+}
+
+static void snapshot_idle_state(const char *field_name,
+                                struct idle_state *s,
+                                unsigned long long *field)
+{
+    get_cpu_idle_state(field_name, s->cpu_id, s->state_index,
+                       field, IDLE_STATE_NUMERIC);
+}
+
+static void snapshot_one_before(struct idle_state *s)
+{
+    snapshot_idle_state("usage", s, &s->before.usage);
+    snapshot_idle_state("above", s, &s->before.above);
+    snapshot_idle_state("below", s, &s->before.below);
+    snapshot_idle_state("time",  s, &s->before.time);
+}
+
+static void snapshot_one_after(struct idle_state *s)
+{
+    snapshot_idle_state("usage", s, &s->after.usage);
+    snapshot_idle_state("above", s, &s->after.above);
+    snapshot_idle_state("below", s, &s->after.below);
+    snapshot_idle_state("time",  s, &s->after.time);
+}
+
+static void snapshot_all_before(void)
+{
+    int i;
+
+    for (i = 0; i < total_idle_states; i++)
+        snapshot_one_before(&wakee_idle_states[i]);
+}
+
+static void snapshot_all_after(void)
+{
+    int i;
+
+    for (i = 0; i < total_idle_states; i++)
+        snapshot_one_after(&wakee_idle_states[i]);
+}
+
+/* ------------------------------------------------------------------ */
+/* Thread affinity helpers                                              */
+/* ------------------------------------------------------------------ */
+
+static cpu_set_t *initialize_cpuset(int num_cpus, int cpu_id)
+{
+    cpu_set_t *cpuset = CPU_ALLOC(num_cpus);
+
+    if (!cpuset) {
+        perror("Unable to allocate cpuset");
+        exit(EXIT_FAILURE);
+    }
+
+    size_t size = CPU_ALLOC_SIZE(num_cpus);
+    CPU_ZERO_S(size, cpuset);
+    CPU_SET_S(cpu_id, size, cpuset);
+    return cpuset;
+}
+
+static void set_thread_affinity(pthread_attr_t *attr, cpu_set_t *cpuset)
+{
+    size_t size = CPU_ALLOC_SIZE(sysconf(_SC_NPROCESSORS_ONLN));
+
+    if (pthread_attr_setaffinity_np(attr, size, cpuset)) {
+        perror("Error setting thread affinity");
+        exit(EXIT_FAILURE);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Thread functions                                                     */
+/* ------------------------------------------------------------------ */
+
+static void *waker_fn(void *arg)
+{
+    struct timespec       begin, cur;
+    unsigned long long    time_diff_ns;
+
+    (void)arg;
+
+    if (current_wakeup_mode == PIPE_WAKEUP) {
+        while (!stop) {
+            clock_gettime(clockid, &begin);
+            do {
+                clock_gettime(clockid, &cur);
+                time_diff_ns = compute_timediff(begin, cur);
+            } while (time_diff_ns <= wakeup_interval_ns);
+
+            clock_gettime(clockid, &wakee_wakeup_time.begin);
+            assert(write(pipe_fd_wakee[WRITE], &pipec, 1) == 1);
+        }
+    } else {
+        /* Timer mode: wakee uses nanosleep; waker has nothing to do */
+        while (!stop)
+            sched_yield();
+    }
+
+    return NULL;
+}
+
+static void *wakee_fn(void *arg)
+{
+    /*
+     * Use SCHED_FIFO to reduce scheduler-induced jitter and make the
+     * measured sleep durations more predictable.
+     */
+    struct sched_param param;
+
+    (void)arg;
+
+    param.sched_priority = sched_get_priority_max(SCHED_FIFO);
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &param) != 0)
+        perror("pthread_setschedparam");
+
+    snapshot_all_before();
+
+    while (!stop) {
+        unsigned long long  wakeup_diff, sleep_diff;
+        struct timespec     sleep_begin, sleep_duration;
+
+        sleep_duration.tv_sec  = wakeup_interval_ns / 1000000000ULL;
+        sleep_duration.tv_nsec = wakeup_interval_ns % 1000000000ULL;
+
+        clock_gettime(clockid, &sleep_begin);
+
+        if (current_wakeup_mode == PIPE_WAKEUP)
+            assert(read(pipe_fd_wakee[READ], &pipec, 1) == 1);
+        else
+            nanosleep(&sleep_duration, NULL);
+
+        clock_gettime(clockid, &wakee_wakeup_time.end);
+
+        wakeup_diff = compute_timediff(wakee_wakeup_time.begin,
+                                       wakee_wakeup_time.end);
+        wakee_wakeup_time_total_ns += wakeup_diff;
+
+        sleep_diff = compute_timediff(sleep_begin, wakee_wakeup_time.end);
+        wakee_sleep_time_total_ns += sleep_diff;
+
+        wakee_wakeup_count++;
+    }
+
+    snapshot_all_after();
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Thread management                                                    */
+/* ------------------------------------------------------------------ */
+
+static void create_thread(pthread_t *thread, pthread_attr_t *attr,
+                          void *(*start_routine)(void *),
+                          const char *thread_name)
+{
+    int ret = pthread_create(thread, attr, start_routine, NULL);
+
+    if (ret) {
+        fprintf(stderr, "Failed to create %s thread\n", thread_name);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void initialize_threads(void)
+{
+    int num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+
+    pthread_attr_t  wakee_attr, waker_attr;
+    cpu_set_t      *cpuset_wakee, *cpuset_waker;
+
+    pthread_attr_init(&wakee_attr);
+    pthread_attr_init(&waker_attr);
+
+    printf("CPU Wakee: %d, CPU Waker: %d\n", wakee_cpu_id, waker_cpu_id);
+
+    cpuset_wakee = initialize_cpuset(num_cpus, wakee_cpu_id);
+    cpuset_waker = initialize_cpuset(num_cpus, waker_cpu_id);
+
+    set_thread_affinity(&wakee_attr, cpuset_wakee);
+    create_thread(&wakee_tid, &wakee_attr, wakee_fn, "wakee");
+
+    set_thread_affinity(&waker_attr, cpuset_waker);
+    create_thread(&waker_tid, &waker_attr, waker_fn, "waker");
+
+    CPU_FREE(cpuset_wakee);
+    CPU_FREE(cpuset_waker);
+}
+
+static void cleanup(void)
+{
+    pthread_join(wakee_tid, NULL);
+    pthread_join(waker_tid, NULL);
+    close(pipe_fd_wakee[READ]);
+    close(pipe_fd_wakee[WRITE]);
+}
+
+static void create_pipe(void)
+{
+    if (pipe(pipe_fd_wakee)) {
+        printf("Failed to create pipe\n");
+        exit(EXIT_FAILURE);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Result reporting                                                     */
+/* ------------------------------------------------------------------ */
+
+static void print_idle_state_summary(int cpu_wakee, int nr_idle_states,
+                                     struct idle_state *states)
+{
+    unsigned long long total_above = 0, total_below = 0;
+    unsigned long long total_usage = 0, total_time  = 0;
+    int i;
+
+    printf("Idle state summary for CPU %d:\n", cpu_wakee);
+
+    for (i = 0; i < nr_idle_states; i++) {
+        struct idle_state *s = &states[i];
+
+        unsigned long long usage_diff = s->after.usage - s->before.usage;
+        unsigned long long above_diff = s->after.above - s->before.above;
+        unsigned long long below_diff = s->after.below - s->before.below;
+        unsigned long long time_diff  = s->after.time  - s->before.time;
+        double above_pct = usage_diff ? (double)above_diff / usage_diff * 100.0 : 0.0;
+        double below_pct = usage_diff ? (double)below_diff / usage_diff * 100.0 : 0.0;
+
+        total_above += above_diff;
+        total_below += below_diff;
+        total_usage += usage_diff;
+        total_time  += time_diff;
+
+        printf("State %d (%s):\n",     i, s->state_name);
+        printf("  Usage diff: %llu\n", usage_diff);
+        printf("  Time diff:  %llu ns\n", time_diff);
+        printf("  Above diff: %llu (%.2f%%)\n", above_diff, above_pct);
+        printf("  Below diff: %llu (%.2f%%)\n", below_diff, below_pct);
+    }
+
+    printf("\n----- Overall Above/Below Summary -----\n");
+    if (total_usage > 0) {
+        printf("Total Above: %llu (%.2f%% of total usage)\n",
+               total_above, (double)total_above / total_usage * 100.0);
+        printf("Total Below: %llu (%.2f%% of total usage)\n",
+               total_below, (double)total_below / total_usage * 100.0);
+    } else {
+        printf("No usage detected.\n");
+    }
+}
+
+static void print_usage(void)
+{
+    printf(
+        "Usage: [options]\n"
+        "  -w <wakee_cpu>          CPU to run wakee thread on (required, != 0)\n"
+        "  -e <waker_cpu>          CPU to run waker thread on (required, != 0)\n"
+        "  -s <sleep_interval_us>  Sleep interval between wakeups in µs (default: 100)\n"
+        "  -d <test_duration>      Duration in seconds to run the test  (default: 5)\n"
+        "  -p                      Pipe-based wakeup mode\n"
+        "  -t                      Timer-based wakeup mode (default)\n"
+        "  -h                      Show this help message\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                 */
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+    int opt;
+
+    while ((opt = getopt(argc, argv, "w:e:s:d:pth")) != -1) {
+        switch (opt) {
+        case 'w':
+            wakee_cpu_id = atoi(optarg);
+            break;
+        case 'e':
+            waker_cpu_id = atoi(optarg);
+            break;
+        case 's':
+            wakeup_interval_ns = strtoul(optarg, NULL, 10) * 1000;
+            break;
+        case 'd':
+            test_duration_sec = strtoul(optarg, NULL, 10);
+            break;
+        case 'p':
+            current_wakeup_mode = PIPE_WAKEUP;
+            break;
+        case 't':
+            current_wakeup_mode = TIMER_WAKEUP;
+            break;
+        case 'h':
+        default:
+            print_usage();
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (wakee_cpu_id == 0 || waker_cpu_id == 0) {
+        fprintf(stderr,
+                "ERROR: Both -w (wakee CPU) and -e (waker CPU) must be "
+                "specified and non-zero.\n\n");
+        print_usage();
+        exit(EXIT_FAILURE);
+    }
+
+    total_idle_states = get_total_idle_states();
+    printf("Total CPU Idle states: %d\n", total_idle_states);
+
+    initialize_wakee_idle_states();
+    create_pipe();
+    initialize_threads();
+
+    sleep(test_duration_sec);
+    stop = 1;
+
+    cleanup();
+
+    if (current_wakeup_mode == PIPE_WAKEUP) {
+        printf("Test complete. Wakee wakeups: %llu, Total wake time: %llu ns\n",
+               wakee_wakeup_count, wakee_wakeup_time_total_ns);
+        printf("Wakee thread average wakeup latency  = %4.3f us\n",
+               wakee_wakeup_count
+                   ? (double)wakee_wakeup_time_total_ns / (wakee_wakeup_count * 1000)
+                   : 0.0);
+    }
+
+    printf("Wakee thread sleep interval  = %4.3f us\n",
+           wakee_wakeup_count
+               ? (double)wakee_sleep_time_total_ns / (wakee_wakeup_count * 1000)
+               : 0.0);
+
+    print_idle_state_summary(wakee_cpu_id, total_idle_states, wakee_idle_states);
+
+    return 0;
+}

--- a/cpu/cpuidle_wakeup_test.py.data/cpuidle_wakeup_test.yaml
+++ b/cpu/cpuidle_wakeup_test.py.data/cpuidle_wakeup_test.yaml
@@ -1,0 +1,17 @@
+# YAML configuration for cpuidle_wakeup_test.py
+#
+# wakee_cpu        - CPU that goes idle and gets woken up
+# waker_cpu        - CPU that drives the wakeup signal via pipe
+# test_duration_sec- How long each individual run lasts (seconds)
+# sleep_intervals_us - Comma-separated list of sleep interval values (µs)
+#                      Each value produces one binary invocation:
+#                        ./cpuidle-state-test -w <wakee> -e <waker> \
+#                          -d <duration> -s <interval> -p
+#
+# Defaults match the originally requested command sweep:
+#   -s 3 5 10 20 30 40 50 60 70 80 90  (all pipe-mode, -d 10)
+
+wakee_cpu: 10
+waker_cpu: 40
+test_duration_sec: 10
+sleep_intervals_us: "3,5,10,20,30,40,50,60,70,80,90"


### PR DESCRIPTION
This test compiles cpuidle_wakeup.c and runs it across a sweep of sleep intervals using pipe-based wakeup mode.

cpuidle_wakeup.c is a micro-benchmark that creates two threads pinned to user-specified CPUs (wakee and waker). The wakee thread goes idle by blocking on a pipe read, and the waker thread wakes it up periodically. This helps measure the real wakeup latency from a cpuidle state and how well the cpuidle governor predicts the sleep duration via above/below residency counters in sysfs.

The test checks:
 - Binary exit status
 - Wakee wakeup count
 - cpuidle above/below residency threshold (default 8%)

Failed runs are logged with reason in cpuidle_wakeup_logs/.