### PR TITLE
workload/htx_test.py: Add vPMEM support for IBM Power

### DIFF
--- a/workload/htx_test.py
+++ b/workload/htx_test.py
@@ -26,6 +26,7 @@ parameters.
 
 """
 
+import json
 import os
 import re
 import shutil
@@ -61,6 +62,7 @@ class HtxTest(Test):
 
         self.mdt_file = self.params.get('mdt_file', default='mdt.mem')
         self.htx_disks = self.params.get('htx_disks', default=None)
+        self.vpmem = self.params.get('vpmem', default=False)
 
         _time_limit = self.params.get('time_limit', default=None)
         if _time_limit is not None:
@@ -76,6 +78,10 @@ class HtxTest(Test):
         self.block_device = ''
         if self.htx_disks and not self.run_all:
             self.block_device = self._resolve_block_devices(self.htx_disks)
+
+        if self.vpmem:
+            self._ensure_ndctl_installed()
+            self._validate_vpmem_devices()
 
         if str(self.name.name).endswith('test_start'):
             self.setup_htx()
@@ -140,6 +146,285 @@ class HtxTest(Test):
 
         self.log.info("HTX RPM %s installed successfully", latest_htx_rpm)
         process.run(f'rm -rf {tmp_rpm}', ignore_status=True)
+
+    def _ensure_ndctl_installed(self):
+        """
+        Ensure ``ndctl`` is available on the system.
+
+        Called unconditionally when ``vpmem: True`` so that both the
+        pre-run validation and the post-run distribution check can use
+        ``ndctl list``.  This is separate from :meth:`_get_distro_packages`
+        which is only invoked during :meth:`setup_htx`.
+        """
+        smm = SoftwareManager()
+        if not smm.check_installed('ndctl') and not smm.install('ndctl'):
+            self.cancel(
+                "Cannot install ndctl — required for vPMEM validation")
+        self.log.info("ndctl is available")
+
+    def _validate_vpmem_devices(self):
+        """
+        Pre-run vPMEM sanity checks.
+
+        Performs three sequential steps:
+
+        1. **Region existence** — runs ``ndctl list -Ru`` and verifies that
+           at least one NVDIMM region is present.  On IBM Power these are
+           created by the ``papr_scm`` driver when vPMEM is configured in
+           the partition profile.  The test is cancelled (not failed) when
+           no region is found because this indicates a missing firmware or
+           driver configuration, not a product regression.
+
+        2. **Namespace provisioning** — for each region that has no
+           namespace, runs ``ndctl create-namespace -r <region>`` to
+           provision one.  This is the normal path on IBM Power where
+           namespaces are not created automatically by the firmware.
+           The test is failed if namespace creation cannot be completed.
+
+        3. **dmesg health** — scans the kernel ring buffer for lines
+           associated with the vPMEM driver stack (``papr_scm``,
+           ``libnvdimm``, ``nd_pmem``, ``pmem``) and fails the test if
+           any of those lines contain error/fault indicators.
+
+        :raises: Cancels the test when no vPMEM region is found.
+        :raises: Fails the test when namespace creation fails or dmesg
+                 reports vPMEM-related errors.
+        """
+        self.log.info("=== vPMEM pre-run validation ===")
+
+        # ── 1. Region existence ──────────────────────────────────────────────
+        # Use -Ru (regions only, human-readable sizes) first — namespaces
+        # may not exist yet and their absence must not be a hard stop here.
+        region_out = process.system_output(
+            'ndctl list -Ru', shell=True,
+            ignore_status=True).decode('utf-8', errors='replace').strip()
+        self.log.info("ndctl list -Ru output:\n%s", region_out)
+
+        if not region_out:
+            self.cancel("ndctl list -Ru returned no output — "
+                        "no vPMEM regions found; ensure papr_scm is "
+                        "loaded and vPMEM is configured in the LPAR profile")
+
+        try:
+            region_data = json.loads(region_out)
+        except json.JSONDecodeError as exc:
+            self.cancel(f"Failed to parse ndctl region JSON output: {exc}")
+
+        regions = (region_data
+                   if isinstance(region_data, list) else [region_data])
+        region_count = len(regions)
+        self.log.info("vPMEM regions found: %d", region_count)
+
+        if region_count == 0:
+            self.cancel("No vPMEM regions detected — "
+                        "ensure papr_scm is loaded and vPMEM is "
+                        "configured in the LPAR profile")
+
+        for region in regions:
+            region_name = region.get('dev', 'unknown')
+            region_size = region.get('size', 0)
+            region_state = region.get('state', 'unknown')
+            self.log.info(
+                "  region=%-12s  size=%s  state=%s",
+                region_name, region_size, region_state)
+
+        # ── 2. Namespace provisioning ────────────────────────────────────────
+        # Re-query with -RNu to discover existing namespaces per region.
+        # ndctl list -RNu can return three different JSON shapes depending on
+        # the kernel/ndctl version and number of regions:
+        #   (a) bare list of region objects:  [{...}, ...]
+        #   (b) single region object dict:    {"dev": "region0", ...}
+        #   (c) wrapper dict with regions key: {"regions": [{...}, ...]}
+        # Normalise all three into a flat list before building the ns_map.
+        ndctl_out = process.system_output(
+            'ndctl list -RNu', shell=True,
+            ignore_status=True).decode('utf-8', errors='replace').strip()
+        self.log.info("ndctl list -RNu output:\n%s", ndctl_out)
+
+        try:
+            ndctl_data = json.loads(ndctl_out) if ndctl_out else []
+        except json.JSONDecodeError as exc:
+            self.cancel(f"Failed to parse ndctl JSON output: {exc}")
+
+        # Normalise to a flat list of region dicts.
+        if isinstance(ndctl_data, list):
+            rlist = ndctl_data
+        elif isinstance(ndctl_data, dict):
+            if 'regions' in ndctl_data:
+                # shape (c): {"regions": [...]}
+                rlist = ndctl_data['regions']
+            else:
+                # shape (b): single region object
+                rlist = [ndctl_data]
+        else:
+            rlist = []
+
+        ns_map = {r.get('dev'): r.get('namespaces', []) for r in rlist}
+
+        for region in regions:
+            region_name = region.get('dev', 'unknown')
+            existing_ns = ns_map.get(region_name, [])
+            # available_size is 0 when the region is fully allocated — use
+            # the raw (non -u) region data from step 1 to get an integer.
+            # The -Ru query returns size as a human string, so compare to
+            # the string "0" as well as the integer 0 for robustness.
+            avail = region.get('available_size', 0)
+            region_full = (avail == 0 or avail == '0' or avail == '0 B')
+
+            if not existing_ns and not region_full:
+                self.log.info(
+                    "No namespaces on %s and space is available — "
+                    "creating one via ndctl", region_name)
+                ret = process.system(
+                    f'ndctl create-namespace -r {region_name}',
+                    shell=True, ignore_status=True)
+                if ret != 0:
+                    self.fail(
+                        f"ndctl create-namespace failed for region "
+                        f"{region_name} (exit code {ret})")
+                self.log.info(
+                    "Namespace created successfully on %s", region_name)
+            elif not existing_ns and region_full:
+                self.fail(
+                    f"Region {region_name} has no namespaces and "
+                    f"available_size is 0 — region may be misconfigured")
+            else:
+                for ns in existing_ns:
+                    ns_name = ns.get('dev', 'unknown')
+                    ns_mode = ns.get('mode', 'unknown')
+                    ns_size = ns.get('size', 0)
+                    ns_state = ns.get('state', 'enabled')
+                    self.log.info(
+                        "  region=%-12s  ns=%-14s  mode=%-8s  "
+                        "size=%s  state=%s",
+                        region_name, ns_name, ns_mode, ns_size, ns_state)
+                    if ns_state == 'disabled':
+                        self.fail(
+                            f"vPMEM namespace {ns_name} in region "
+                            f"{region_name} is in 'disabled' state "
+                            f"before HTX run")
+
+        # ── 3. dmesg health check ────────────────────────────────────────────
+        dmesg_out = process.system_output(
+            'dmesg', shell=True,
+            ignore_status=True).decode('utf-8', errors='replace')
+
+        vpmem_drivers = ('papr_scm', 'libnvdimm', 'nd_pmem', 'pmem', 'nfit')
+        error_patterns = re.compile(
+            r'\b(error|fail(?:ed|ure)?|bug|oops|panic|corrupt|warn(?:ing)?)\b',
+            re.IGNORECASE)
+
+        vpmem_errors = []
+        for line in dmesg_out.splitlines():
+            line_lower = line.lower()
+            if any(drv in line_lower for drv in vpmem_drivers):
+                if error_patterns.search(line):
+                    vpmem_errors.append(line.strip())
+
+        if vpmem_errors:
+            for err_line in vpmem_errors:
+                self.log.error("dmesg vPMEM error: %s", err_line)
+            self.fail(
+                f"dmesg contains {len(vpmem_errors)} vPMEM-related "
+                f"error/warning line(s) — check log for details")
+
+        self.log.info(
+            "vPMEM pre-run validation PASSED — "
+            "%d region(s) present, namespaces provisioned, dmesg clean",
+            region_count)
+
+    def _check_vpmem_namespace_distribution(self):
+        """
+        Post-HTX vPMEM namespace distribution check.
+
+        After an HTX ``mdt.mem_all`` run, verifies that:
+
+        * Every detected region still has at least one active namespace
+          (confirming the memory was distributed into multiple chunks as
+          expected by the PowerVM vPMEM implementation).
+        * No namespace has transitioned to a ``disabled`` or unhealthy state
+          during the HTX run.
+        * Logs the full per-region namespace map for post-run analysis.
+
+        :raises: Fails the test on any distribution or health anomaly.
+        """
+        self.log.info("=== vPMEM post-HTX namespace distribution check ===")
+
+        ndctl_out = process.system_output(
+            'ndctl list -RNu', shell=True,
+            ignore_status=True).decode('utf-8', errors='replace').strip()
+        self.log.info("Post-HTX ndctl list -RNu output:\n%s", ndctl_out)
+
+        if not ndctl_out:
+            self.fail("ndctl list -RNu returned no output after HTX run")
+
+        try:
+            ndctl_data = json.loads(ndctl_out)
+        except json.JSONDecodeError as exc:
+            self.fail(f"Failed to parse post-HTX ndctl JSON output: {exc}")
+
+        # Normalise to a flat list of region dicts — same three shapes as
+        # in _validate_vpmem_devices: bare list, single dict, or wrapper dict.
+        if isinstance(ndctl_data, list):
+            regions = ndctl_data
+        elif isinstance(ndctl_data, dict) and 'regions' in ndctl_data:
+            regions = ndctl_data['regions']
+        else:
+            regions = [ndctl_data]
+        total_namespaces = 0
+        distribution_errors = []
+
+        for region in regions:
+            region_name = region.get('dev', 'unknown')
+            region_size = region.get('size', 0)
+            ns_list = region.get('namespaces', [])
+
+            self.log.info(
+                "Region: %-12s  size=%s  namespaces=%d",
+                region_name, region_size, len(ns_list))
+
+            # Each region must have at least one active namespace after the
+            # HTX run — this confirms memory chunks (one per region minimum)
+            # survived the workload intact.
+            if not ns_list:
+                distribution_errors.append(
+                    f"Region {region_name} has no namespaces after "
+                    f"HTX run — expected at least one chunk per region")
+                continue
+
+            for ns in ns_list:
+                ns_name = ns.get('dev', 'unknown')
+                ns_mode = ns.get('mode', 'unknown')
+                ns_size = ns.get('size', 0)
+                ns_state = ns.get('state', 'enabled')
+                ns_uuid = ns.get('uuid', 'n/a')
+                total_namespaces += 1
+
+                self.log.info(
+                    "  ns=%-14s  mode=%-8s  size=%-12s  "
+                    "state=%-10s  uuid=%s",
+                    ns_name, ns_mode, ns_size, ns_state, ns_uuid)
+
+                if ns_state == 'disabled':
+                    distribution_errors.append(
+                        f"Namespace {ns_name} in region {region_name} "
+                        f"is disabled after HTX run")
+
+        self.log.info(
+            "Post-HTX summary: %d region(s), %d total namespace(s)",
+            len(regions), total_namespaces)
+
+        if distribution_errors:
+            for err in distribution_errors:
+                self.log.error("vPMEM distribution error: %s", err)
+            self.fail(
+                f"vPMEM post-HTX check found {len(distribution_errors)} "
+                f"distribution/health error(s) — check log for details")
+
+        self.log.info(
+            "vPMEM post-HTX namespace distribution check PASSED — "
+            "%d namespace(s) across %d region(s), all active",
+            total_namespaces, len(regions))
 
     def _get_distro_packages(self):
         """
@@ -372,8 +657,14 @@ class HtxTest(Test):
     def test_stop(self):
         """
         Shutdown the MDT and the HTX daemon.
+
+        When ``vpmem: True``, also runs a post-HTX namespace distribution
+        check to verify that vPMEM memory remained chunked and healthy
+        across the entire HTX run.
         """
         self.stop_htx()
+        if self.vpmem:
+            self._check_vpmem_namespace_distribution()
 
     def stop_htx(self):
         """

--- a/workload/htx_test.py.data/README
+++ b/workload/htx_test.py.data/README
@@ -5,12 +5,13 @@ test methods in sequence with the same YAML file:
 
   test_start  -- install HTX (first run only), select MDT, activate devices
   test_check  -- poll for errors every 60 s for the configured duration
-  test_stop   -- suspend devices and shut down the HTX daemon
+  test_stop   -- suspend devices, shut down HTX daemon; vPMEM check if enabled
 
 YAML Parameters
 ---------------
 mdt_file       MDT filename to select and run.  Default: ``mdt.mem``
-               Examples: mdt.cpu, mdt.hd, mdt.all, mdt.mem_inter_node
+               Examples: mdt.cpu, mdt.hd, mdt.all, mdt.mem_inter_node,
+               mdt.mem_all
 
 time_interval  Duration of the test_check polling loop, expressed in
                minutes.  Default: ``2``
@@ -29,16 +30,34 @@ htx_disks      Space-separated block devices to stress-test exclusively
 all            ``True`` — activate every device in the MDT without filtering.
                ``False`` (default) — use the ``htx_disks`` list.
 
+vpmem          ``True`` — enable IBM Power vPMEM (Virtual Persistent Memory)
+               validation mode.  When set:
+               * Installs ``ndctl`` if not already present.
+               * In setUp(), runs a pre-run check:
+                 - ``ndctl list -RNu``: verifies >=1 region and >=1 namespace
+                   exist (papr_scm / libnvdimm driver path).
+                 - ``dmesg``: scans papr_scm/libnvdimm/nd_pmem/pmem lines
+                   and cancels/fails if any contain error indicators.
+               * In test_stop(), after HTX shutdown, runs a post-run check:
+                 - ``ndctl list -RNu``: verifies every region still has >=1
+                   active namespace (memory distributed into multiple chunks).
+                 - Fails if any namespace is 'disabled' or total namespace
+                   count is < 2 (no distribution detected).
+               ``False`` (default) — vPMEM checks are skipped entirely.
+
 YAML Variants
 -------------
 htx_test.yaml          2-min smoke run, mdt.all.  No htx_rpm_link needed.
 htx_cpu.yaml           30-min CPU stress, mdt.cpu.  IBM GSA RPM URL set.
-htx_mem.yaml           Memory variants via !mux (5–120 min, mdt.mem_*).
+htx_mem.yaml           Memory variants via !mux (5-120 min, mdt.mem_*).
 htx_isst.yml           ISST power-management variants, 1440 min (24 h),
                        mdt.bu/less/all.
-htx_pmem.yaml          PMEM/NVDIMM variants via !mux (60–120 min).
+htx_pmem.yaml          PMEM/NVDIMM variants via !mux (60-120 min).
 htx_block_devices.yaml 60-min targeted run; set htx_disks before use.
 htx_all_devices.yaml   1440-min (24 h) full MDT sweep; all: True, mdt.hd.
+htx_vpmem.yaml         30-min IBM Power vPMEM stress run on mdt.mem_all.
+                       Requires papr_scm driver and ndctl.  Performs pre-run
+                       and post-run ndctl + dmesg validation.
 
 Example Invocations
 -------------------
@@ -49,10 +68,21 @@ Example Invocations
               htx_test.py:HtxTest.test_stop \
              -m htx_test.py.data/htx_block_devices.yaml
 
+  avocado run htx_test.py:HtxTest.test_start \
+              htx_test.py:HtxTest.test_check \
+              htx_test.py:HtxTest.test_stop \
+             -m htx_test.py.data/htx_vpmem.yaml
+
 Notes
 -----
 * Error detection reads /tmp/htxerr via htxcmdline -geterrlog; a non-zero
   file size fails test_check immediately.
 * test_stop issues ``umount /htx_pmem*`` unconditionally to clean up any
   PMEM mounts left by HTX regardless of the MDT in use.
-
+* vPMEM on IBM Power uses the papr_scm kernel driver (CONFIG_PAPR_SCM).
+  The libnvdimm subsystem exposes vPMEM as NVDIMM regions.  Each region is
+  split into one or more namespaces by the PowerVM hypervisor.
+  ``ndctl list -RNu`` output is JSON: -R includes region objects, -N nests
+  namespace objects inside each region, -u formats sizes as human-readable.
+  The post-run check verifies this chunked namespace layout survives a full
+  HTX mem_all stress run intact.

--- a/workload/htx_test.py.data/htx_vpmem.yaml
+++ b/workload/htx_test.py.data/htx_vpmem.yaml
@@ -1,0 +1,24 @@
+# HTX vPMEM (Virtual Persistent Memory) stress test
+#
+# Validates IBM Power vPMEM devices (exposed via papr_scm / libnvdimm) under
+# HTX workload using the mem_all MDT.
+#
+# Parameters
+# ----------
+# vpmem         Enable vPMEM-specific validation and ndctl dependency install.
+#               Default: True
+#
+# mdt_file      HTX MDT that covers all memory including vPMEM regions.
+#               Default: mdt.mem_all
+#
+# time_interval Duration of the test_check polling loop, in minutes.
+#               Default: 30
+#
+# htx_rpm_link  URL to the HTX RPM directory or a direct .rpm URL.
+#               Leave empty if HTX is already installed on the system.
+
+vpmem: True
+# time_interval is in minutes
+time_interval: 30
+mdt_file: 'mdt.mem_all'
+htx_rpm_link: 'https://rchgsa.ibm.com/gsa/rchgsa/projects/h/htx/public_html/htxonly/'


### PR DESCRIPTION
Adds vPMEM (Virtual Persistent Memory) validation to htx_test.py, exercised via the new htx_vpmem.yaml configuration.

On IBM Power, vPMEM is backed by PowerVM hypervisor memory and exposed to Linux through the papr_scm / libnvdimm driver stack as NVDIMM regions and namespaces. This change enables HTX stress-testing of vPMEM using the mdt.mem_all MDT and adds pre-run and post-run ndctl-based validation.

New YAML: htx_vpmem.yaml
  - vpmem: True (default)
  - mdt_file: mdt.mem_all
  - time_interval: 30 minutes

New behaviour when vpmem: True
  - Installs ndctl via SoftwareManager if not already present (_ensure_ndctl_installed)
  - Pre-run validation (_validate_vpmem_devices):
    1. Checks ndctl list -Ru for at least one NVDIMM region; cancels if none found (environment/firmware config issue, not regression)
    2. For each region: if no namespace exists and available_size > 0, creates one via ndctl create-namespace -r <region>; if no namespace and available_size == 0, fails with a misconfiguration message; handles all three ndctl JSON shapes (bare list, single dict, wrapper dict with 'regions' key)
    3. Scans dmesg for papr_scm/libnvdimm/nd_pmem/pmem error lines and fails if any are found
  - Post-run check (_check_vpmem_namespace_distribution) in test_stop: Verifies every region still has >= 1 active namespace after HTX run, confirming memory chunks survived the workload intact; fails on any disabled namespace or empty region