### PR TITLE
cpu: Fix ebizzy sourceforge download URL

### DIFF
--- a/cpu/ebizzy.py
+++ b/cpu/ebizzy.py
@@ -66,8 +66,8 @@ class Ebizzy(Test):
         for package in deps:
             if not sm.check_installed(package) and not sm.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
-        url = 'http://sourceforge.net/projects/ebizzy/files/ebizzy/' \
-              '0.3/ebizzy-0.3.tar.gz'
+        url = 'https://downloads.sourceforge.net/project/ebizzy/' \
+              'ebizzy/0.3/ebizzy-0.3.tar.gz'
         tarball = self.fetch_asset(self.params.get("ebizy_url", default=url))
         archive.extract(tarball, self.workdir)
         version = os.path.basename(tarball.split('.tar.')[0])

--- a/cpu/em_smt_folding_test.py
+++ b/cpu/em_smt_folding_test.py
@@ -55,8 +55,8 @@ class SmtFolding(Test):
         for package in deps:
             if not smg.check_installed(package) and not smg.install(package):
                 self.cancel("%s is needed for the test to be run" % package)
-        url = 'https://downloads.sourceforge.net/projects//ebizzy/files/ebizzy/0.3/' \
-              'ebizzy-0.3.tar.gz'
+        url = 'https://downloads.sourceforge.net/project/ebizzy/' \
+              'ebizzy/0.3/ebizzy-0.3.tar.gz'
         tarball = self.fetch_asset(self.params.get("ebizy_url", default=url),
                                    expire='7d')
         self.cpu_unit = self.params.get('cpu_unit', default=.1)


### PR DESCRIPTION
ebizzy.py was using http://sourceforge.net which is unreliable and may be blocked in some environments.

em_smt_folding_test.py had two bugs in the URL:
- 'projects' (plural) instead of 'project'
- double slash '//'

Both updated to use https://downloads.sourceforge.net/project/ebizzy/ which is the correct, direct download URL.