### PR TITLE
Fix unreachable git URL in connectathon and missing Perl deps in openssl-tests

### DIFF
--- a/generic/connectathon.py
+++ b/generic/connectathon.py
@@ -66,7 +66,7 @@ class Connectathon(Test):
                             package)
 
         self.tmpdir = tempfile.mkdtemp(prefix='avocado_' + __name__)
-        git.get_repo('git://git.linux-nfs.org/projects/steved/cthon04.git',
+        git.get_repo('https://github.com/linux-nfs/cthon04.git',
                      destination_dir=self.workdir)
         os.chdir(self.workdir)
 


### PR DESCRIPTION
generic/connectathon.py: git://git.linux-nfs.org is unreachable when
git protocol (port 9418) is blocked by firewalls. Use the GitHub
mirror over HTTPS instead.

security/openssl-tests.py: perl-FindBin and perl-Time-Piece are
required by openssl's Configure script but were only being installed
for RHEL 9. Extended the condition to also cover RHEL 10.

Signed-off-by: Venkat Rao Bagalkote <venkat@linux.ibm.com>