### PR TITLE
kernel/kselftest: Fix buldir path handling for custom run_type

### DIFF
--- a/kernel/kselftest.py
+++ b/kernel/kselftest.py
@@ -152,7 +152,7 @@ class kselftest(Test):
                         path = glob.glob(self.workdir)
             for l_dir in path:
                 if os.path.isdir(l_dir) and 'Makefile' in os.listdir(l_dir):
-                    self.buldir = os.path.join(self.workdir, l_dir)
+                    self.buldir = l_dir
                     break
             self.sourcedir = os.path.join(self.buldir, self.testdir)
             if (self.comp != "cpufreq" and self.comp != "bpf"):
@@ -163,7 +163,7 @@ class kselftest(Test):
                 if not self.comp:
                     process.system("make install -C %s" % self.sourcedir,
                                    shell=True, sudo=True)
-            else:
+            elif self.run_type == 'upstream':
                 self.buldir = self.params.get('location', default='')
         else:
             # Make sure kernel source repo is configured


### PR DESCRIPTION
Two bugs introduced by commit c2809842 (kselftest run from custom linux source):

1. self.buldir was incorrectly set to os.path.join(self.workdir, l_dir) where l_dir is already an absolute path. Changed to self.buldir = l_dir.

2. The else block unconditionally overwrote self.buldir with the 'location' param when comp == 'bpf' or 'cpufreq', wiping out the correctly set buldir for custom run_type. Guarded it with elif self.run_type == 'upstream' so custom run_type retains the correct buldir.